### PR TITLE
Support asterisk as a DNT block-scope

### DIFF
--- a/nx/blocks/loc/connectors/glaas/dnt.js
+++ b/nx/blocks/loc/connectors/glaas/dnt.js
@@ -223,7 +223,8 @@ const addDntInfoToHtml = (html) => {
   document.querySelector('footer')?.remove();
 
   globalDntConfig.get('docRules').forEach((operations, selector) => {
-    addDntAttribute(selector, operations, document);
+    const newSelector = selector.startsWith('.* >') ? selector.replace('.* >', 'div[class] >') : selector;
+    addDntAttribute(newSelector, operations, document);
   });
   globalDntConfig.get('contentRules').forEach((content) => {
     findAndAddDntWrapper(document, content);

--- a/nx/blocks/loc/views/translate/index.js
+++ b/nx/blocks/loc/views/translate/index.js
@@ -54,10 +54,13 @@ export async function getUrls(org, site, service, sourceLocation, urls, fetchCon
 
       // Only add DNT if a connector exists
       // Copy sources will not have a connector
+      url.content = content;
       if (connector) {
-        url.content = await connector.dnt.addDnt(content, config, { fileType });
-      } else {
-        url.content = content;
+        try {
+          url.content = await connector.dnt.addDnt(content, config, { fileType });
+        } catch (error) {
+          url.error = `Error adding DNT to ${url.daBasePath} - ${error.message}`;
+        }
       }
     };
 


### PR DESCRIPTION
- transforming the selector from `.* >` to `div[class] >`, since blocks always have a CSS class with their name
- adding more safeguards around invoking DNT, since incorrect DNT config can lead to a document being handed off as `undefined` instead of the actual HTML content with DNT applied; catching the exception in the "translate" block ensures that `url.error` can be set and the handoff to GLaaS (or any other connector) is stopped

Fixes: #85

