### PR TITLE
MWPW-188346: Fix media_ URL conversion in GlaaS translation flow

### DIFF
--- a/nx/blocks/loc/connectors/glaas/dnt.js
+++ b/nx/blocks/loc/connectors/glaas/dnt.js
@@ -1,6 +1,8 @@
 let globalDntConfig;
 const ALT_TEXT_PLACEHOLDER = '*alt-placeholder*';
 
+const isAemHost = (hostname) => /\.(aem|hlx)\.(page|live)$/.test(hostname);
+
 const getHtmlSelector = (blockscope, blockConfig) => {
   const getChildSelector = (indexStr) => {
     if (indexStr === '*' || Number.isNaN(indexStr)) {
@@ -182,7 +184,7 @@ function makeHrefsRelative(document) {
 function makeUrlRelative(originalSrc) {
   try {
     const url = new URL(originalSrc);
-    return `.${url.pathname}${url.search}${url.hash}`;
+    return isAemHost(url.hostname) && !url.search ? `.${url.pathname}${url.hash}` : null;
   } catch (e) {
     return null;
   }

--- a/test/loc/glaas/dnt.test.js
+++ b/test/loc/glaas/dnt.test.js
@@ -51,7 +51,7 @@ describe('Glaas DNT', () => {
       <p>Some text with a <span class="icon icon-happy"></span> icon</p>
     </div>
     <div>
-      <img src="./media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg?optimize=medium" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
+      <img src="https://main--da-bacom--adobecom.aem.live/media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg?optimize=medium" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
     </div>
   </main>
 </body></html>`,
@@ -82,5 +82,57 @@ describe('Glaas DNT', () => {
 
     const jsonWithoutDnt = `${await removeDnt(htmlWithDnt, 'adobecom', 'da-bacom', { fileType: 'json' })}\n`;
     expect(JSON.parse(jsonWithoutDnt)).to.deep.equal(JSON.parse(json));
+  });
+
+  it.only('Converts media paths to relative for aem links without parameters', async () => {
+    const config = JSON.parse((await readFile({ path: './mocks/hubspot/translate.json' })));
+    const html = `<body>
+  <header></header>
+  <main>
+    <div>
+      <p>Some text with a :happy: icon</p>
+    </div>
+    <div>
+      <img src="https://main--milo--adobecom.aem.page/media_14397d257748618c661379e599afb2fdd682c2335.png?width=750&amp;format=png&amp;optimize=medium" alt="https://a.com | Text here | :play:" loading="lazy" />
+    </div>
+        <div>
+      <img src="https://main--da-bacom--adobecom.aem.live/media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg" alt="https://a.com | Text here | :play:" loading="lazy" />
+    </div>
+    <div>
+      <img src="https://main--da-bacom--adobecom.aem.live/media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg#test" />
+    </div>
+    <div>
+      <picture>
+        <source srcset="https://content.da.live/adobecom/da-cc/drafts/test/.imagetestfeb26/media_1866efd6c49d4eb614bae84d2d5d546a97de25654.png" />
+      </picture>
+    </div>
+  </main>
+</body>`;
+    const htmlWithDnt = await addDnt(html, config, { reset: true });
+    console.log(htmlWithDnt);
+    expect(htmlWithDnt).to.equal(
+      `<html><head></head><body>
+  
+  <main>
+    <div>
+      <p>Some text with a <span class="icon icon-happy"></span> icon</p>
+    </div>
+    <div>
+      <img src="https://main--milo--adobecom.aem.page/media_14397d257748618c661379e599afb2fdd682c2335.png?width=750&amp;format=png&amp;optimize=medium" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
+    </div>
+        <div>
+      <img src="./media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg" alt="Text here" loading="lazy" dnt-alt-content="https://a.com | *alt-placeholder* | :play:">
+    </div>
+    <div>
+      <img src="./media_14a4b58fd73d82e553ccb65d5f53c3f5ff552330d.jpeg#test">
+    </div>
+    <div>
+      <picture>
+        <source srcset="https://content.da.live/adobecom/da-cc/drafts/test/.imagetestfeb26/media_1866efd6c49d4eb614bae84d2d5d546a97de25654.png">
+      </picture>
+    </div>
+  </main>
+</body></html>`,
+    );
   });
 });


### PR DESCRIPTION
In the GlaaS flow, media_ links were being converted due to below some of these cases where images are broken

1. Images added from libraries including width and height query parameters, causing the hash to change.
2. Uploaded images named media_<number> using content.da.live URLs, which must be retained.

Change:
Make media_ URLs relative only when:

* The link is an AEM URL, and
* The URL does not contain query parameters. This behavior can be reverted after the da.live PR is merged, where media_ image URLs added from the library will no longer include query parameters.

Fix: MWPW-188346