### PR TITLE
Scheduler fix

### DIFF
--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -95,7 +95,11 @@ export async function deleteSnapshot(name, paths = ['/*']) {
   }));
   const firstError = results.find((result) => result.error);
   if (firstError) return firstError;
-  return results[0];
+  // once all resources are deleted, delete the snapshot as well
+  const opts = { method: 'DELETE' };
+  const resp = await daFetch(`${AEM_ORIGIN}/snapshot/${org}/${site}/main/${name}`, opts);
+  if (!resp.ok) return formatError(resp);
+  return { success: true };
 }
 
 export function setOrgSite(suppliedOrg, suppliedSite) {

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -103,6 +103,17 @@ export function setOrgSite(suppliedOrg, suppliedSite) {
   site = suppliedSite;
 }
 
+export async function addResourcesToSnapshot(name, resources) {
+  const opts = {
+    method: 'POST',
+    body: JSON.stringify({ paths: resources }),
+    headers: { 'Content-Type': 'application/json' },
+  };
+  const resp = await daFetch(`${AEM_ORIGIN}/snapshot/${org}/${site}/main/${name}/*`, opts);
+  if (!resp.ok) return formatError(resp);
+  return { success: true };
+}
+
 export async function updatePaths(name, currPaths, editedHrefs) {
   const paths = filterPaths(editedHrefs);
   const { removed, added } = comparePaths(currPaths, paths);
@@ -115,15 +126,8 @@ export async function updatePaths(name, currPaths, editedHrefs) {
 
   // Handle adds
   if (added.length > 0) {
-    const opts = {
-      method: 'POST',
-      body: JSON.stringify({ paths: added }),
-      headers: { 'Content-Type': 'application/json' },
-    };
-
-    // This is technically a bulk ops request
-    const resp = await daFetch(`${AEM_ORIGIN}/snapshot/${org}/${site}/main/${name}/*`, opts);
-    if (!resp.ok) return formatError(resp);
+    const result = await addResourcesToSnapshot(name, added);
+    if (result.error) return result;
   }
 
   // The formatting of the response will be bulk job-like,

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -107,17 +107,6 @@ export function setOrgSite(suppliedOrg, suppliedSite) {
   site = suppliedSite;
 }
 
-export async function addResourcesToSnapshot(name, resources) {
-  const opts = {
-    method: 'POST',
-    body: JSON.stringify({ paths: resources }),
-    headers: { 'Content-Type': 'application/json' },
-  };
-  const resp = await daFetch(`${AEM_ORIGIN}/snapshot/${org}/${site}/main/${name}/*`, opts);
-  if (!resp.ok) return formatError(resp);
-  return { success: true };
-}
-
 export async function updatePaths(name, currPaths, editedHrefs) {
   const paths = filterPaths(editedHrefs);
   const { removed, added } = comparePaths(currPaths, paths);
@@ -130,8 +119,15 @@ export async function updatePaths(name, currPaths, editedHrefs) {
 
   // Handle adds
   if (added.length > 0) {
-    const result = await addResourcesToSnapshot(name, added);
-    if (result.error) return result;
+    const opts = {
+      method: 'POST',
+      body: JSON.stringify({ paths: added }),
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    // This is technically a bulk ops request
+    const resp = await daFetch(`${AEM_ORIGIN}/snapshot/${org}/${site}/main/${name}/*`, opts);
+    if (!resp.ok) return formatError(resp);
   }
 
   // The formatting of the response will be bulk job-like,

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -10,6 +10,7 @@ import {
   reviewSnapshot,
   updateSchedule,
   formatLocalDate,
+  addResourcesToSnapshot,
 } from '../utils/utils.js';
 
 const nx = `${new URL(import.meta.url).origin}/nx`;
@@ -176,6 +177,15 @@ class NxSnapshot extends LitElement {
       ? 'Forking content into snapshot.'
       : 'Promoting content from snapshot.';
     await copyManifest(this.basics.name, this._manifest.resources, direction);
+    if (this._action === 'fork') {
+      // we copied the content into the snapshot
+      // now we need to add the resources to the snapshot again to update aem.reviews
+      const result = await addResourcesToSnapshot(this.basics.name, this._manifest.resources);
+      if (result.error) {
+        this._message = { heading: 'Note', message: result.error, open: true };
+        return;
+      }
+    }
     this._action = undefined;
   }
 

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -10,7 +10,6 @@ import {
   reviewSnapshot,
   updateSchedule,
   formatLocalDate,
-  addResourcesToSnapshot,
 } from '../utils/utils.js';
 
 const nx = `${new URL(import.meta.url).origin}/nx`;
@@ -177,15 +176,6 @@ class NxSnapshot extends LitElement {
       ? 'Forking content into snapshot.'
       : 'Promoting content from snapshot.';
     await copyManifest(this.basics.name, this._manifest.resources, direction);
-    if (this._action === 'fork') {
-      // we copied the content into the snapshot
-      // now we need to add the resources to the snapshot again to update aem.reviews
-      const result = await addResourcesToSnapshot(this.basics.name, this._manifest.resources);
-      if (result.error) {
-        this._message = { heading: 'Note', message: result.error, open: true };
-        return;
-      }
-    }
     this._action = undefined;
   }
 


### PR DESCRIPTION
ignore the branch name. initially it was for something scheduler related and reused the same branch for the delete snapshot fix.

Fix #105 

Test URLs:
- Before: https://main--da-nx--adobe.aem.live/apps/snapshots
- After: https://main--da-live--adobe.aem.live/apps/snapshots?nx=scheduler-fix
