### PR TITLE
Address backward compatibility issue in GLaaS API

### DIFF
--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -127,6 +127,9 @@ export async function addAssets({
       const assetMetadata = {
         assetName: glaasFilename,
         metadata: { 'source-preview-url': item.aemHref.replace(/\/index$/, '/') },
+        // GLaaS backward compatibility issue for WS (En-GB) - hence adding here as well.
+        assetType: 'SOURCE',
+        targetLocales,
         ...(item.translationMetadata && { langMetadata: item.translationMetadata }),
       };
       body.append('_asset_metadata_', new Blob(


### PR DESCRIPTION
- For WS projects if asset_metadata is added - all information needs to be there as well as in fileDetails.
- currently altlang is failing. 

