### PR TITLE
prevent quick edit re-downloading all images on every interaction

### DIFF
--- a/nx/blocks/quick-edit-portal/src/prose2aem.js
+++ b/nx/blocks/quick-edit-portal/src/prose2aem.js
@@ -14,6 +14,39 @@ const EDITABLES = [
 ];
 const EDITABLE_SELECTORS = EDITABLES.map((edit) => edit.selector).join(', ');
 
+export function extractCursors(view) {
+  const remoteCursors = view.dom.querySelectorAll('.ProseMirror-yjs-cursor');
+  const cursorMap = new Map();
+
+  remoteCursors.forEach((remoteCursor) => {
+    let highestEditable = null;
+    let current = remoteCursor.parentElement;
+
+    while (current) {
+      if (current.matches?.(EDITABLE_SELECTORS)) {
+        highestEditable = current;
+      }
+      current = current.parentElement;
+    }
+
+    if (!highestEditable) return;
+
+    try {
+      const proseIndex = view.posAtDOM(highestEditable, 0);
+      cursorMap.set(proseIndex, {
+        proseIndex,
+        remote: remoteCursor.innerText,
+        color: remoteCursor.style['border-color'],
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('Could not find position for remote cursor:', e);
+    }
+  });
+
+  return [...cursorMap.values()];
+}
+
 export function getInstrumentedHTML(view) {
   // Clone the editor first so we don't modify the real DOM
   const editorClone = view.dom.cloneNode(true);

--- a/nx/blocks/quick-edit-portal/src/render.js
+++ b/nx/blocks/quick-edit-portal/src/render.js
@@ -1,5 +1,5 @@
 import { TextSelection, yUndo, yRedo } from 'da-y-wrapper';
-import { getInstrumentedHTML } from './prose2aem.js';
+import { getInstrumentedHTML, extractCursors } from './prose2aem.js';
 
 export function updateDocument(ctx) {
   // Skip rerender if suppressed (e.g., during image updates)
@@ -9,8 +9,8 @@ export function updateDocument(ctx) {
 }
 
 export function updateCursors(ctx) {
-  const body = getInstrumentedHTML(window.view);
-  ctx.port.postMessage({ type: 'set-cursors', body });
+  const cursors = extractCursors(window.view);
+  ctx.port.postMessage({ type: 'set-cursors', cursors });
 }
 
 export function updateState(data, ctx) {

--- a/nx/public/plugins/quick-edit/quick-edit.js
+++ b/nx/public/plugins/quick-edit/quick-edit.js
@@ -27,7 +27,7 @@ function onMessage(e, ctx) {
     const { editorState, cursorOffset } = e.data;
     setEditorState(cursorOffset, editorState, ctx);
   } else if (e.data.type === 'set-cursors') {
-    setCursors(e.data.body, ctx);
+    setCursors(e.data.cursors, ctx);
   } else if (e.data.type === 'update-image-src') {
     const { newSrc, originalSrc } = e.data;
     updateImageSrc(originalSrc, newSrc);

--- a/nx/public/plugins/quick-edit/src/cursors.js
+++ b/nx/public/plugins/quick-edit/src/cursors.js
@@ -12,9 +12,7 @@ export function setRemoteCursors() {
   });
 }
 
-export async function setCursors(body) {
-  const doc = new DOMParser().parseFromString(body, 'text/html');
-
+export async function setCursors(payload) {
   // Remove all existing data-cursor attributes from current document
   const currentElements = document.querySelectorAll('[data-cursor-remote]');
   currentElements.forEach((element) => {
@@ -22,22 +20,13 @@ export async function setCursors(body) {
     element.removeAttribute('data-cursor-remote-color');
   });
 
-  // Get all elements with data-cursor from the parsed doc
-  const parsedElements = doc.querySelectorAll('[data-cursor-remote]');
+  payload.forEach(({ proseIndex, remote, color }) => {
+    if (!proseIndex) return;
 
-  // For each element in parsed doc, find matching element in current doc by data-cursor
-  parsedElements.forEach((parsedElement) => {
-    const remoteCursorValue = parsedElement.getAttribute('data-cursor-remote');
-    const remoteCursorColor = parsedElement.getAttribute('data-cursor-remote-color');
-    const dataCursor = parsedElement.getAttribute('data-prose-index');
-
-    // Find element in current document with the same data-cursor value
-    if (dataCursor) {
-      const matchingElement = document.querySelector(`[data-prose-index="${dataCursor}"]`);
-      if (matchingElement) {
-        matchingElement.setAttribute('data-cursor-remote', remoteCursorValue);
-        matchingElement.setAttribute('data-cursor-remote-color', remoteCursorColor);
-      }
+    const matchingElement = document.querySelector(`[data-prose-index="${proseIndex}"]`);
+    if (matchingElement) {
+      matchingElement.setAttribute('data-cursor-remote', remote);
+      matchingElement.setAttribute('data-cursor-remote-color', color);
     }
   });
 


### PR DESCRIPTION
## Issue

getInstrumentedHtml was called on every user interaction to update the collab cursors. This clones the dom, which re-downloads all images every time a user moves their cursor.

## What changed

We now extract the cursors in-place and send that between the quick edit frames without cloning the dom. On a full page re-render, getInstrumendHtml will still be called and cause all images to re-download.

Test URLs:
- After: https://qe-reduce-data--da-nx--adobe.hlx.live/