### PR TITLE
Do not trim strings next to elements, just collapse multiple whitespace

### DIFF
--- a/nx/blocks/loc/project/index.js
+++ b/nx/blocks/loc/project/index.js
@@ -124,8 +124,8 @@ function collapseInnerTextSpaces(html) {
       return match;
     }
 
-    // Collapse multiple spaces to single space, trim padding
-    const cleaned = textContent.replace(/\s+/g, ' ').trim();
+    // Collapse multiple spaces to single space
+    const cleaned = textContent.replace(/\s+/g, ' ');
     return `>${cleaned}<`;
   });
 }


### PR DESCRIPTION
Inline elements were getting spaces next to them removed
