### PR TITLE
MWPW-184966 Loc fails when source content path is root (/)

### DIFF
--- a/nx/blocks/loc/utils/utils.js
+++ b/nx/blocks/loc/utils/utils.js
@@ -93,8 +93,9 @@ export function convertPath({ path, sourcePrefix, destPrefix, snapshotPrefix = '
   const paths = { daBasePath: `${snapshotPrefix}${daBasePath}`, aemBasePath: `${snapshotPrefix}${aemBasePath}`, ext };
 
   if (destPrefix) {
-    paths.daDestPath = `${snapshotPrefix}${destPrefix}${daBasePath}`;
-    paths.aemDestPath = `${snapshotPrefix}${destPrefix}${aemBasePath}`;
+    const normalizedDestPrefix = destPrefix.replace(/\/$/, '');
+    paths.daDestPath = `${snapshotPrefix}${normalizedDestPrefix}${daBasePath}`;
+    paths.aemDestPath = `${snapshotPrefix}${normalizedDestPrefix}${aemBasePath}`;
   }
 
   return paths;


### PR DESCRIPTION
- When source path is /, the contsructed destination path to download urls has // which leads to 400 bad request
- Replace any trailing slash in destPrefix with empty

Fix #MWPW-184966

