### PR TITLE
fix: Reset results array on each run (google connector)

### DIFF
--- a/nx/blocks/loc/connectors/google/index.js
+++ b/nx/blocks/loc/connectors/google/index.js
@@ -52,6 +52,8 @@ export async function sendAllLanguages({
   const { sendMessage, saveState } = actions;
   const sourceLanguage = options['source.language']?.location || '/';
 
+  results.length = 0;
+
   const translateUrl = async (url) => {
     await sendForTranslation(org, site, url);
   };


### PR DESCRIPTION
Not resetting can lead to stale data being used.
