### PR TITLE
Use custom diff labels; Scrub diff content on overwriteCopy

### DIFF
--- a/nx/blocks/loc/project/index.js
+++ b/nx/blocks/loc/project/index.js
@@ -117,31 +117,6 @@ async function saveVersion(path, label) {
   return res;
 }
 
-export async function overwriteCopy(url, title) {
-  let blob;
-  // If source content was supplied upstream, use it.
-  if (url.sourceContent) {
-    const type = url.destination.includes('.json') ? 'application/json' : 'text/html';
-    blob = new Blob([url.sourceContent], { type });
-  } else {
-    const srcResp = await daFetch(`${DA_ORIGIN}/source${url.source}`);
-    if (!srcResp.ok) {
-      url.status = 'error';
-      return srcResp;
-    }
-    blob = await srcResp.blob();
-  }
-
-  const body = new FormData();
-  body.append('data', blob);
-  const opts = { method: 'POST', body };
-  const daResp = await daFetch(`${DA_ORIGIN}/source${url.destination}`, opts);
-  url.status = 'success';
-  // Don't wait for the version save
-  saveVersion(url.destination, `${title} - Rolled Out`);
-  return daResp;
-}
-
 function collapseInnerTextSpaces(html) {
   return html.replace(/>([^<]*)</g, (match, textContent) => {
     // Only process if there's actual text content
@@ -173,13 +148,55 @@ const getDaUrl = (url) => {
   return { org, repo, pathname };
 };
 
+export async function overwriteCopy(url, title) {
+  let resp;
+  if (url.sourceContent) {
+    // If source content was supplied upstream, use it.
+    const type = url.destination.includes('.json') ? 'application/json' : 'text/html';
+    const blob = new Blob([url.sourceContent], { type });
+    const opts = {
+      method: 'POST',
+      body: new FormData(),
+    };
+    opts.body.append('data', blob);
+    resp = await daFetch(`${DA_ORIGIN}/source${url.destination}`, opts);
+  } else {
+    const srcHtml = await getHtml(url.source);
+    if (srcHtml) {
+      removeLocTags(srcHtml);
+      const daMetadata = getElementMetadata(srcHtml.querySelector(DA_METADATA_SELECTOR));
+      delete daMetadata?.acceptedhashes;
+      delete daMetadata?.rejectedhashes;
+      resp = await saveToDa(
+        srcHtml.querySelector('main').innerHTML,
+        getDaUrl(url.destination),
+        daMetadata,
+      );
+    }
+  }
+
+  if (!resp?.ok) {
+    url.status = 'error';
+    return null;
+  }
+
+  url.status = 'success';
+  // Don't wait for the version save
+  saveVersion(url.destination, `${title} - Rolled Out`);
+  return resp;
+}
+
 function getPreviousHashes(metadata) {
   const acceptedHashes = metadata.acceptedhashes?.text?.split(',') || [];
   const rejectedHashes = metadata.rejectedhashes?.text?.split(',') || [];
   return { acceptedHashes, rejectedHashes };
 }
 
-export async function rolloutCopy(url, projectTitle) {
+export async function rolloutCopy(
+  url,
+  projectTitle,
+  { labelLocal = null, labelUpstream = null } = {},
+) {
   // if the regional folder has content that differs from langstore,
   // then a regional diff needs to be done
   try {
@@ -203,14 +220,18 @@ export async function rolloutCopy(url, projectTitle) {
     }
 
     const daMetadataEl = regionalCopy.querySelector(DA_METADATA_SELECTOR);
-    const { acceptedHashes, rejectedHashes } = getPreviousHashes(getElementMetadata(daMetadataEl));
+    const daMetadata = getElementMetadata(daMetadataEl);
+    const { acceptedHashes, rejectedHashes } = getPreviousHashes(daMetadata);
 
     // There are differences, upload the diffed regional file
     const diffed = await regionalDiff(langstoreCopy, regionalCopy, acceptedHashes, rejectedHashes);
 
+    if (labelLocal) daMetadata['diff-label-local'] = labelLocal;
+    if (labelUpstream) daMetadata['diff-label-upstream'] = labelUpstream;
+
     return new Promise((resolve) => {
       const daUrl = getDaUrl(url);
-      const savePromise = saveToDa(diffed.innerHTML, daUrl, { daMetadataEl });
+      const savePromise = saveToDa(diffed.innerHTML, daUrl, daMetadata);
 
       const timedout = setTimeout(() => {
         url.status = 'timeout';
@@ -235,10 +256,17 @@ export async function rolloutCopy(url, projectTitle) {
   }
 }
 
-export async function mergeCopy(url, projectTitle) {
+export async function mergeCopy(
+  url,
+  projectTitle,
+  { labelLocal = null, labelUpstream = null } = {},
+) {
   try {
     const regionalCopy = await getHtml(url.destination);
-    if (!regionalCopy) throw new Error('No regional content or error fetching');
+    const regionalMain = regionalCopy?.querySelector('body > main').innerHTML;
+    if (!regionalCopy || regionalMain === '' || regionalMain === '<div></div>') {
+      throw new Error('No regional content or error fetching');
+    }
 
     const langstoreCopy = url.sourceContent
       ? await getHtml(null, url.sourceContent)
@@ -255,13 +283,17 @@ export async function mergeCopy(url, projectTitle) {
     }
 
     const daMetadataEl = regionalCopy.querySelector(DA_METADATA_SELECTOR);
-    const { acceptedHashes, rejectedHashes } = getPreviousHashes(getElementMetadata(daMetadataEl));
+    const daMetadata = getElementMetadata(daMetadataEl);
+    const { acceptedHashes, rejectedHashes } = getPreviousHashes(daMetadata);
 
     // There are differences, upload the annotated loc file
     const diffed = await regionalDiff(langstoreCopy, regionalCopy, acceptedHashes, rejectedHashes);
 
+    if (labelLocal) daMetadata['diff-label-local'] = labelLocal;
+    if (labelUpstream) daMetadata['diff-label-upstream'] = labelUpstream;
+
     const daUrl = getDaUrl(url);
-    const { daResp } = await saveToDa(diffed.innerHTML, daUrl, { daMetadataEl });
+    const { daResp } = await saveToDa(diffed.innerHTML, daUrl, daMetadata);
     if (daResp.ok) {
       url.status = 'success';
       saveVersion(url.destination, `${projectTitle} - Rolled Out`);

--- a/nx/blocks/snapshot-admin/utils/utils.js
+++ b/nx/blocks/snapshot-admin/utils/utils.js
@@ -140,7 +140,10 @@ export async function copyManifest(name, resources, direction) {
   // The action to take
   const copyUrl = async (url) => {
     if (url.source.endsWith('.html')) {
-      await mergeCopy(url, `Snapshot ${direction}`);
+      const labels = (direction === 'fork')
+        ? { labelLocal: 'Snapshot', labelUpstream: 'Main' }
+        : { labelLocal: 'Main', labelUpstream: 'Snapshot' };
+      await mergeCopy(url, `Snapshot ${direction}`, labels);
     } else {
       await overwriteCopy(url, `Snapshot ${direction}`);
     }

--- a/nx/utils/daFetch.js
+++ b/nx/utils/daFetch.js
@@ -40,7 +40,7 @@ export const daFetch = async (url, opts = {}) => {
   return resp;
 };
 
-export function replaceHtml(text, fromOrg, fromRepo, { daMetadataEl = null } = {}) {
+export function replaceHtml(text, fromOrg, fromRepo, daMetadata = {}) {
   let inner = text;
   if (fromOrg && fromRepo) {
     const fromOrigin = `https://main--${fromRepo}--${fromOrg}.aem.live`;
@@ -49,22 +49,29 @@ export function replaceHtml(text, fromOrg, fromRepo, { daMetadataEl = null } = {
       .replaceAll('href="/', `href="${fromOrigin}/`);
   }
 
+  let metadataHTML = '';
+  if (Object.keys(daMetadata).length > 0) {
+    const daRows = Object.entries(daMetadata)
+      .map(([key, value]) => `<div><div>${key}</div><div>${value}</div></div>`)
+      .join('');
+    metadataHTML = `\n  <div class="da-metadata">${daRows}</div>\n`;
+  }
+
   return `
     <body>
       <header></header>
       <main>${inner}</main>
-      ${daMetadataEl ? `<div class="da-metadata">${daMetadataEl.innerHTML}</div>` : ''}
-      <footer></footer>
+      ${metadataHTML}<footer></footer>
     </body>
   `;
 }
 
-export async function saveToDa(text, url, { daMetadataEl = null } = {}) {
-  const daPath = `/${url.org}/${url.repo}${url.pathname}`;
+export async function saveToDa(text, url, daMetadata = {}) {
+  const { org, repo, pathname } = url;
+  const daPath = `/${org}/${repo}${pathname}`;
   const daHref = `https://da.live/edit#${daPath}`;
-  const { org, repo } = url;
 
-  const body = replaceHtml(text, org, repo, { daMetadataEl });
+  const body = replaceHtml(text, org, repo, daMetadata);
 
   const blob = new Blob([body], { type: 'text/html' });
   const formData = new FormData();

--- a/test/utils/daFetch.test.js
+++ b/test/utils/daFetch.test.js
@@ -1,0 +1,110 @@
+import { expect } from '@esm-bundle/chai';
+import { replaceHtml } from '../../nx/utils/daFetch.js';
+
+describe('replaceHtml', () => {
+  describe('structure', () => {
+    it('wraps content in body/header/main/footer', () => {
+      const out = replaceHtml('hello');
+      expect(out).to.include('<body>');
+      expect(out).to.include('<header></header>');
+      expect(out).to.include('<main>hello</main>');
+      expect(out).to.include('<footer></footer>');
+    });
+
+    it('handles empty text', () => {
+      const out = replaceHtml('');
+      expect(out).to.include('<main></main>');
+    });
+  });
+
+  describe('when fromOrg or fromRepo is missing', () => {
+    it('does not replace ./media or href when both missing', () => {
+      const text = 'x ./media y href="/foo"';
+      const out = replaceHtml(text);
+      expect(out).to.include('<main>x ./media y href="/foo"</main>');
+      expect(out).not.to.include('aem.live');
+    });
+
+    it('does not replace when only fromOrg is set', () => {
+      const text = './media href="/bar"';
+      expect(replaceHtml(text, 'myorg', null)).to.include(`<main>${text}</main>`);
+      expect(replaceHtml(text, 'myorg', undefined)).to.include(`<main>${text}</main>`);
+      expect(replaceHtml(text, 'myorg', null)).not.to.include('aem.live');
+    });
+
+    it('does not replace when only fromRepo is set', () => {
+      const text = './media href="/baz"';
+      expect(replaceHtml(text, null, 'myrepo')).to.include(`<main>${text}</main>`);
+      expect(replaceHtml(text, '', 'myrepo')).to.include(`<main>${text}</main>`);
+      expect(replaceHtml(text, null, 'myrepo')).not.to.include('aem.live');
+    });
+  });
+
+  describe('when fromOrg and fromRepo are set', () => {
+    const origin = 'https://main--myrepo--myorg.aem.live';
+
+    it('replaces ./media with origin-prefixed /media', () => {
+      const out = replaceHtml('link ./media/image.png', 'myorg', 'myrepo');
+      expect(out).to.include(`${origin}/media/image.png`);
+      expect(out).not.to.include('./media/image.png');
+    });
+
+    it('replaces all ./media occurrences', () => {
+      const text = './media/a ./media/b';
+      const out = replaceHtml(text, 'myorg', 'myrepo');
+      expect(out).to.include(`${origin}/media/a`);
+      expect(out).to.include(`${origin}/media/b`);
+    });
+
+    it('replaces href="/ with origin-prefixed href', () => {
+      const out = replaceHtml('href="/page"', 'myorg', 'myrepo');
+      expect(out).to.include(`href="${origin}/page"`);
+      expect(out).not.to.include('href="/page"');
+    });
+
+    it('replaces all href="/ occurrences', () => {
+      const text = 'href="/a" href="/b"';
+      const out = replaceHtml(text, 'myorg', 'myrepo');
+      expect(out).to.include(`href="${origin}/a"`);
+      expect(out).to.include(`href="${origin}/b"`);
+    });
+
+    it('applies both replacements in one string', () => {
+      const text = 'link ./media/x.png and href="/y"';
+      const out = replaceHtml(text, 'myorg', 'myrepo');
+      expect(out).to.include(`${origin}/media/x.png`);
+      expect(out).to.include(`href="${origin}/y"`);
+    });
+  });
+
+  describe('daMetadata', () => {
+    it('adds no da-metadata div when empty object', () => {
+      const out = replaceHtml('x', null, null, {});
+      expect(out).not.to.include('da-metadata');
+    });
+
+    it('adds no da-metadata div when not passed', () => {
+      const out = replaceHtml('x');
+      expect(out).not.to.include('da-metadata');
+    });
+
+    it('adds da-metadata div with key/value rows when metadata provided', () => {
+      const out = replaceHtml('x', null, null, { foo: 'bar' });
+      expect(out).to.include('class="da-metadata"');
+      expect(out).to.include('<div>foo</div><div>bar</div>');
+    });
+
+    it('adds multiple metadata entries', () => {
+      const out = replaceHtml('x', null, null, { a: '1', b: '2' });
+      expect(out).to.include('<div>a</div><div>1</div>');
+      expect(out).to.include('<div>b</div><div>2</div>');
+    });
+
+    it('combines metadata with url replacement', () => {
+      const out = replaceHtml('./media/img.png', 'o', 'r', { key: 'val' });
+      expect(out).to.include('class="da-metadata"');
+      expect(out).to.include('<div>key</div><div>val</div>');
+      expect(out).to.include('https://main--r--o.aem.live/media/img.png');
+    });
+  });
+});


### PR DESCRIPTION
Fix: https://github.com/adobe/da-live/issues/747

* Custom diff labels now used for snapshots ("Main" and "Snapshot")
* mergeCopy now accepts local/upstream custom labels params
* Updates overwriteCopy to remove all da-diff info from source when copying
* Use metadata object instead of element for saveToDa and replaceHtml
* Add replaceHtml unit test

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- https://da.live/apps/snapshots?nx=ccc-747
