### PR TITLE
MWPW-188346 — GlaaS translation asset URLs converted to relative paths when media_ files / library blocks are uploaded

### DIFF
--- a/nx/blocks/loc/views/translate/index.js
+++ b/nx/blocks/loc/views/translate/index.js
@@ -70,7 +70,7 @@ export async function getUrls(
       url.content = content;
       if (connector) {
         try {
-          url.content = await connector.dnt.addDnt(content, config, { fileType });
+          url.content = await connector.dnt.addDnt(content, config, { fileType, org, site });
         } catch (error) {
           url.error = `Error adding DNT to ${url.daBasePath} - ${error.message}`;
         }

--- a/test/loc/glaas/dnt.test.js
+++ b/test/loc/glaas/dnt.test.js
@@ -39,9 +39,12 @@ describe('Glaas DNT', () => {
     <div>
       <img src="https://main--da-bacom--adobecom.aem.live/media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg?optimize=medium" alt="https://a.com | Text here | :play:" loading="lazy" />
     </div>
+    <div>
+      <img src="https://main--milo--adobecom.aem.live/media_164cffa8fd2b5e7afd2d7036f4725604a2381aa91.jpeg?optimize=medium" alt="https://a.com | Text here | :play:" loading="lazy" />
+    </div>
   </main>
 </body>`;
-    const htmlWithDnt = await addDnt(html, config, { reset: true });
+    const htmlWithDnt = await addDnt(html, config, { reset: true, org: 'adobecom', site: 'da-bacom' });
     console.log(htmlWithDnt);
     expect(htmlWithDnt).to.equal(
       `<html><head></head><body>
@@ -52,6 +55,9 @@ describe('Glaas DNT', () => {
     </div>
     <div>
       <img src="./media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg?optimize=medium" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
+    </div>
+    <div>
+      <img src="https://main--milo--adobecom.aem.live/media_164cffa8fd2b5e7afd2d7036f4725604a2381aa91.jpeg?optimize=medium" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
     </div>
   </main>
 </body></html>`,
@@ -67,6 +73,9 @@ describe('Glaas DNT', () => {
     </div>
     <div>
       <img src="https://main--da-bacom--adobecom.aem.live/media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg?optimize=medium" alt="https://a.com | Text here | :play:" loading="lazy">
+    </div>
+    <div>
+      <img src="https://main--milo--adobecom.aem.live/media_164cffa8fd2b5e7afd2d7036f4725604a2381aa91.jpeg?optimize=medium" alt="https://a.com | Text here | :play:" loading="lazy">
     </div>
   </main>
 </body></html>`,


### PR DESCRIPTION
When content containing media_<hash> assets (or library blocks referencing images/media_ with main--milo) is sent to localization and a target preview is not rendering the image. This is due to relative url conversion for media_<hash> urls Example: content.da.live/test/.page/media_1234.jpg → ./test/.page/media_1234.jpg. After the localized content is converted back to a DA document, the rewritten relative URLs are broken.

Change -
These media URLs now are not rewritten to relative paths. Only URLs containing the current main--<repo>--org structure are being converted to relative paths.

Resolves: MWPW-188346