### PR TITLE
fix(media-library): keep existing index visible during discovery

### DIFF
--- a/nx/blocks/media-library/core/constants.js
+++ b/nx/blocks/media-library/core/constants.js
@@ -16,6 +16,8 @@ export const IndexConfig = Object.freeze({
   USAGE_MAP_PROGRESSIVE_BATCH_SIZE: 1000,
   /* Index chunking configuration */
   MEDIA_INDEX_CHUNK_SIZE: 20_000, /* Entries per chunk (~15-20MB per chunk) */
+  LOCK_HEARTBEAT_INTERVAL_MS: 60_000,
+  LOCK_STALE_THRESHOLD_MS: 10 * 60_000,
 });
 
 export const Operation = Object.freeze({

--- a/nx/blocks/media-library/core/state.js
+++ b/nx/blocks/media-library/core/state.js
@@ -26,6 +26,7 @@ let appState = {
   selectedMediaTab: 'usage',
 
   isIndexing: false,
+  isBackgroundRefreshInProgress: false,
   indexProgress: null,
   indexStartTime: null,
   indexLockedByOther: false,

--- a/nx/blocks/media-library/indexing/coordinator.js
+++ b/nx/blocks/media-library/indexing/coordinator.js
@@ -1,6 +1,9 @@
 import buildMediaIndex, {
   loadMediaIfUpdated,
   checkIndexLock,
+  isFreshIndexLock,
+  getIndexLockOwnerId,
+  loadMediaSheet,
 } from './load.js';
 import { ensureAuthenticated, getCanonicalMediaTimestamp } from '../core/utils.js';
 import { updateAppState, getAppState, showNotification } from '../core/state.js';
@@ -16,6 +19,10 @@ let pollingInterval = null;
 let lockCheckInterval = null;
 let pollingStarted = false;
 let onMediaDataUpdated = null;
+
+function stateHasMediaData() {
+  return (getAppState().mediaData?.length || 0) > 0;
+}
 
 // Starts polling for media updates when authenticated.
 export async function startPolling() {
@@ -33,7 +40,11 @@ export async function startPolling() {
         const { hasChanged, mediaData, indexMissing } = result;
 
         if (hasChanged && onMediaDataUpdated) {
-          updateAppState({ indexMissing: !!indexMissing });
+          updateAppState({
+            indexMissing: !!indexMissing,
+            isBackgroundRefreshInProgress: false,
+            indexLockedByOther: false,
+          });
           onMediaDataUpdated(mediaData || []);
         }
       } catch (error) {
@@ -72,15 +83,72 @@ function startLockCheckPolling(sitePath, org, repo) {
   stopLockCheckPolling();
   lockCheckInterval = setInterval(async () => {
     const state = getAppState();
-    if (!state.indexLockedByOther || !sitePath) {
+    if ((!state.indexLockedByOther && !state.isBackgroundRefreshInProgress) || !sitePath) {
       stopLockCheckPolling();
       return;
     }
     try {
+      const lock = await checkIndexLock(sitePath);
+      const stateHasData = stateHasMediaData();
+      if (!isFreshIndexLock(lock)) {
+        stopLockCheckPolling();
+
+        if (!stateHasData) {
+          const {
+            data,
+            indexMissing,
+            indexing,
+          } = await loadMediaSheet(sitePath);
+
+          if (!indexing && onMediaDataUpdated) {
+            if (indexMissing) {
+              updateAppState({
+                indexLockedByOther: true,
+                isBackgroundRefreshInProgress: false,
+                indexMissing: false,
+              });
+              return;
+            }
+            updateAppState({
+              indexLockedByOther: false,
+              isBackgroundRefreshInProgress: false,
+              indexMissing: !!indexMissing,
+            });
+            onMediaDataUpdated(data || []);
+            return;
+          }
+        }
+
+        const {
+          hasChanged,
+          mediaData,
+          indexMissing,
+        } = await loadMediaIfUpdated(sitePath, org, repo);
+        if (hasChanged && onMediaDataUpdated) {
+          updateAppState({
+            indexLockedByOther: false,
+            isBackgroundRefreshInProgress: false,
+            indexMissing: !!indexMissing,
+          });
+          onMediaDataUpdated(mediaData || []);
+          return;
+        }
+
+        updateAppState({
+          indexLockedByOther: false,
+          isBackgroundRefreshInProgress: false,
+        });
+        return;
+      }
+
       const { hasChanged, mediaData, indexMissing } = await loadMediaIfUpdated(sitePath, org, repo);
       if (hasChanged && onMediaDataUpdated) {
         stopLockCheckPolling();
-        updateAppState({ indexLockedByOther: false, indexMissing: !!indexMissing });
+        updateAppState({
+          indexLockedByOther: false,
+          isBackgroundRefreshInProgress: false,
+          indexMissing: !!indexMissing,
+        });
         onMediaDataUpdated(mediaData || []);
       }
     } catch { /* swallow */ }
@@ -117,6 +185,8 @@ export async function triggerBuild(sitePath, org, repo, ref = 'main') {
 
   updateAppState({
     isIndexing: true,
+    isBackgroundRefreshInProgress: false,
+    indexLockedByOther: false,
     indexProgress: { stage: 'starting', message: '', duration: null },
     indexStartTime: Date.now(),
     progressiveMediaData: [],
@@ -217,6 +287,7 @@ export async function triggerBuild(sitePath, org, repo, ref = 'main') {
           mediaReferences: finalProgress.mediaReferences,
         },
         isIndexing: false,
+        isBackgroundRefreshInProgress: false,
         progressiveMediaData: [],
         progressiveTotalCount: null,
         progressiveCountCapped: false,
@@ -235,6 +306,7 @@ export async function triggerBuild(sitePath, org, repo, ref = 'main') {
           mediaReferences: 0,
         },
         isIndexing: false,
+        isBackgroundRefreshInProgress: false,
         progressiveMediaData: [],
         progressiveTotalCount: null,
         progressiveCountCapped: false,
@@ -269,6 +341,7 @@ export async function triggerBuild(sitePath, org, repo, ref = 'main') {
       const updates = {
         isIndexing: false,
         indexLockedByOther: false,
+        isBackgroundRefreshInProgress: false,
         indexMissing: false,
         progressiveTotalCount: null,
         progressiveCountCapped: false,
@@ -285,7 +358,11 @@ export async function triggerBuild(sitePath, org, repo, ref = 'main') {
         showNotification(t('NOTIFY_ERROR'), msg, 'danger');
       }
     } else {
-      updateAppState({ isIndexing: false, indexLockedByOther: true });
+      updateAppState({
+        isIndexing: false,
+        indexLockedByOther: true,
+        isBackgroundRefreshInProgress: stateHasMediaData(),
+      });
       startLockCheckPolling(sitePath, org, repo);
     }
 
@@ -311,10 +388,16 @@ export async function initService(sitePath, options = {}) {
   try {
     // Check if someone else is building
     const lock = await checkIndexLock(sitePath);
+    const ownerId = getIndexLockOwnerId();
+    const ownsLock = lock.ownerId && lock.ownerId === ownerId;
+    const freshLock = isFreshIndexLock(lock);
 
-    if (lock.exists && lock.locked) {
-      // Someone else is building - do nothing, just wait
-      // Polling will automatically reload when they finish (timestamp will change)
+    if (freshLock && !ownsLock) {
+      updateAppState({
+        isBackgroundRefreshInProgress: stateHasMediaData(),
+        indexLockedByOther: !stateHasMediaData(),
+      });
+      startLockCheckPolling(sitePath, org, repo);
       return;
     }
 

--- a/nx/blocks/media-library/indexing/load.js
+++ b/nx/blocks/media-library/indexing/load.js
@@ -18,7 +18,10 @@ import { getDedupeKey, canonicalizeMediaUrl } from '../core/urls.js';
 import {
   IndexFiles,
   SheetNames,
+  IndexConfig,
 } from '../core/constants.js';
+
+const LOCK_OWNER_STORAGE_KEY = 'media-library-lock-owner-id';
 
 function getOrgRepoFromSitePath(sitePath) {
   if (!sitePath) return { org: null, repo: null };
@@ -52,12 +55,50 @@ export async function checkIndexLock(sitePath) {
         exists: true,
         locked: lockData.locked || false,
         timestamp: lockData.timestamp || null,
+        startedAt: lockData.startedAt || lockData.timestamp || null,
+        lastUpdated: lockData.lastUpdated || lockData.timestamp || null,
+        ownerId: lockData.ownerId || '',
+        mode: lockData.mode || '',
       };
     }
   } catch (e) {
-    return { exists: false, locked: false, timestamp: null };
+    return {
+      exists: false,
+      locked: false,
+      timestamp: null,
+      startedAt: null,
+      lastUpdated: null,
+      ownerId: '',
+      mode: '',
+    };
   }
-  return { exists: false, locked: false, timestamp: null };
+  return {
+    exists: false,
+    locked: false,
+    timestamp: null,
+    startedAt: null,
+    lastUpdated: null,
+    ownerId: '',
+    mode: '',
+  };
+}
+
+export function getIndexLockOwnerId() {
+  if (typeof window === 'undefined' || !window.sessionStorage) return '';
+
+  let ownerId = window.sessionStorage.getItem(LOCK_OWNER_STORAGE_KEY);
+  if (ownerId) return ownerId;
+
+  ownerId = `ml-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  window.sessionStorage.setItem(LOCK_OWNER_STORAGE_KEY, ownerId);
+  return ownerId;
+}
+
+export function isFreshIndexLock(lock, now = Date.now()) {
+  if (!(lock?.exists && lock?.locked)) return false;
+  const heartbeat = lock.lastUpdated || lock.timestamp || lock.startedAt;
+  if (!heartbeat) return false;
+  return (now - heartbeat) < IndexConfig.LOCK_STALE_THRESHOLD_MS;
 }
 
 export async function saveMediaSheet(data, sitePath) {
@@ -74,11 +115,8 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
   const basePath = getMediaLibraryPath(sitePath);
   const metaPath = `${basePath}/${IndexFiles.MEDIA_INDEX_META}`;
   const { org, repo } = getOrgRepoFromSitePath(sitePath);
-
   const lock = await checkIndexLock(sitePath);
-  if (lock.exists && lock.locked) {
-    return { data: [], indexing: true };
-  }
+  const lockFresh = isFreshIndexLock(lock);
 
   try {
     // Check if index is chunked by loading meta
@@ -87,7 +125,7 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
     if (meta?.chunked === true) {
       const chunkCount = meta.chunkCount || 0;
       if (chunkCount === 0) {
-        return { data: [] };
+        return { data: [], lockFresh };
       }
 
       try {
@@ -107,6 +145,7 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
         }));
         return {
           data: mappedData,
+          lockFresh,
         };
       } catch (chunkError) {
         // eslint-disable-next-line no-console
@@ -128,6 +167,7 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
           ...item,
           url: canonicalizeMediaUrl(item.url, org, repo),
         })),
+        lockFresh,
       };
     }
 
@@ -137,7 +177,12 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
     }
 
     if (resp.status === 404) {
-      return { data: [], indexMissing: true };
+      return {
+        data: [],
+        indexMissing: true,
+        indexing: lockFresh,
+        lockFresh,
+      };
     }
 
     logMediaLibraryError(ErrorCodes.INDEX_LOAD_FAILED, { path, status: resp.status });
@@ -201,11 +246,40 @@ export async function loadMediaIfUpdated(sitePath, org, repo) {
 
 export async function createIndexLock(sitePath) {
   const path = getIndexLockPath(sitePath);
+  const ownerId = getIndexLockOwnerId();
+  const now = Date.now();
   const lockData = [{
-    timestamp: Date.now(),
+    timestamp: now,
+    startedAt: now,
+    lastUpdated: now,
+    ownerId,
     locked: true,
   }];
   const formData = await createSheet(lockData);
+  const resp = await daFetch(`${DA_ORIGIN}/source${path}`, {
+    method: 'PUT',
+    body: formData,
+  });
+  if (!resp.ok) {
+    logMediaLibraryError(ErrorCodes.LOCK_CREATE_FAILED, { status: resp.status, path });
+    const isDenied = resp.status === 401 || resp.status === 403;
+    const msg = isDenied ? t('LOCK_CREATE_FAILED_PERMISSION') : t('LOCK_CREATE_FAILED_GENERIC');
+    throw new MediaLibraryError(ErrorCodes.LOCK_CREATE_FAILED, msg, { status: resp.status, path });
+  }
+  return resp;
+}
+
+export async function refreshIndexLock(sitePath, lockData = {}) {
+  const path = getIndexLockPath(sitePath);
+  const now = Date.now();
+  const formData = await createSheet([{
+    locked: true,
+    timestamp: lockData.timestamp || lockData.startedAt || now,
+    startedAt: lockData.startedAt || lockData.timestamp || now,
+    lastUpdated: now,
+    ownerId: lockData.ownerId || getIndexLockOwnerId(),
+    mode: lockData.mode || '',
+  }]);
   const resp = await daFetch(`${DA_ORIGIN}/source${path}`, {
     method: 'PUT',
     body: formData,
@@ -307,17 +381,41 @@ export default async function buildMediaIndex(
   const startTime = Date.now();
 
   const existingLock = await checkIndexLock(sitePath);
-  if (existingLock.exists && existingLock.locked) {
-    const lockAge = Date.now() - existingLock.timestamp;
-    const maxLockAge = 30 * 60 * 1000; // 30 minutes
-
-    if (lockAge < maxLockAge) {
-      throw new Error(`Index build already in progress. Lock created ${Math.round(lockAge / 1000 / 60)} minutes ago.`);
-    }
+  const ownerId = getIndexLockOwnerId();
+  const ownsExistingLock = existingLock.ownerId && existingLock.ownerId === ownerId;
+  if (isFreshIndexLock(existingLock) && !ownsExistingLock) {
+    const heartbeat = existingLock.lastUpdated
+      || existingLock.timestamp
+      || existingLock.startedAt
+      || Date.now();
+    const lockAge = Date.now() - heartbeat;
+    throw new Error(
+      `Index build already in progress. Lock updated ${Math.round(lockAge / 1000 / 60)} minutes ago.`,
+    );
+  }
+  if (
+    existingLock.exists
+    && existingLock.locked
+    && !isFreshIndexLock(existingLock)
+    && !ownsExistingLock
+  ) {
     await removeIndexLock(sitePath);
   }
 
   await createIndexLock(sitePath);
+  const heartbeatLockData = {
+    startedAt: ownsExistingLock
+      ? (existingLock.startedAt || existingLock.timestamp || Date.now())
+      : Date.now(),
+    timestamp: ownsExistingLock
+      ? (existingLock.timestamp || existingLock.startedAt || Date.now())
+      : Date.now(),
+    ownerId,
+    mode: forceFull ? 'full' : 'incremental',
+  };
+  const heartbeatTimer = setInterval(() => {
+    refreshIndexLock(sitePath, heartbeatLockData).catch(() => {});
+  }, IndexConfig.LOCK_HEARTBEAT_INTERVAL_MS);
 
   try {
     const reindexCheck = await checkReindexEligibility(sitePath, org, repo);
@@ -363,5 +461,7 @@ export default async function buildMediaIndex(
       await removeIndexLock(sitePath);
     } catch { /* swallow */ }
     throw error;
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }

--- a/nx/blocks/media-library/media-library.js
+++ b/nx/blocks/media-library/media-library.js
@@ -81,6 +81,7 @@ const MEDIA_LIBRARY_STATE_KEYS = [
   'progressiveTotalCount',
   'progressiveCountCapped',
   'isIndexing',
+  'isBackgroundRefreshInProgress',
   'isValidating',
   'isLoadingData',
   'isProgressiveLoading',
@@ -209,6 +210,7 @@ class NxMediaLibrary extends LitElement {
           mediaData: [],
           processedData: null,
           indexLockedByOther: false,
+          isBackgroundRefreshInProgress: false,
         });
         this.resetSearchState();
       }
@@ -565,6 +567,9 @@ class NxMediaLibrary extends LitElement {
       sitePath: this.sitePath,
       org: this.org,
       repo: this.repo,
+      isIndexing: false,
+      isBackgroundRefreshInProgress: false,
+      indexLockedByOther: false,
       isValidating: true,
       sitePathValid: false,
       validationError: null,
@@ -647,7 +652,9 @@ class NxMediaLibrary extends LitElement {
         }
       };
 
-      const { data, indexMissing, indexing } = await loadMediaSheet(
+      const {
+        data, indexMissing, indexing, lockFresh,
+      } = await loadMediaSheet(
         this.sitePath,
         onProgressiveChunk,
       );
@@ -656,19 +663,31 @@ class NxMediaLibrary extends LitElement {
         updateAppState({
           isLoadingData: false,
           isProgressiveLoading: false,
-          isIndexing: true,
+          isIndexing: false,
+          isBackgroundRefreshInProgress: false,
+          indexLockedByOther: true,
+          indexMissing: true,
           persistentError: null,
         });
         return;
       }
 
-      updateAppState({ persistentError: null, indexMissing: !!indexMissing });
+      updateAppState({
+        persistentError: null,
+        indexMissing: !!indexMissing,
+        indexLockedByOther: false,
+        isBackgroundRefreshInProgress: !!(data?.length > 0) && !!lockFresh,
+      });
 
       const finalData = accumulatedData.length > 0 ? accumulatedData : data;
       await this.setMediaData(finalData);
       updateAppState({ isLoadingData: false, isProgressiveLoading: false });
     } catch (error) {
-      updateAppState({ isLoadingData: false, isProgressiveLoading: false });
+      updateAppState({
+        isLoadingData: false,
+        isProgressiveLoading: false,
+        isBackgroundRefreshInProgress: false,
+      });
 
       const { MediaLibraryError, ErrorCodes } = await import('./core/errors.js');
       if (error instanceof MediaLibraryError) {
@@ -702,7 +721,6 @@ class NxMediaLibrary extends LitElement {
 
     if (isEmpty) {
       updateAppState({
-        indexLockedByOther: false,
         mediaData: [],
         usageIndex: new Map(),
         processedData: initializeProcessedData(),
@@ -785,6 +803,7 @@ class NxMediaLibrary extends LitElement {
             .mediaData=${this._appState.mediaData}
             .processedData=${this._appState.processedData}
             .isIndexing=${this._appState.isIndexing}
+            .isBackgroundRefreshInProgress=${this._appState.isBackgroundRefreshInProgress}
             .isProgressiveLoading=${this._appState.isProgressiveLoading}
             .org=${this._appState.org}
             .repo=${this._appState.repo}
@@ -887,6 +906,7 @@ class NxMediaLibrary extends LitElement {
     const displayData = this.displayMediaData;
 
     const resultsBusy = !!(this._appState.isIndexing
+      || this._appState.isBackgroundRefreshInProgress
       || this._appState.isProgressiveLoading
       || this._appState.isLoadingData);
 

--- a/nx/blocks/media-library/views/grid/grid.js
+++ b/nx/blocks/media-library/views/grid/grid.js
@@ -122,12 +122,7 @@ class NxMediaGrid extends LitElement {
 
   render() {
     if (!this.mediaData || this.mediaData.length === 0) {
-      return html`
-        <div class="empty-state">
-          <h3>No results found</h3>
-          <p>Try a different search or type selection</p>
-        </div>
-      `;
+      return html``;
     }
 
     return html`

--- a/nx/blocks/media-library/views/topbar/topbar.js
+++ b/nx/blocks/media-library/views/topbar/topbar.js
@@ -33,6 +33,7 @@ class NxMediaTopBar extends LitElement {
     mediaData: { attribute: false },
     processedData: { attribute: false },
     isIndexing: { type: Boolean },
+    isBackgroundRefreshInProgress: { type: Boolean },
     isProgressiveLoading: { type: Boolean },
     org: { attribute: false },
     repo: { attribute: false },
@@ -57,6 +58,7 @@ class NxMediaTopBar extends LitElement {
     this.mediaData = [];
     this.processedData = null;
     this.isIndexing = false;
+    this.isBackgroundRefreshInProgress = false;
     this.isProgressiveLoading = false;
     this.org = null;
     this.repo = null;
@@ -283,7 +285,7 @@ class NxMediaTopBar extends LitElement {
 
         ${this.resultSummary ? html`
           <div class="result-count" aria-live="polite" aria-atomic="true">
-            ${this.isIndexing || this.isProgressiveLoading ? html`
+            ${this.isIndexing || this.isBackgroundRefreshInProgress || this.isProgressiveLoading ? html`
               <span class="result-count-spinner" aria-hidden="true"></span>
             ` : ''}
             ${this.resultSummary}


### PR DESCRIPTION
  Keep saved media visible during indexing by turning the DA lock into a heartbeat writer lock and letting
  readers load existing index data through it.

Fix #<gh-issue-id>

Test URLs:
- Before: https://da.live/apps/media-library#/adobecom/da-bacom-blog
- After: https://da.live/apps/media-library?nx=mllockui#/adobecom/da-bacom-blog
