### PR TITLE
Remove any whitespace

### DIFF
--- a/nx/blocks/loc/connectors/glaas/dnt.js
+++ b/nx/blocks/loc/connectors/glaas/dnt.js
@@ -238,8 +238,7 @@ const addDntInfoToHtml = (html) => {
   });
 
   processAltText(document);
-  const processedHtml = document.documentElement.outerHTML;
-  return cleanWhitespace(processedHtml);
+  return cleanWhitespace(document.documentElement.outerHTML);
 };
 
 const unwrapDntContent = (document) => {


### PR DESCRIPTION
- Remove spaces just before return to ensure no additional ones are introduced. 
