### PR TITLE
Snapshot scheduling updates

### DIFF
--- a/nx/blocks/snapshot-admin/snapshot-admin.js
+++ b/nx/blocks/snapshot-admin/snapshot-admin.js
@@ -20,6 +20,7 @@ class NxSnapshotAdmin extends LitElement {
     _sitePathError: { state: true },
     _snapshots: { state: true },
     _isRegistered: { state: false },
+    _userPermissions: { state: true },
   };
 
   connectedCallback() {
@@ -55,6 +56,7 @@ class NxSnapshotAdmin extends LitElement {
 
     this._snapshots = result.snapshots;
     this._isRegistered = await isRegistered(org, site);
+    this._userPermissions = result.permissions || [];
   }
 
   handleSetSite(e) {
@@ -97,7 +99,7 @@ class NxSnapshotAdmin extends LitElement {
         <div class="nx-snapshot-list">
           <ul>
             ${repeat(this._snapshots, (snapshot) => snapshot.name, (snapshot, idx) => html`
-              <li><nx-snapshot @delete=${() => this.handleDelete(idx)} .basics=${snapshot} .isRegistered=${this._isRegistered}></nx-snapshot></li>
+              <li><nx-snapshot @delete=${() => this.handleDelete(idx)} .basics=${snapshot} .isRegistered=${this._isRegistered} .userPermissions=${this._userPermissions}></nx-snapshot></li>
             `)}
           </ul>
         </div>

--- a/nx/blocks/snapshot-admin/snapshot-admin.js
+++ b/nx/blocks/snapshot-admin/snapshot-admin.js
@@ -1,6 +1,6 @@
 import { html, LitElement, repeat, nothing } from 'da-lit';
 import getStyle from '../../utils/styles.js';
-import { fetchSnapshots, setOrgSite, isRegistered } from './utils/utils.js';
+import { fetchSnapshots, setOrgSite, isRegistered, getUserPublishPermission } from './utils/utils.js';
 
 import '../../public/sl/components.js';
 import './views/dialog.js';
@@ -56,7 +56,7 @@ class NxSnapshotAdmin extends LitElement {
 
     this._snapshots = result.snapshots;
     this._isRegistered = await isRegistered(org, site);
-    this._userPermissions = result.permissions || [];
+    this._userPermissions = await getUserPublishPermission();
   }
 
   handleSetSite(e) {

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -83,7 +83,7 @@ export async function fetchSnapshots() {
     { org, site, name: snapshot }
   ));
 
-  return { snapshots };
+  return { snapshots, permissions: resp.permissions };
 }
 
 export async function deleteSnapshot(name, paths = ['/*']) {

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -82,7 +82,7 @@ export async function fetchSnapshots() {
   const snapshots = json.snapshots.map((snapshot) => (
     { org, site, name: snapshot }
   ));
-
+  console.log('permissions', resp.permissions);
   return { snapshots, permissions: resp.permissions };
 }
 

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -172,12 +172,13 @@ export async function copyManifest(name, resources, direction) {
   await Promise.all(urls.map((url) => queue.push(url)));
 }
 
-export async function updateSchedule(snapshotId) {
+export async function updateSchedule(snapshotId, approved = false) {
   const adminURL = `${SNAPSHOT_SCHEDULER_URL}/schedule`;
   const body = {
     org,
     site,
     snapshotId,
+    approved,
   };
   const headers = { 'content-type': 'application/json' };
   const resp = await daFetch(`${adminURL}`, {

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -82,8 +82,8 @@ export async function fetchSnapshots() {
   const snapshots = json.snapshots.map((snapshot) => (
     { org, site, name: snapshot }
   ));
-  console.log('permissions', resp.permissions);
-  return { snapshots, permissions: resp.permissions };
+
+  return { snapshots };
 }
 
 export async function deleteSnapshot(name, paths = ['/*']) {
@@ -188,6 +188,22 @@ export async function updateSchedule(snapshotId, approved = false) {
   });
   const result = resp.headers.get('X-Error');
   return { status: resp.status, text: result };
+}
+
+export async function getUserPublishPermission(path = '/') {
+  try {
+    // Use the admin.hlx.page status endpoint to check permissions
+    const statusURL = `https://admin.hlx.page/status/${org}/${site}/main${path}`;
+    const resp = await daFetch(statusURL);
+    if (!resp.ok) return false;
+
+    const json = await resp.json();
+    // Check if 'write' is in the live.permissions array - this indicates publish permission
+    return json.live?.permissions?.includes('write') || false;
+  } catch (error) {
+    console.error('Error checking user publish permission', error);
+    return false;
+  }
 }
 
 export async function isRegistered() {

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -175,6 +175,9 @@ class NxSnapshot extends LitElement {
         // Schedule the publish instead of immediate approval
         this._action = 'Scheduling';
 
+        // Validate scheduled publish time before saving
+        this.validateSchedule(scheduledPublish);
+
         // Save the manifest first with the scheduled publish data
         const manifest = this.getUpdatedManifest();
         await this.handleEditUrls();

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -31,6 +31,7 @@ class NxSnapshot extends LitElement {
   static properties = {
     basics: { attribute: false },
     isRegistered: { attribute: false },
+    userPermissions: { attribute: false },
     _manifest: { state: true },
     _editUrls: { state: true },
     _message: { state: true },
@@ -257,6 +258,10 @@ class NxSnapshot extends LitElement {
     return undefined;
   }
 
+  get _hasPublishPermission() {
+    return this.userPermissions?.includes('publish') || this.userPermissions?.includes('basic_publish');
+  }
+
   renderUrls() {
     return html`
       <ul class="nx-snapshot-urls">
@@ -330,7 +335,7 @@ class NxSnapshot extends LitElement {
             <sl-textarea name="description" resize="none" .value="${this._manifest?.description}"></sl-textarea>
             <p class="nx-snapshot-sub-heading">Password</p>
             <sl-input type="password" name="password" .value=${this._manifest?.metadata?.reviewPassword}></sl-input>
-            ${this.isRegistered ? html`
+            ${this.isRegistered && this._hasPublishPermission ? html`
               <p class="nx-snapshot-sub-heading">Schedule Publish</p>
               <sl-input type="datetime-local" name="scheduler" .value=${formatLocalDate(this._manifest?.metadata?.scheduledPublish)}></sl-input>
             ` : nothing}

--- a/nx/blocks/snapshot-admin/views/snapshot.js
+++ b/nx/blocks/snapshot-admin/views/snapshot.js
@@ -259,7 +259,7 @@ class NxSnapshot extends LitElement {
   }
 
   get _hasPublishPermission() {
-    return this.userPermissions?.includes('publish') || this.userPermissions?.includes('basic_publish');
+    return this.userPermissions === true;
   }
 
   renderUrls() {


### PR DESCRIPTION
- Check user has publish perms before showing them the scheduled publish input in snapshot details
- When a user adds a scheduled publish and then Approve & Publish - schedule instead of publishing right away

Fix #129 
Fix #128 

Test URLs:
- Before: https://main--da-nx--adobe.hlx.live/
- After: https://main--da-live--adobe.aem.live/apps/snapshots?nx=snapshot-update
