### PR TITLE
MWPW-190474 Links containing icon like segments broken in glaas dnt

### DIFF
--- a/nx/blocks/loc/connectors/glaas/dnt.js
+++ b/nx/blocks/loc/connectors/glaas/dnt.js
@@ -204,8 +204,8 @@ function makeImagesRelative(document) {
 }
 
 function makeIconSpans(html) {
-  // Regex that matches :icon: but not when inside alt text double-quoted string
-  const iconRegex = /(?<!alt="[^"]*):([a-zA-Z0-9-]+?):/gm;
+  // Regex to match icon segments in text, but NOT inside any HTML attribute values
+  const iconRegex = /(?<!\w)(?<!="[^"]*):([a-zA-Z0-9-]+?):/gm;
 
   return html.replace(iconRegex, (_, iconName) => `<span class="icon icon-${iconName}"></span>`);
 }

--- a/test/loc/glaas/dnt.test.js
+++ b/test/loc/glaas/dnt.test.js
@@ -135,4 +135,24 @@ describe('Glaas DNT', () => {
 </body></html>`,
     );
   });
+
+  it.only('Does not convert URN-style URL segments to icon spans', async () => {
+    const config = JSON.parse((await readFile({ path: './mocks/hubspot/translate.json' })));
+    const html = `<body>
+  <main>
+    <div>
+      <p>Some text with a :happy: icon</p>
+    </div>
+    <div>
+      <a href="https://stage.acrobat.adobe.com/link/spaces/urn:aaid:sc:US:48c94977-5619b/?x_api_client_id=pdf_spaces&x_api_client_location=adobe">https://stage.acrobat.adobe.com/link/spaces/urn:aaid:sc:US:48c94977-9292-45e0-9564-0a68b795619b/?x_api_client_id=pdf_spaces&x_api_client_location=adobe</a>
+    </div>
+  </main>
+</body>`;
+    const htmlWithDnt = await addDnt(html, config, { reset: true });
+    expect(htmlWithDnt).to.include('<span class="icon icon-happy"></span>');
+    expect(htmlWithDnt).to.not.include('icon-aaid');
+    expect(htmlWithDnt).to.not.include('icon-sc');
+    expect(htmlWithDnt).to.not.include('icon-US');
+    expect(htmlWithDnt).to.include('urn:aaid:sc:US:48c94977');
+  });
 });


### PR DESCRIPTION
(Reopening - https://github.com/adobe/da-nx/pull/235)

There are link authored with icon like segments
e.g. https://stage.acrobat.adobe.com/link/spaces/urn:aaid:sc:US.... During DNT only the alt attribute is handled. Extending this to all attributes.

Fix #MWPW-190474