### PR TITLE
Bubble the dialog close event

### DIFF
--- a/nx/public/sl/components.js
+++ b/nx/public/sl/components.js
@@ -271,13 +271,17 @@ class SlDialog extends LitElement {
     this._dialog.close();
   }
 
+  onClose(e) {
+    this.dispatchEvent(new Event('close', e));
+  }
+
   get _dialog() {
     return this.shadowRoot.querySelector('dialog');
   }
 
   render() {
     return html`
-      <dialog class="sl-dialog">
+      <dialog class="sl-dialog" @close=${this.onClose}>
         <slot></slot>
       </dialog>`;
   }


### PR DESCRIPTION
Allows for consumers to listen for the close event on sl-dialog