### PR TITLE
Allow passing an array of paths to crawl

### DIFF
--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -89,7 +89,7 @@ export function crawl({ path, callback, concurrent, throttle = 100 }) {
   let isCanceled = false;
   const files = [];
   const errors = [];
-  const folders = [path];
+  const folders = Array.isArray(path) ? [...path] : [path];
   const inProgress = [];
   const startTime = Date.now();
   const queue = new Queue(callback, concurrent, (item, err) => errors.push({ item, err }));


### PR DESCRIPTION
Crawl currently only accepts a single path to crawl, this adds support to pass an array of paths to crawl

Part of fix for https://github.com/adobe/da-live/issues/243