### PR TITLE
chore(canvas-actions): publish button class + toolbar layout

### DIFF
--- a/nx2/blocks/canvas-actions/canvas-actions.css
+++ b/nx2/blocks/canvas-actions/canvas-actions.css
@@ -6,7 +6,14 @@
   color: var(--s2-gray-800);
 }
 
-.canvas-actions button {
+.canvas-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.canvas-actions .publish-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -25,22 +32,21 @@
   cursor: pointer;
 }
 
-.canvas-actions button:focus-visible {
+.canvas-actions .publish-btn:focus-visible {
   outline: 2px solid var(--s2-blue-800);
   outline-offset: 2px;
 }
 
-.canvas-actions button:disabled {
+.canvas-actions .publish-btn:disabled {
   color: var(--s2-gray-400);
   background-color: var(--s2-gray-200);
   cursor: not-allowed;
 }
 
-.canvas-actions button:hover:not(:disabled) {
+.canvas-actions .publish-btn:hover:not(:disabled) {
   background-color: var(--s2-blue-1000);
 }
 
-.canvas-actions button:active:not(:disabled) {
+.canvas-actions .publish-btn:active:not(:disabled) {
   background-color: var(--s2-blue-1100);
 }
-

--- a/nx2/blocks/canvas-actions/canvas-actions.js
+++ b/nx2/blocks/canvas-actions/canvas-actions.js
@@ -13,7 +13,7 @@ class NXCanvasActions extends LitElement {
   render() {
     return html`
       <div class="canvas-actions">
-        <button>Publish</button>
+        <button type="button" class="publish-btn">Publish</button>
       </div>
     `;
   }


### PR DESCRIPTION
## What changes (vs `ew`)

`ew` already ships Publish-only in `nx-canvas-actions` — there is **no** layout picker to remove on this branch.

This PR only:

- Sets `type="button"` and `class="publish-btn"` on Publish (clearer semantics / styling hook).
- Adds a flex row container on `.canvas-actions` with `gap: 12px` for future actions.
- Scopes button styles from `.canvas-actions button` to `.canvas-actions .publish-btn` so extra controls won’t accidentally pick up the primary button look.

No feature removal — naming in the original monolithic PR was about older work where a picker had existed elsewhere.