### PR TITLE
Adding name validation for new snapshots

### DIFF
--- a/nx/blocks/snapshot-admin/views/snapshot.css
+++ b/nx/blocks/snapshot-admin/views/snapshot.css
@@ -56,6 +56,11 @@ svg.icon {
     gap: var(--spacing-400);
   }
 
+  .name-missing {
+    border: 2px dotted var(--s2-red-900);
+    padding-left: 3px;
+  }
+
   .nx-snapshot-expand {
     position: relative;
     display: block;

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -77,8 +77,14 @@ class NxSnapshot extends LitElement {
   }
 
   async handleSave(lock) {
-    this._action = 'Saving';
     const name = this.basics.name || this.getValue('[name="name"]');
+    if (!name) {
+      this._message = { heading: 'Note', message: 'Please enter a name for the snapshot.', open: true };
+      this.shadowRoot.querySelector('[name="name"]').classList.add('name-missing');
+      return;
+    }
+
+    this._action = 'Saving';
 
     // Set the name if it isn't already set
     if (!this.basics.name) this.basics.name = name;
@@ -274,7 +280,7 @@ class NxSnapshot extends LitElement {
   }
 
   renderEditName() {
-    return html`<input type="text" name="name" placeholder="Enter snapshot name" />`;
+    return html`<input type="text" name="name" placeholder="Enter snapshot name" @input=${() => this.shadowRoot.querySelector('[name="name"]')?.classList?.remove('name-missing')} />`;
   }
 
   renderName() {


### PR DESCRIPTION
- checking if the name is empty/undefined
- if so, display a message and return to prevent saving
- adding CSS class to indicate, where the issue is
- clearing the CSS class as soon as the user starts adding input to the form field

Fix: #89
