### PR TITLE
fix: hash handling

### DIFF
--- a/nx/blocks/shell/shell.js
+++ b/nx/blocks/shell/shell.js
@@ -45,9 +45,8 @@ function getParts() {
  */
 function getUrl() {
   const { org, repo, ref, path, search, hash } = getParts();
-  const hashPart = hash ? `#${hash}` : '';
-  if (ref === 'local') return `http://localhost:3000/${path}.html${search}${hashPart}`;
-  return `https://${ref}--${repo}--${org}.aem.live/${path}.html${search}${hashPart}`;
+  if (ref === 'local') return `http://localhost:3000/${path}.html${search}${hash}`;
+  return `https://${ref}--${repo}--${org}.aem.live/${path}.html${search}${hash}`;
 }
 
 /**


### PR DESCRIPTION
Simplify and fix the hash handling. Empty check is not needed also `window.location.hash` includes the `#`, hence no prefix is needed.