### PR TITLE
chore: add daFetch to nx2

### DIFF
--- a/nx2/blocks/profile/profile.js
+++ b/nx2/blocks/profile/profile.js
@@ -1,7 +1,8 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { getConfig, loc } from '../../scripts/nx.js';
 import { loadIms, handleSignOut, handleSignIn } from '../../utils/ims.js';
-import { DA_ORIGIN, loadStyle, daFetch } from '../../utils/utils.js';
+import { loadStyle } from '../../utils/utils.js';
+import { DA_ORIGIN, daFetch } from '../../utils/daFetch.js';
 
 const config = getConfig();
 

--- a/nx2/utils/daFetch.js
+++ b/nx2/utils/daFetch.js
@@ -1,0 +1,43 @@
+// move to public constants
+export const DA_ORIGIN = 'https://admin.da.live';
+export const AEM_ORIGIN = 'https://admin.hlx.page';
+
+let imsDetails;
+
+async function initIms() {
+  if (imsDetails) return imsDetails;
+  const { loadIms } = await import('./ims.js');
+  try {
+    imsDetails = await loadIms();
+    return imsDetails;
+  } catch {
+    return null;
+  }
+}
+
+export const daFetch = async (url, opts = {}) => {
+  opts.headers ||= {};
+  if (localStorage.getItem('nx-ims') || imsDetails) {
+    const { accessToken } = await initIms();
+    if (accessToken) {
+      opts.headers.Authorization = `Bearer ${accessToken.token}`;
+
+      if (url.startsWith(AEM_ORIGIN)) {
+        opts.headers['x-content-source-authorization'] = `Bearer ${accessToken.token}`;
+      }
+    }
+  }
+  let resp;
+  try {
+    resp = await fetch(url, opts);
+  } catch (err) {
+    return new Response(null, { status: 500, statusText: err.message });
+  }
+  if (resp.status === 401) {
+    const { loadIms, handleSignIn } = await import('./ims.js');
+    await loadIms();
+    handleSignIn();
+  }
+  resp.permissions = resp.headers.get('x-da-actions')?.split('=').pop().split(',');
+  return resp;
+};

--- a/nx2/utils/daFetch.js
+++ b/nx2/utils/daFetch.js
@@ -1,6 +1,22 @@
-// move to public constants
-export const DA_ORIGIN = 'https://admin.da.live';
 export const AEM_ORIGIN = 'https://admin.hlx.page';
+
+const DA_ADMIN_ENVS = {
+  local: 'http://localhost:8787',
+  stage: 'https://stage-admin.da.live',
+  prod: 'https://admin.da.live',
+};
+
+function getDaEnv(key, envs) {
+  const query = new URL(window.location.href).searchParams.get(key);
+  if (query === 'reset') {
+    localStorage.removeItem(key);
+  } else if (query) {
+    localStorage.setItem(key, query);
+  }
+  return envs[localStorage.getItem(key) || 'prod'];
+}
+
+export const DA_ORIGIN = (() => getDaEnv('da-admin', DA_ADMIN_ENVS))();
 
 let imsDetails;
 

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -1,6 +1,3 @@
-export const DA_ORIGIN = (() => 'https://admin.da.live')();
-export const daFetch = (() => 'https://admin.da.live')();
-
 const parse = (location = window.location) => {
   const pathView = location.pathname.slice(1);
   const view = pathView === '' ? 'browse' : pathView;


### PR DESCRIPTION
- Reusing https://github.com/adobe/da-nx/blob/main/nx/utils/daFetch.js in nx2
- Included minimal getDaEnv and related constants also to the same file: can be moved later to public constants if needed following the same pattern as nx

