### PR TITLE
fix files that have query strings being matched as an extension

### DIFF
--- a/nx/blocks/importer/index.js
+++ b/nx/blocks/importer/index.js
@@ -114,7 +114,7 @@ async function importUrl(url, findFragmentsFlag, liveDomain, setProcessed) {
     return;
   }
 
-  const isExt = EXTS.some((ext) => href.endsWith(`.${ext}`));
+  const isExt = EXTS.some((ext) => pathname.endsWith(`.${ext}`));
   const path = href.endsWith('/') ? `${pathname}index` : pathname;
   const srcPath = isExt ? path : `${path}.md`;
   url.destPath = isExt ? path : `${path}.html`;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

If you import a a json file, everything works as expected. However, if you add any query string the requested file becomes {filename}.json.md - which is obviously incorrect.

Before:
- https://main--da-nx--adobe.aem.live/

After:
- https://limit--da-nx--dkuntze.aem.live/


