### PR TITLE
fix: correct handling of upper case & lower case key

### DIFF
--- a/nx/blocks/form/utils/html2json.js
+++ b/nx/blocks/form/utils/html2json.js
@@ -64,7 +64,7 @@ export default class HTMLConverter {
       // If we are looking for a reference,
       // use the variation, not the block name
       const idx = searchRef ? 1 : 0;
-      if (block.properties.className[idx] === searchTerm) {
+      if (block.properties.className[idx]?.toLowerCase() === searchTerm.toLowerCase()) {
         const properties = this.getProperties(block);
         // If the block contains only @items, it represents an array
         // Return the array value directly instead of the object wrapper

--- a/nx/blocks/form/utils/json2html.js
+++ b/nx/blocks/form/utils/json2html.js
@@ -28,7 +28,7 @@ function createRow(key, valCol) {
 
 function createBlock(name) {
   const block = document.createElement('div');
-  block.className = name;
+  block.className = name.toLowerCase();
   return block;
 }
 
@@ -58,13 +58,13 @@ function createArrayBlock(key, arr, nestedBlocks) {
       // Nested array within array
       const itemGuid = createArrayBlock(key, item, nestedBlocks);
       const li = document.createElement('li');
-      li.textContent = `self://#${key}-${itemGuid}`;
+      li.textContent = `self://#${key.toLowerCase()}-${itemGuid}`;
       ul.append(li);
     } else if (typeof item === 'object' && item !== null) {
       // Object within array - use original key, not '@items'
       const itemGuid = createNestedBlock(key, item, nestedBlocks);
       const li = document.createElement('li');
-      li.textContent = `self://#${key}-${itemGuid}`;
+      li.textContent = `self://#${key.toLowerCase()}-${itemGuid}`;
       ul.append(li);
     } else {
       // Primitive within array
@@ -104,13 +104,13 @@ function createValueCol(key, value, nestedBlocks) {
             // Handle nested array (array within array)
             const guid = createArrayBlock(key, item, nestedBlocks);
             const li = document.createElement('li');
-            li.textContent = `self://#${key}-${guid}`;
+            li.textContent = `self://#${key.toLowerCase()}-${guid}`;
             ul.append(li);
           } else if (typeof item === 'object' && item !== null) {
             // Handle object within array
             const guid = createNestedBlock(key, item, nestedBlocks);
             const li = document.createElement('li');
-            li.textContent = `self://#${key}-${guid}`;
+            li.textContent = `self://#${key.toLowerCase()}-${guid}`;
             ul.append(li);
           } else {
             // Handle primitive within array
@@ -129,7 +129,7 @@ function createValueCol(key, value, nestedBlocks) {
         return null;
       }
       const guid = createNestedBlock(key, value, nestedBlocks);
-      valPara.textContent = `self://#${key}-${guid}`;
+      valPara.textContent = `self://#${key.toLowerCase()}-${guid}`;
     } else {
       valPara.textContent = value;
     }

--- a/test/form/utils/html2json.test.js
+++ b/test/form/utils/html2json.test.js
@@ -273,6 +273,21 @@ describe('HTML to JSON Conversion', () => {
       expect(convertedJson.data).to.deep.equal(expectedJson.data);
     });
 
+    it('should convert simpleArray.html to expected JSON', async () => {
+      const htmlRaw = await readFile({ path: './mocks/simpleArray.html' });
+      const html = cleanHtmlWhitespace(htmlRaw);
+
+      const simpleArrayJson = await readFile({ path: './mocks/simpleArray.json' });
+      const expectedJson = JSON.parse(simpleArrayJson);
+
+      const converter = new HTMLConverter(html);
+
+      const convertedJson = converter.json;
+
+      expect(convertedJson.metadata).to.deep.equal(expectedJson.metadata);
+      expect(convertedJson.data).to.deep.equal(expectedJson.data);
+    });
+
     it('should convert nestedArrays.html to expected JSON', async () => {
       const htmlRaw = await readFile({ path: './mocks/nestedArrays.html' });
       const html = cleanHtmlWhitespace(htmlRaw);

--- a/test/form/utils/json2html.test.js
+++ b/test/form/utils/json2html.test.js
@@ -373,4 +373,14 @@ describe('Real-world Examples', () => {
 
     expect(normalizeHtml(generatedHtml)).to.equal(normalizeHtml(expectedHtml));
   });
+
+  it('should convert simpleArray.json to HTML', async () => {
+    const jsonContent = await readFile({ path: './mocks/simpleArray.json' });
+    const json = JSON.parse(jsonContent);
+
+    const generatedHtml = json2html(json);
+    const expectedHtml = await readFile({ path: './mocks/simpleArray.html' });
+
+    expect(normalizeHtml(generatedHtml)).to.equal(normalizeHtml(expectedHtml));
+  });
 });

--- a/test/form/utils/mocks/nestedArrays.html
+++ b/test/form/utils/mocks/nestedArrays.html
@@ -27,8 +27,8 @@
           </div>
           <div>
             <ul>
-              <li>self://#emergencyContacts-rfx2f9</li>
-              <li>self://#emergencyContacts-i3mm2y</li>
+              <li>self://#emergencycontacts-rfx2f9</li>
+              <li>self://#emergencycontacts-i3mm2y</li>
             </ul>
           </div>
         </div>
@@ -38,8 +38,8 @@
           </div>
           <div>
             <ul>
-              <li>self://#workHistory-f6vxk9</li>
-              <li>self://#workHistory-5sglgq</li>
+              <li>self://#workhistory-f6vxk9</li>
+              <li>self://#workhistory-5sglgq</li>
             </ul>
           </div>
         </div>
@@ -49,9 +49,9 @@
           </div>
           <div>
             <ul>
-              <li>self://#skillCategories-xbjqvk</li>
-              <li>self://#skillCategories-1pqfky</li>
-              <li>self://#skillCategories-24u1wd</li>
+              <li>self://#skillcategories-xbjqvk</li>
+              <li>self://#skillcategories-1pqfky</li>
+              <li>self://#skillcategories-24u1wd</li>
             </ul>
           </div>
         </div>
@@ -61,13 +61,13 @@
           </div>
           <div>
             <ul>
-              <li>self://#projectGroups-1zr93v</li>
-              <li>self://#projectGroups-y8emdn</li>
+              <li>self://#projectgroups-1zr93v</li>
+              <li>self://#projectgroups-y8emdn</li>
             </ul>
           </div>
         </div>
       </div>
-      <div class="emergencyContacts emergencyContacts-rfx2f9">
+      <div class="emergencycontacts emergencycontacts-rfx2f9">
         <div>
           <div>
             <p>name</p>
@@ -93,7 +93,7 @@
           </div>
         </div>
       </div>
-      <div class="emergencyContacts emergencyContacts-i3mm2y">
+      <div class="emergencycontacts emergencycontacts-i3mm2y">
         <div>
           <div>
             <p>name</p>
@@ -119,7 +119,7 @@
           </div>
         </div>
       </div>
-      <div class="workHistory workHistory-f6vxk9">
+      <div class="workhistory workhistory-f6vxk9">
         <div>
           <div>
             <p>company</p>
@@ -165,7 +165,7 @@
           </div>
         </div>
       </div>
-      <div class="workHistory workHistory-5sglgq">
+      <div class="workhistory workhistory-5sglgq">
         <div>
           <div>
             <p>company</p>
@@ -211,7 +211,7 @@
           </div>
         </div>
       </div>
-      <div class="skillCategories skillCategories-xbjqvk">
+      <div class="skillcategories skillcategories-xbjqvk">
         <div>
           <div>
             <p>@items</p>
@@ -225,7 +225,7 @@
           </div>
         </div>
       </div>
-      <div class="skillCategories skillCategories-1pqfky">
+      <div class="skillcategories skillcategories-1pqfky">
         <div>
           <div>
             <p>@items</p>
@@ -239,7 +239,7 @@
           </div>
         </div>
       </div>
-      <div class="skillCategories skillCategories-24u1wd">
+      <div class="skillcategories skillcategories-24u1wd">
         <div>
           <div>
             <p>@items</p>
@@ -253,7 +253,7 @@
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-7v8ajv">
+      <div class="projectgroups projectgroups-7v8ajv">
         <div>
           <div>
             <p>name</p>
@@ -287,7 +287,7 @@
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-l0cg2p">
+      <div class="projectgroups projectgroups-l0cg2p">
         <div>
           <div>
             <p>name</p>
@@ -321,20 +321,20 @@
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-1zr93v">
+      <div class="projectgroups projectgroups-1zr93v">
         <div>
           <div>
             <p>@items</p>
           </div>
           <div>
             <ul>
-              <li>self://#projectGroups-7v8ajv</li>
-              <li>self://#projectGroups-l0cg2p</li>
+              <li>self://#projectgroups-7v8ajv</li>
+              <li>self://#projectgroups-l0cg2p</li>
             </ul>
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-wibmsz">
+      <div class="projectgroups projectgroups-wibmsz">
         <div>
           <div>
             <p>name</p>
@@ -368,7 +368,7 @@
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-j34nj3">
+      <div class="projectgroups projectgroups-j34nj3">
         <div>
           <div>
             <p>name</p>
@@ -402,15 +402,15 @@
           </div>
         </div>
       </div>
-      <div class="projectGroups projectGroups-y8emdn">
+      <div class="projectgroups projectgroups-y8emdn">
         <div>
           <div>
             <p>@items</p>
           </div>
           <div>
             <ul>
-              <li>self://#projectGroups-wibmsz</li>
-              <li>self://#projectGroups-j34nj3</li>
+              <li>self://#projectgroups-wibmsz</li>
+              <li>self://#projectgroups-j34nj3</li>
             </ul>
           </div>
         </div>

--- a/test/form/utils/mocks/simpleArray.html
+++ b/test/form/utils/mocks/simpleArray.html
@@ -1,0 +1,5 @@
+<body>
+  <header></header>
+  <main><div><div class="da-form"><div><div><p>x-schema-name</p></div><div><p>undefined</p></div></div><div><div><p>title</p></div><div><p>test-array-v-7</p></div></div></div><div class="undefined"><div><div><p>name</p></div><div><p>test</p></div></div><div><div><p>projectGroups</p></div><div><ul><li>self://#projectgroups-fkrn08</li></ul></div></div></div><div class="projectgroups projectgroups-4n80im"><div><div><p>name</p></div><div><p>project 4</p></div></div></div><div class="projectgroups projectgroups-fkrn08"><div><div><p>@items</p></div><div><ul><li>self://#projectgroups-4n80im</li></ul></div></div></div></div></main>
+  <footer></footer>
+</body>

--- a/test/form/utils/mocks/simpleArray.json
+++ b/test/form/utils/mocks/simpleArray.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "schemaName": "undefined",
+    "title": "test-array-v-7"
+  },
+  "data": {
+    "name": "test",
+    "projectGroups": [
+      [
+        {
+          "name": "project 4"
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
Make sure all block class names and self:// references are lower case when writing and ignore case when reading during the HTML > JSON > HTML conversion.
