### PR TITLE
fix: remove extra '?'

### DIFF
--- a/nx/blocks/shell/shell.js
+++ b/nx/blocks/shell/shell.js
@@ -38,8 +38,8 @@ function getParts() {
  */
 function getUrl() {
   const { org, repo, ref, path, search } = getParts();
-  if (ref === 'local') return `http://localhost:3000/${path}.html?${search}`;
-  return `https://${ref}--${repo}--${org}.aem.live/${path}.html?${search}`;
+  if (ref === 'local') return `http://localhost:3000/${path}.html${search}`;
+  return `https://${ref}--${repo}--${org}.aem.live/${path}.html${search}`;
 }
 
 /**


### PR DESCRIPTION
Oops. Added an extra `?`. Didn't realize `window.locaton.search` comes with the prefix `?`.

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/0445bde8-4922-465d-bf35-481f693c2bd2" />

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/08b0e9fa-d435-49e3-8610-4303d15b23cc" />

Test URLs:
- https://pass-search-fix--da-nx--adobe.aem.live
