### PR TITLE
MWPW-184636: Default Locales Support in Config

### DIFF
--- a/nx/blocks/loc/views/options/utils/utils.js
+++ b/nx/blocks/loc/views/options/utils/utils.js
@@ -122,7 +122,16 @@ export function formatLangs(langs, config) {
     [lang.activeAction] = split;
 
     if (typeof lang.locales === 'string') {
-      lang.locales = lang.locales.split(',').map((value) => ({ code: value.trim(), active: true }));
+      const hasDefaultLocales = 'default locales' in lang;
+      const defaultLocales = lang['default locales']
+        ?.split(',')
+        .map((value) => value.trim())
+        .filter((v) => v);
+
+      lang.locales = lang.locales.split(',').map((value) => {
+        const code = value.trim();
+        return { code, active: hasDefaultLocales ? defaultLocales?.includes(code) ?? false : true };
+      });
     }
 
     if (lang['source language']) {


### PR DESCRIPTION
- If defaultLocale column is not present fallback to legacy behaviour - all locales active
- If defaultLocale column is present - locales present in default set are active, if empty none of the locales are active
- For the cases where there is only 1 locale (jp, kr) - the expectation is that in the configuration the author adds the locale in both locale list and default locale list.

