### PR TITLE
fix: [dasc] Fix checkbox default value and fix validation pointer.

### DIFF
--- a/nx/blocks/form/data/model.js
+++ b/nx/blocks/form/data/model.js
@@ -9,6 +9,7 @@ import {
   getValue,
   setValue,
   removeValue,
+  clearValue,
   moveBefore,
   insertBefore,
 } from '../utils/pointer.js';
@@ -57,8 +58,7 @@ export default class FormModel {
   }
 
   validate() {
-    const prunedData = pruneRecursive(this._json.data);
-    return validateJson(this._schema, prunedData ?? {}, this.annotated);
+    return validateJson(this._schema, this._json.data ?? {}, this.annotated);
   }
 
   htmlToJson(html) {
@@ -71,7 +71,7 @@ export default class FormModel {
     if (!node) return;
     const effectiveValue = resolveValue(node, value, false);
     if (isEmpty(effectiveValue)) {
-      removeValue(this._json, name);
+      clearValue(this._json, name, effectiveValue);
     } else {
       setValue(this._json, name, effectiveValue);
     }

--- a/nx/blocks/form/utils/pointer.js
+++ b/nx/blocks/form/utils/pointer.js
@@ -140,6 +140,30 @@ export function removeValue(data, pointer) {
 }
 
 /**
+ * Clear value at pointer. For array elements: sets to emptyValue (preserves slot).
+ * For object properties: removes.
+ * @param {Object} data - Root object
+ * @param {string} pointer - RFC 6901 pointer
+ * @param {*} [emptyValue=''] - Value to set when clearing an array element
+ * @returns {boolean} True if cleared
+ */
+export function clearValue(data, pointer, emptyValue = '') {
+  const target = getParent(data, pointer);
+  if (!target) return false;
+
+  const { parent, lastSegment } = target;
+  const index = parseInt(lastSegment, 10);
+  const isArrayElement = Array.isArray(parent)
+    && Number.isInteger(index) && index >= 0 && index < parent.length;
+
+  if (isArrayElement) {
+    setValue(data, pointer, emptyValue);
+    return true;
+  }
+  return removeValue(data, pointer);
+}
+
+/**
  * Move array item before another item, or to end if beforePointer is empty.
  * @param {Object} data - Root object
  * @param {string} pointer - RFC 6901 pointer to the item to move

--- a/nx/blocks/form/utils/value-resolver.js
+++ b/nx/blocks/form/utils/value-resolver.js
@@ -16,6 +16,7 @@ function generateObject(node, useSchemaDefaults, generate) {
 
 /**
  * Generate value from annotated node (no user data).
+ * Returns value from schema; undefined = omit.
  * @param {Object} node - Annotated node { type, key?, children?, default? }
  * @param {boolean} [useSchemaDefaults=true] - Apply schema default when true
  * @returns {*} Resolved value (undefined = omit)
@@ -28,10 +29,12 @@ export function generateValue(node, useSchemaDefaults = true) {
     case 'array':
       return [];
     case 'string':
+      return (useSchemaDefaults && node.default !== undefined) ? node.default : '';
     case 'number':
     case 'integer':
-    case 'boolean':
       return (useSchemaDefaults && node.default !== undefined) ? node.default : undefined;
+    case 'boolean':
+      return (useSchemaDefaults && node.default !== undefined) ? node.default : false;
     default:
       return undefined;
   }
@@ -62,8 +65,7 @@ function resolveArray(node, userValue, fillDefaults, resolve) {
 
 function resolvePrimitive(node, userValue, fillDefaults) {
   if (userValue !== undefined) return userValue;
-  if (node.required) return generateValue(node, fillDefaults);
-  return (fillDefaults && node.default !== undefined) ? node.default : undefined;
+  return generateValue(node, fillDefaults);
 }
 
 /**


### PR DESCRIPTION
Ticket: https://github.com/adobe/da-nx/issues/230

Fixes added:

**Checkbox:** 

When a checkbox has no value, the form now treats it as `false` and persists it. Unchecked checkboxes are saved correctly.

**Validation:** 

Validation now runs on the full form data instead of the pruned version. Empty items stay in the data during validation, so array indices match and errors appear on the correct item. Pruning is only applied when saving.

Strings get a default empty value instead of null, so validation no longer shows "null values are not allowed", this empty value is not persisted.

**Clear action:** 

A new clear method handles the clear action differently depending on the target: for array elements it sets the value to empty (preserving the slot), for object properties it removes the key.