### PR TITLE
Fix issue #142 - Sandbox toast bug

### DIFF
--- a/nx/utils/org-check.js
+++ b/nx/utils/org-check.js
@@ -10,7 +10,7 @@ async function getIsSandbox(org) {
   const { status } = confResp;
 
   // Handle not authorized
-  if (status === 403 && status === 401) return false;
+  if (status === 403 || status === 401) return false;
 
   // Handle found config
   if (status === 200) {


### PR DESCRIPTION
Fix #142

Description: this bug causes the sandbox toast to show incorrectly when someone does not have authorization to read the DA config.
<img width="1264" height="115" alt="image" src="https://github.com/user-attachments/assets/98a92ef8-2631-4647-a08f-d7b76e250198" />
