### PR TITLE
Scheduler

### DIFF
--- a/nx/blocks/snapshot-admin/snapshot-admin.js
+++ b/nx/blocks/snapshot-admin/snapshot-admin.js
@@ -1,6 +1,6 @@
 import { html, LitElement, repeat, nothing } from 'da-lit';
 import getStyle from '../../utils/styles.js';
-import { fetchSnapshots, setOrgSite } from './utils/utils.js';
+import { fetchSnapshots, setOrgSite, isRegistered } from './utils/utils.js';
 
 import '../../public/sl/components.js';
 import './views/dialog.js';
@@ -19,6 +19,7 @@ class NxSnapshotAdmin extends LitElement {
     _error: { state: true },
     _sitePathError: { state: true },
     _snapshots: { state: true },
+    _isRegistered: { state: false },
   };
 
   connectedCallback() {
@@ -53,6 +54,7 @@ class NxSnapshotAdmin extends LitElement {
     }
 
     this._snapshots = result.snapshots;
+    this._isRegistered = await isRegistered(org, site);
   }
 
   handleSetSite(e) {
@@ -95,7 +97,7 @@ class NxSnapshotAdmin extends LitElement {
         <div class="nx-snapshot-list">
           <ul>
             ${repeat(this._snapshots, (snapshot) => snapshot.name, (snapshot, idx) => html`
-              <li><nx-snapshot @delete=${() => this.handleDelete(idx)} .basics=${snapshot}></nx-snapshot></li>
+              <li><nx-snapshot @delete=${() => this.handleDelete(idx)} .basics=${snapshot} .isRegistered=${this._isRegistered}></nx-snapshot></li>
             `)}
           </ul>
         </div>

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -1,4 +1,4 @@
-import { AEM_ORIGIN } from '../../../public/utils/constants.js';
+import { AEM_ORIGIN, SNAPSHOT_SCHEDULER_URL } from '../../../public/utils/constants.js';
 import { daFetch } from '../../../utils/daFetch.js';
 import { mergeCopy, overwriteCopy } from '../../loc/project/index.js';
 import { Queue } from '../../../public/utils/tree.js';
@@ -164,4 +164,43 @@ export async function copyManifest(name, resources, direction) {
   // Setup a new Queue with the copy function
   const queue = new Queue(copyUrl, 50);
   await Promise.all(urls.map((url) => queue.push(url)));
+}
+
+export async function updateScheduledPublish(snapshotId) {
+  const adminURL = `${SNAPSHOT_SCHEDULER_URL}/schedule`;
+  const body = {
+    org,
+    site,
+    snapshotId,
+  };
+
+  const headers = {
+    'content-type': 'application/json',
+  };
+
+  const resp = await fetch(`${adminURL}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const result = resp.headers.get('X-Error');
+  return { status: resp.status, text: result };
+}
+
+export async function isRegisteredForSnapshotScheduler() {
+  try {
+    const adminURL = `${SNAPSHOT_SCHEDULER_URL}/register/${org}/${site}`;
+    const resp = await fetch(adminURL);
+    return resp.status === 200;
+  } catch (error) {
+    console.error('Error checking if registered for snapshot scheduler', error);
+    return false;
+  }
+}
+
+// Convert UTC date to local datetime-local format
+export function formatLocalDate(utcDate) {
+  if (!utcDate) return '';
+  const d = new Date(utcDate);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}T${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -1,7 +1,9 @@
-import { AEM_ORIGIN, SNAPSHOT_SCHEDULER_URL } from '../../../public/utils/constants.js';
+import { AEM_ORIGIN } from '../../../public/utils/constants.js';
 import { daFetch } from '../../../utils/daFetch.js';
 import { mergeCopy, overwriteCopy } from '../../loc/project/index.js';
 import { Queue } from '../../../public/utils/tree.js';
+
+const SNAPSHOT_SCHEDULER_URL = 'https://helix-snapshot-scheduler-prod.adobeaem.workers.dev';
 
 let org;
 let site;
@@ -166,7 +168,7 @@ export async function copyManifest(name, resources, direction) {
   await Promise.all(urls.map((url) => queue.push(url)));
 }
 
-export async function updateScheduledPublish(snapshotId) {
+export async function updateSchedule(snapshotId) {
   const adminURL = `${SNAPSHOT_SCHEDULER_URL}/schedule`;
   const body = {
     org,
@@ -183,7 +185,7 @@ export async function updateScheduledPublish(snapshotId) {
   return { status: resp.status, text: result };
 }
 
-export async function isRegisteredForSnapshotScheduler() {
+export async function isRegistered() {
   try {
     const adminURL = `${SNAPSHOT_SCHEDULER_URL}/register/${org}/${site}`;
     const resp = await fetch(adminURL);

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -173,11 +173,7 @@ export async function updateScheduledPublish(snapshotId) {
     site,
     snapshotId,
   };
-
-  const headers = {
-    'content-type': 'application/json',
-  };
-
+  const headers = { 'content-type': 'application/json' };
   const resp = await fetch(`${adminURL}`, {
     method: 'POST',
     headers,

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -176,7 +176,7 @@ export async function updateSchedule(snapshotId) {
     snapshotId,
   };
   const headers = { 'content-type': 'application/json' };
-  const resp = await fetch(`${adminURL}`, {
+  const resp = await daFetch(`${adminURL}`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
@@ -188,7 +188,7 @@ export async function updateSchedule(snapshotId) {
 export async function isRegistered() {
   try {
     const adminURL = `${SNAPSHOT_SCHEDULER_URL}/register/${org}/${site}`;
-    const resp = await fetch(adminURL);
+    const resp = await daFetch(adminURL);
     return resp.status === 200;
   } catch (error) {
     console.error('Error checking if registered for snapshot scheduler', error);

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -8,7 +8,6 @@ import {
   copyManifest,
   updatePaths,
   reviewSnapshot,
-  isRegistered,
   updateSchedule,
   formatLocalDate,
 } from '../utils/utils.js';
@@ -31,19 +30,18 @@ const ICONS = [
 class NxSnapshot extends LitElement {
   static properties = {
     basics: { attribute: false },
+    isRegistered: { attribute: false },
     _manifest: { state: true },
     _editUrls: { state: true },
     _message: { state: true },
     _isOpen: { state: true },
     _action: { state: true },
-    _isRegistered: { state: true },
   };
 
   async connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
     getSvg({ parent: this.shadowRoot, paths: ICONS });
-    this._isRegistered = await isRegistered();
   }
 
   update(props) {
@@ -284,7 +282,7 @@ class NxSnapshot extends LitElement {
             <sl-textarea name="description" resize="none" .value="${this._manifest?.description}"></sl-textarea>
             <p class="nx-snapshot-sub-heading">Password</p>
             <sl-input type="password" name="password" .value=${this._manifest?.metadata?.reviewPassword}></sl-input>
-            ${this._isRegistered ? html`
+            ${this.isRegistered ? html`
               <p class="nx-snapshot-sub-heading">Schedule Publish</p>
               <sl-input type="datetime-local" name="scheduler" .value=${formatLocalDate(this._manifest?.metadata?.scheduledPublish)}></sl-input>
             ` : nothing}

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -93,6 +93,24 @@ class NxSnapshot extends LitElement {
     // Set the name if it isn't already set
     if (!this.basics.name) this.basics.name = name;
 
+    // Validate scheduled publish time before saving
+    const scheduledPublish = this.getValue('[name="scheduler"]');
+    if (scheduledPublish) {
+      const scheduledDate = new Date(scheduledPublish);
+      const now = new Date();
+      const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
+      
+      if (scheduledDate < fiveMinutesFromNow) {
+        this._action = undefined;
+        this._message = { 
+          heading: 'Schedule Error', 
+          message: 'Scheduled publish date must be at least 5 minutes from now', 
+          open: true 
+        };
+        return;
+      }
+    }
+
     const manifest = this.getUpdatedManifest();
 
     // Handle any URLs which may have changed
@@ -111,21 +129,7 @@ class NxSnapshot extends LitElement {
     this._manifest = result;
 
     // Handle scheduled publish if the field exists and has a value
-    const scheduledPublish = this.getValue('[name="scheduler"]');
     if (scheduledPublish) {
-      const scheduledDate = new Date(scheduledPublish);
-      const now = new Date();
-      const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
-      
-      if (scheduledDate < fiveMinutesFromNow) {
-        this._message = { 
-          heading: 'Schedule Error', 
-          message: 'Scheduled publish date must be at least 5 minutes from now', 
-          open: true 
-        };
-        return;
-      }
-      
       const scheduleResult = await updateScheduledPublish(name);
       if (scheduleResult.status !== 200) {
         this._message = { 

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -275,7 +275,7 @@ class NxSnapshot extends LitElement {
             <sl-input type="password" name="password" .value=${this._manifest?.metadata?.reviewPassword}></sl-input>
             ${this._isRegisteredForSnapshotScheduler ? html`
               <p class="nx-snapshot-sub-heading">Schedule Publish</p>
-              <input type="datetime-local" name="scheduler" .value=${formatLocalDate(this._manifest?.metadata?.scheduledPublish)}>
+              <sl-input type="datetime-local" name="scheduler" .value=${formatLocalDate(this._manifest?.metadata?.scheduledPublish)}></sl-input>
             ` : nothing}
           </div>
           <div class="nx-snapshot-actions">

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -99,13 +99,12 @@ class NxSnapshot extends LitElement {
       const scheduledDate = new Date(scheduledPublish);
       const now = new Date();
       const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
-      
       if (scheduledDate < fiveMinutesFromNow) {
         this._action = undefined;
-        this._message = { 
-          heading: 'Schedule Error', 
-          message: 'Scheduled publish date must be at least 5 minutes from now', 
-          open: true 
+        this._message = {
+          heading: 'Schedule Error',
+          message: 'Scheduled publish date must be at least 5 minutes from now',
+          open: true,
         };
         return;
       }
@@ -132,10 +131,10 @@ class NxSnapshot extends LitElement {
     if (scheduledPublish) {
       const scheduleResult = await updateScheduledPublish(name);
       if (scheduleResult.status !== 200) {
-        this._message = { 
-          heading: 'Schedule Error', 
-          message: scheduleResult.text || 'Failed to schedule publish', 
-          open: true 
+        this._message = {
+          heading: 'Schedule Error',
+          message: scheduleResult.headers.get('X-Error') || 'Failed to schedule publish',
+          open: true,
         };
       }
     }

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -113,6 +113,19 @@ class NxSnapshot extends LitElement {
     // Handle scheduled publish if the field exists and has a value
     const scheduledPublish = this.getValue('[name="scheduler"]');
     if (scheduledPublish) {
+      const scheduledDate = new Date(scheduledPublish);
+      const now = new Date();
+      const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
+      
+      if (scheduledDate < fiveMinutesFromNow) {
+        this._message = { 
+          heading: 'Schedule Error', 
+          message: 'Scheduled publish date must be at least 5 minutes from now', 
+          open: true 
+        };
+        return;
+      }
+      
       const scheduleResult = await updateScheduledPublish(name);
       if (scheduleResult.status !== 200) {
         this._message = { 

--- a/nx/public/sl/components.css
+++ b/nx/public/sl/components.css
@@ -37,6 +37,7 @@ svg.icon {
   input[type="number"],
   input[type="password"],
   input[type="date"],
+  input[type="datetime-local"],
   textarea {
     width: 100%;
     display: block;

--- a/nx/public/utils/constants.js
+++ b/nx/public/utils/constants.js
@@ -1,4 +1,5 @@
 export const AEM_ORIGIN = 'https://admin.hlx.page';
+export const SNAPSHOT_SCHEDULER_URL = 'https://helix-snapshot-scheduler-prod.adobeaem.workers.dev';
 
 export const SUPPORTED_FILES = {
   html: 'text/html',

--- a/nx/public/utils/constants.js
+++ b/nx/public/utils/constants.js
@@ -1,5 +1,4 @@
 export const AEM_ORIGIN = 'https://admin.hlx.page';
-export const SNAPSHOT_SCHEDULER_URL = 'https://helix-snapshot-scheduler-prod.adobeaem.workers.dev';
 
 export const SUPPORTED_FILES = {
   html: 'text/html',


### PR DESCRIPTION
Fix #96 

@auniverseaway main update is to use `daFetch` instead of regular `fetch` since the last merge to this branch. Tested using the `nx=local` and `nx=scheduler` params.

Test URLs:
- Before: https://main--da-live--adobe.aem.live/apps/snapshots
- After: https://main--da-live--adobe.aem.live/apps/snapshots?nx=scheduler
