### PR TITLE
fix: recreate channels on load

### DIFF
--- a/nx/blocks/shell/shell.js
+++ b/nx/blocks/shell/shell.js
@@ -7,7 +7,6 @@ import { IMS_ORIGIN, loadIms } from '../../utils/ims.js';
 import { DA_ORIGIN } from '../../public/utils/constants.js';
 
 const IMS_DETAILS = await loadIms();
-const CHANNEL = new MessageChannel();
 
 await import('../../public/sl/components.js');
 
@@ -69,7 +68,10 @@ function getUrl() {
  * @param {HTMLIFrameElement} event.target - The loaded iframe element
  */
 function handleLoad({ target }) {
-  CHANNEL.port1.onmessage = (e) => {
+  const channel = new MessageChannel();
+  const { port1, port2 } = channel;
+
+  port1.onmessage = (e) => {
     if (e.data.action === 'setTitle') {
       document.title = e.data.details;
     }
@@ -82,7 +84,7 @@ function handleLoad({ target }) {
   };
 
   setTimeout(() => {
-    target.contentWindow.postMessage(message, '*', [CHANNEL.port2]);
+    target.contentWindow.postMessage(message, '*', [port2]);
   }, 750);
 }
 


### PR DESCRIPTION
If the app reloads or "navigates" (internal navigation), the SDK fails to load: 

```
shell.js:85 Uncaught DataCloneError: Failed to execute 'postMessage' on 'Window': Port at index 0 is already neutered.
```
﻿
The ports are neutered and needs to be recreated.
There is no reason to have a global variable anyway.