### PR TITLE
Crawl horizontal 

### DIFF
--- a/nx/blocks/media-library/utils/processing.js
+++ b/nx/blocks/media-library/utils/processing.js
@@ -528,7 +528,7 @@ export default async function runScan(sitePath, updateTotal, updateProgressive =
     }
   };
 
-  const { results, getDuration } = crawl({ path: sitePath, callback });
+  const { results, getDuration } = crawl({ path: sitePath, callback, mode: 'horizontal' });
   await results;
 
   const allMediaEntries = [];

--- a/nx/blocks/media-library/utils/utils.js
+++ b/nx/blocks/media-library/utils/utils.js
@@ -114,14 +114,24 @@ export { isSvgFile, extractFileExtension };
  */
 export function sortMediaData(mediaData) {
   return [...mediaData].sort((a, b) => {
-    // Sort by recently used first, then alphabetical
+    // Sort by recently used first
     const lastUsedA = new Date(a.lastUsedAt || 0);
     const lastUsedB = new Date(b.lastUsedAt || 0);
     const timeDiff = lastUsedB - lastUsedA;
 
     if (timeDiff !== 0) return timeDiff;
 
-    // Fallback to alphabetical
+    // Sort by doc path depth (shallow pages first)
+    const docPathA = a.doc || '';
+    const docPathB = b.doc || '';
+
+    const depthA = docPathA ? docPathA.split('/').filter((p) => p).length : 999;
+    const depthB = docPathB ? docPathB.split('/').filter((p) => p).length : 999;
+
+    const depthDiff = depthA - depthB;
+    if (depthDiff !== 0) return depthDiff;
+
+    // Fallback to alphabetical by name
     const nameA = (a.name || '').toLowerCase();
     const nameB = (b.name || '').toLowerCase();
     return nameA.localeCompare(nameB);

--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -68,14 +68,16 @@ function calculateCrawlTime(startTime) {
 }
 
 /**
- * Assign the project to an employee.
+ * Crawl a directory tree with configurable traversal strategy.
  * @param {Object} options - The crawl options.
  * @param {string} options.path - The parent path to crawl.
  * @param {function} options.callback - The callback to run when a file is found.
  * @param {number} options.concurrent - The amount of concurrent requests for the callback queue.
  * @param {number} options.throttle - How much to throttle the crawl.
+ * @param {string} options.mode - Crawl mode: 'vertical' (depth-first, default)
+ *   or 'horizontal' (breadth-first).
  */
-export function crawl({ path, callback, concurrent, throttle = 100 }) {
+export function crawl({ path, callback, concurrent, throttle = 100, mode = 'vertical' }) {
   let time;
   let isCanceled = false;
   const files = [];
@@ -89,7 +91,7 @@ export function crawl({ path, callback, concurrent, throttle = 100 }) {
     const interval = setInterval(async () => {
       if (folders.length > 0) {
         inProgress.push(true);
-        const currentPath = folders.pop();
+        const currentPath = mode === 'horizontal' ? folders.shift() : folders.pop();
         const children = await getChildren(currentPath);
         files.push(...children.files);
         folders.push(...children.folders);


### PR DESCRIPTION
Adds a mode parameter to the crawl() function in tree.js to support breadth-first (horizontal) traversal in addition to the default depth-first (vertical) traversal.

**Modes:**

Vertical (default, depth-first): Completely processes each folder and all its subfolders before moving to the next sibling folder
Horizontal (breadth-first): Processes all folders at the current depth level before descending to the next level



**UI Changes:**
Added performance timing instrumentation in media library for scan operations
Integrated horizontal crawl mode for media scanning workflow

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/
