### PR TITLE
fix : support a scrollbar for users with many organizations

### DIFF
--- a/nx/blocks/profile/profile.css
+++ b/nx/blocks/profile/profile.css
@@ -212,6 +212,8 @@ p {
   position: relative;
   margin: -1px 0;
   padding: 24px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .nx-all-orgs-title {


### PR DESCRIPTION
The DA.LIVE user-profile Organization-Switcher does not support a scrollbar for users with many organizations, prevending to switch to some ORGs.

Fix for https://github.com/adobe/da-live/issues/430

