### PR TITLE
feat: add da-continuation-token support

### DIFF
--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -52,9 +52,15 @@ export class Queue {
 async function getChildren(path) {
   const files = [];
   const folders = [];
+  let continuationToken = null;
 
-  const resp = await daFetch(`${DA_ORIGIN}/list${path}`);
-  if (resp.ok) {
+  do {
+    const opts = continuationToken
+      ? { headers: { 'da-continuation-token': continuationToken } }
+      : {};
+    const resp = await daFetch(`${DA_ORIGIN}/list${path}`, opts);
+    if (!resp.ok) break;
+
     const json = await resp.json();
     json.forEach((child) => {
       if (!child.name) {
@@ -68,7 +74,10 @@ async function getChildren(path) {
         folders.push(child.path);
       }
     });
-  }
+
+    continuationToken = resp.headers.get('da-continuation-token');
+  } while (continuationToken);
+
   return { files, folders };
 }
 

--- a/test/utils/tree.test.js
+++ b/test/utils/tree.test.js
@@ -312,6 +312,40 @@ describe('getChildren (via crawl)', () => {
     const files = await results;
     expect(files.length).to.equal(0);
   });
+
+  it('Batches list results using da-continuation-token when >1000 children', async () => {
+    const page1 = [
+      { path: '/big/file1.html', name: 'file1', ext: 'html', lastModified: 1753691701858 },
+    ];
+    const page2 = [
+      { path: '/big/file2.json', name: 'file2', ext: 'json', lastModified: 1762282196814 },
+    ];
+    let callCount = 0;
+    window.fetch = async (url, opts = {}) => {
+      callCount += 1;
+      const hasToken = opts.headers?.['da-continuation-token'];
+      const json = hasToken ? page2 : page1;
+      const nextToken = hasToken ? null : 'token-page2';
+      return {
+        ok: true,
+        json: async () => json,
+        headers: { get: (name) => (name === 'da-continuation-token' ? nextToken : null) },
+      };
+    };
+
+    const { results } = crawl({
+      path: '/big',
+      callback: null,
+      concurrent: 10,
+      throttle: 10,
+    });
+
+    const files = await results;
+    expect(callCount).to.equal(2);
+    expect(files.length).to.equal(2);
+    expect(files.some((f) => f.name === 'file1')).to.equal(true);
+    expect(files.some((f) => f.name === 'file2')).to.equal(true);
+  });
 });
 
 describe('crawl', () => {


### PR DESCRIPTION
https://github.com/adobe/da-admin/pull/241 added pagination to list api. This allows now to get the correct number of children if more than 1000. 