### PR TITLE
Re-throw "does not provide an export named" errors

### DIFF
--- a/nx/scripts/nexter.js
+++ b/nx/scripts/nexter.js
@@ -62,7 +62,11 @@ export async function loadBlock(block) {
         await (await import(`${blockPath}.js`)).default(block);
       } catch (e) {
         // eslint-disable-next-line no-console
-        console.log(e);
+        console.log(`Error loading block ${name}:`, e);
+        if (e.message.includes('does not provide an export named')) {
+          // rethrow the error so da-live attempts to reload without cache
+          throw e;
+        }
       }
       resolve();
     })();


### PR DESCRIPTION
Re-throws `SyntaxError: The requested module ... does not provide an export named ...`

This is so the da-live code in https://github.com/adobe/da-live/pull/741 will then attempt to reload the page without any local caching.

Merge this after the da-live PR has been merged.