### PR TITLE
Add fragments found in img alt text

### DIFF
--- a/nx/blocks/loc/views/validate/validate-utils.js
+++ b/nx/blocks/loc/views/validate/validate-utils.js
@@ -1,0 +1,37 @@
+const FRAGMENT_SELECTOR = 'a[href*="/fragments/"], .fragment a';
+
+/**
+ * Extracts fragment URLs from image alt attributes in the DOM.
+ * @param {Document} dom
+ * @returns {string[]}
+ */
+export function getImageAltFragmentUrls(dom) {
+  return [...dom.body.querySelectorAll('img[alt]')]
+    .map((img) => {
+      const alt = img.getAttribute('alt');
+      // Alt fragments are in this format:
+      // https://main--bacom--adobecom.hlx.live/fragments/products/modal/videos/adobe-experience-manager/sites/omnichannel-experiences/experience-fragments#xf | Experience Fragment demo video | :play-medium:
+      if (alt.includes('/fragments/')) {
+        const [href] = alt.split('|');
+        if (href?.includes('/fragments/')) {
+          return href;
+        }
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Extracts all fragment URLs (from anchors and image alts) from HTML text.
+ * @param {string} html
+ * @returns {string[]} Array of fragment hrefs (strings)
+ */
+export function getFragmentUrls(html) {
+  const parser = new DOMParser();
+  const dom = parser.parseFromString(html, 'text/html');
+  const results = dom.body.querySelectorAll(FRAGMENT_SELECTOR);
+  const fragmentUrls = [...results].map((a) => a.getAttribute('href'));
+  const imgAltUrls = getImageAltFragmentUrls(dom);
+  return [...fragmentUrls, ...imgAltUrls];
+}

--- a/test/loc/validate.test.js
+++ b/test/loc/validate.test.js
@@ -1,0 +1,58 @@
+import { expect } from '@esm-bundle/chai';
+import { getImageAltFragmentUrls, getFragmentUrls } from '../../nx/blocks/loc/views/validate/validate-utils.js';
+
+describe('validate-utils', () => {
+  describe('getImageAltFragmentUrls', () => {
+    it('extracts fragment URLs from image alt attributes', () => {
+      const parser = new DOMParser();
+      const html = `
+        <html>
+          <body>
+            <img alt="https://main--site--adobecom.aem.page/fragments/video#xf | Video description | :play-medium:" />
+            <img alt="https://main--site--adobecom.aem.page/fragments/banner#xf | Banner description" />
+            <img alt="Regular image description" />
+          </body>
+        </html>
+      `;
+      const dom = parser.parseFromString(html, 'text/html');
+      const urls = getImageAltFragmentUrls(dom);
+      expect(urls).to.have.length(2);
+      expect(urls[0]).to.include('/fragments/video');
+      expect(urls[1]).to.include('/fragments/banner');
+    });
+
+    it('returns empty array if no image alts with fragments', () => {
+      const parser = new DOMParser();
+      const html = '<html><body><img alt="No fragment here" /></body></html>';
+      const dom = parser.parseFromString(html, 'text/html');
+      const urls = getImageAltFragmentUrls(dom);
+      expect(urls).to.have.length(0);
+    });
+  });
+
+  describe('extractFragmentUrls', () => {
+    it('extracts fragment URLs from anchors and image alts', () => {
+      const html = `
+        <html>
+          <body>
+            <a href="https://main--site--adobecom.aem.page/fragments/header">Header</a>
+            <a href="https://main--site--adobecom.aem.page/fragments/footer">Footer</a>
+            <img alt="https://main--site--adobecom.aem.page/fragments/video#xf | Video description" />
+            <img alt="Regular image description" />
+          </body>
+        </html>
+      `;
+      const urls = getFragmentUrls(html);
+      expect(urls).to.include('https://main--site--adobecom.aem.page/fragments/header');
+      expect(urls).to.include('https://main--site--adobecom.aem.page/fragments/footer');
+      expect(urls).to.include('https://main--site--adobecom.aem.page/fragments/video#xf ');
+      expect(urls).to.have.length(3);
+    });
+
+    it('returns empty array if no fragments found', () => {
+      const html = '<html><body><a href="/not-a-fragment">Not a fragment</a></body></html>';
+      const urls = getFragmentUrls(html);
+      expect(urls).to.have.length(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #44

Test URLs:
- Before: https://main--da-live--adobe.aem.live/apps/loc#/validate/adobecom/da-bacom/.da/translation/active/1752782463953
- After: https://main--da-live--adobe.aem.live/apps/loc?nx=44-altfrag#/validate/adobecom/da-bacom/.da/translation/active/1752782463953
