### PR TITLE
Add API utilities and refactor environment configuration

### DIFF
--- a/nx/scripts/nexter.js
+++ b/nx/scripts/nexter.js
@@ -3,11 +3,17 @@ const AUTO_BLOCKS = [
   { 'nx-youtube': 'https://www.youtube.com' },
 ];
 
-function getEnv() {
-  const { host } = new URL(window.location.href);
-  if (!['.aem.page', 'local'].some((check) => host.includes(check))) return 'prod';
-  if (['.hlx.', '.aem.'].some((check) => host.includes(check))) return 'stage';
+export const env = (() => {
+  const { host } = window.location;
+  if (host.endsWith('.aem.live')) return 'prod';
+  if (!['--', 'local'].some((check) => host.includes(check))) return 'prod';
+  if (['--'].some((check) => host.includes(check))) return 'stage';
   return 'dev';
+})();
+
+export function getColorScheme() {
+  return localStorage.getItem('color-scheme')
+    || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-scheme' : 'light-scheme');
 }
 
 export const [setConfig, getConfig] = (() => {
@@ -16,7 +22,7 @@ export const [setConfig, getConfig] = (() => {
     (conf = {}) => {
       config = {
         ...conf,
-        env: getEnv(),
+        env,
         nxBase: `${import.meta.url.replace('/scripts/nexter.js', '')}`,
       };
       window.c = config;
@@ -51,7 +57,7 @@ export async function loadBlock(block) {
   const { classList } = block;
   let name = classList[0];
   const isNx = name.startsWith('nx-');
-  if (isNx) name = name.replace('nx-', '');
+  name = isNx ? name.replace('nx-', '') : name;
   block.dataset.blockName = name;
   const { nxBase, codeBase = '' } = getConfig();
   const path = isNx ? `${nxBase}/blocks` : `${codeBase}/blocks`;
@@ -143,12 +149,14 @@ function decorateHeader() {
 }
 
 export async function loadArea(area = document) {
+  const { decorateArea } = getConfig();
   const isDoc = area === document;
   if (isDoc) {
     if (getMetadata('signin')) await import('../utils/signin.js');
     document.documentElement.lang = 'en';
     decorateHeader();
   }
+  if (decorateArea) await decorateArea(area);
   const sections = decorateSections(area, isDoc);
   for (const [idx, section] of sections.entries()) {
     await Promise.all(section.autoBlocks.map((block) => loadBlock(block)));

--- a/nx/utils/utils.js
+++ b/nx/utils/utils.js
@@ -1,4 +1,4 @@
-import { env } from '../scripts/nx.js';
+import { env } from '../scripts/nexter.js';
 
 export const SUPPORTED_FILES = {
   html: 'text/html',

--- a/nx2/blocks/profile/profile.js
+++ b/nx2/blocks/profile/profile.js
@@ -1,7 +1,8 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { getConfig, loc } from '../../scripts/nx.js';
 import { loadIms, handleSignOut, handleSignIn } from '../../utils/ims.js';
-import { DA_ORIGIN, loadStyle, daFetch } from '../../utils/utils.js';
+import { loadStyle } from '../../utils/utils.js';
+import { signout } from '../../utils/api.js';
 
 const config = getConfig();
 
@@ -71,9 +72,9 @@ class NxProfile extends LitElement {
 
   async handleSignOut() {
     try {
-      await daFetch(`${DA_ORIGIN}/logout`);
+      signout();
     } catch {
-      // logout did not work.
+      config.log('Could not sign out');
     }
     handleSignOut();
     const opts = { bubbles: true, composed: true };
@@ -82,21 +83,16 @@ class NxProfile extends LitElement {
   }
 
   handleScheme() {
-    const { body } = document;
-
-    let currPref = localStorage.getItem('color-scheme');
-    if (!currPref) {
-      currPref = matchMedia('(prefers-color-scheme: dark)')
-        .matches ? 'dark-scheme' : 'light-scheme';
+    let curr = localStorage.getItem('color-scheme');
+    if (!curr) {
+      curr = matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark-scheme' : 'light-scheme';
     }
 
-    const theme = currPref === 'dark-scheme'
-      ? { add: 'light-scheme', remove: 'dark-scheme' }
-      : { add: 'dark-scheme', remove: 'light-scheme' };
-
-    body.classList.remove(theme.remove);
-    body.classList.add(theme.add);
-    localStorage.setItem('color-scheme', theme.add);
+    const next = curr === 'dark-scheme' ? 'light-scheme' : 'dark-scheme';
+    document.body.classList.remove('dark-scheme', 'light-scheme');
+    document.body.classList.add(next);
+    localStorage.setItem('color-scheme', next);
   }
 
   get _org() {

--- a/nx2/blocks/sidenav/sidenav.js
+++ b/nx2/blocks/sidenav/sidenav.js
@@ -1,15 +1,13 @@
 import { LitElement, html, nothing } from 'da-lit';
 
 import { loadFragment } from '../fragment/fragment.js';
-import { loadStyle, HashController } from '../../utils/utils.js';
+import { loadStyle } from '../../utils/utils.js';
 
 const DEFAULT_NAV_PATH = '/nx/fragments/sidenav';
 
 const style = await loadStyle(import.meta.url);
 
 class NXSidenav extends LitElement {
-  details = new HashController(this);
-
   static properties = {
     path: { attribute: false },
     _navLinks: { state: true },

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -12,6 +12,11 @@
 
 const LOG = async (ex, el) => (await import('../utils/error.js')).default(ex, el);
 
+export function getColorScheme() {
+  return localStorage.getItem('color-scheme')
+    || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-scheme' : 'light-scheme');
+}
+
 export function getMetadata(name) {
   const attr = name && name.includes(':') ? 'property' : 'name';
   const meta = document.head.querySelector(`meta[${attr}="${name}"]`);
@@ -20,7 +25,7 @@ export function getMetadata(name) {
 
 export function getLocale(locales) {
   const key = getMetadata('lang') || localStorage.getItem('lang') || '';
-  if (locales[key].lang) document.documentElement.lang = locales[key].lang;
+  if (locales[key]?.lang) document.documentElement.lang = locales[key].lang;
   return { key, ...locales[key] };
 }
 
@@ -32,18 +37,22 @@ export const env = (() => {
   return 'dev';
 })();
 
-async function getStrings(locales, locale) {
+async function getStrings(locales, locale, log) {
   const strings = new Map();
 
   // If not the default lang, load localized strings
-  const defaultLang = Object.values(locales)[0].lang;
-  if (locale.lang !== defaultLang) {
-    const resp = await fetch(`/${locale.lang}/placeholders.json`);
-    if (resp.ok) {
-      const { data } = await resp.json();
-      for (const row of data) {
-        strings.set(row.key, row.value);
+  const defaultLang = Object.values(locales)[0]?.lang;
+  if (locale.lang && locale.lang !== defaultLang) {
+    try {
+      const resp = await fetch(`/${locale.lang}/placeholders.json`);
+      if (resp.ok) {
+        const { data } = await resp.json();
+        for (const row of data) {
+          strings.set(row.key, row.value);
+        }
       }
+    } catch {
+      log(`Could not load strings for ${locale.lang}.`);
     }
   }
 
@@ -54,9 +63,10 @@ export const [setConfig, getConfig] = (() => {
   let config;
   return [
     async (conf = {}) => {
+      const log = conf.log || LOG;
       const locales = conf.locales || { '': {} };
       const locale = getLocale(locales);
-      const strings = await getStrings(locales, locale);
+      const strings = await getStrings(locales, locale, log);
       const nxBase = `${import.meta.url.replace('/scripts/nx.js', '')}`;
 
       config = {
@@ -66,7 +76,7 @@ export const [setConfig, getConfig] = (() => {
         linkBlocks: conf.linkBlocks || [{ fragment: '/fragments/' }],
         providers: conf.providers || {},
         codeBase: conf.codeBase || nxBase,
-        log: conf.log || LOG,
+        log,
         locales,
         locale,
         strings,

--- a/nx2/test/mocks/ims.js
+++ b/nx2/test/mocks/ims.js
@@ -1,0 +1,21 @@
+let _accessToken = { token: 'test-token' };
+let _anonymous = false;
+
+export function setMockIms({ token, anonymous } = {}) {
+  if (token !== undefined) _accessToken = token;
+  if (anonymous !== undefined) _anonymous = anonymous;
+}
+
+export function resetMockIms() {
+  _accessToken = { token: 'test-token' };
+  _anonymous = false;
+}
+
+export const loadIms = async () => {
+  if (_anonymous) return { anonymous: true };
+  return { accessToken: _accessToken };
+};
+
+export function handleSignIn() {}
+
+export function handleSignOut() {}

--- a/nx2/test/mocks/test.css
+++ b/nx2/test/mocks/test.css
@@ -1,0 +1,1 @@
+:host { display: block; }

--- a/nx2/test/unit/nx/scripts/nx.test.js
+++ b/nx2/test/unit/nx/scripts/nx.test.js
@@ -1,365 +1,688 @@
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import {
+  getColorScheme,
   getMetadata,
   getLocale,
+  env,
   setConfig,
   getConfig,
-  decorateLink,
+  loc,
   loadBlock,
+  decorateLink,
   loadArea,
 } from '../../../../scripts/nx.js';
 
-const BASE_CONFIG = {
-  hostnames: ['adobe.com'],
-  linkBlocks: [],
-  locales: { '': {} },
-  log: () => {},
-};
+// ─── getColorScheme ─────────────────────────────────────────────────────────
 
-// ─── getMetadata ─────────────────────────────────────────────────────────────
+describe('getColorScheme', () => {
+  let originalMatchMedia;
 
-describe('getMetadata', () => {
   beforeEach(() => {
-    document.head.querySelectorAll('meta[name], meta[property]').forEach((el) => el.remove());
-  });
-
-  it('returns content for a name-based meta tag', () => {
-    const meta = document.createElement('meta');
-    meta.name = 'description';
-    meta.content = 'Test description';
-    document.head.append(meta);
-    expect(getMetadata('description')).to.equal('Test description');
-  });
-
-  it('returns content for a property-based meta tag', () => {
-    const meta = document.createElement('meta');
-    meta.setAttribute('property', 'og:title');
-    meta.content = 'OG Title';
-    document.head.append(meta);
-    expect(getMetadata('og:title')).to.equal('OG Title');
-  });
-
-  it('returns null when the meta tag does not exist', () => {
-    expect(getMetadata('nonexistent')).to.be.null;
-  });
-});
-
-// ─── getLocale ───────────────────────────────────────────────────────────────
-
-describe('getLocale', () => {
-  beforeEach(() => {
-    document.head.querySelectorAll('meta[name="lang"]').forEach((el) => el.remove());
-    document.documentElement.removeAttribute('lang');
-    localStorage.removeItem('lang');
+    localStorage.clear();
+    originalMatchMedia = window.matchMedia;
   });
 
   afterEach(() => {
-    document.head.querySelectorAll('meta[name="lang"]').forEach((el) => el.remove());
-    localStorage.removeItem('lang');
+    window.matchMedia = originalMatchMedia;
+    localStorage.clear();
   });
 
-  it('returns root locale by default', () => {
-    const result = getLocale({ '': {} });
+  it('returns stored color-scheme from localStorage if present', () => {
+    localStorage.setItem('color-scheme', 'dark-scheme');
+    expect(getColorScheme()).to.equal('dark-scheme');
+  });
+
+  it('returns dark-scheme when matchMedia prefers dark', () => {
+    localStorage.removeItem('color-scheme');
+    window.matchMedia = sinon.stub().returns({ matches: true });
+    expect(getColorScheme()).to.equal('dark-scheme');
+  });
+
+  it('returns light-scheme when matchMedia does not prefer dark', () => {
+    localStorage.removeItem('color-scheme');
+    window.matchMedia = sinon.stub().returns({ matches: false });
+    expect(getColorScheme()).to.equal('light-scheme');
+  });
+
+  it('prioritizes localStorage over matchMedia', () => {
+    localStorage.setItem('color-scheme', 'light-scheme');
+    window.matchMedia = sinon.stub().returns({ matches: true });
+    expect(getColorScheme()).to.equal('light-scheme');
+  });
+});
+
+// ─── getMetadata ────────────────────────────────────────────────────────────
+
+describe('getMetadata', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('returns content for name attribute', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'description');
+    meta.setAttribute('content', 'Test description');
+    document.head.appendChild(meta);
+
+    expect(getMetadata('description')).to.equal('Test description');
+  });
+
+  it('returns content for property attribute when name includes colon', () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('property', 'og:title');
+    meta.setAttribute('content', 'Open Graph Title');
+    document.head.appendChild(meta);
+
+    expect(getMetadata('og:title')).to.equal('Open Graph Title');
+  });
+
+  it('returns null when meta tag not found', () => {
+    expect(getMetadata('nonexistent')).to.be.null;
+  });
+
+  it('returns null when name is falsy', () => {
+    expect(getMetadata('')).to.be.null;
+    expect(getMetadata(null)).to.be.null;
+  });
+});
+
+// ─── getLocale ──────────────────────────────────────────────────────────────
+
+describe('getLocale', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    localStorage.clear();
+    document.documentElement.lang = '';
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = '';
+    localStorage.clear();
+    document.documentElement.lang = '';
+  });
+
+  it('returns default locale when no meta or localStorage', () => {
+    const locales = { '': { lang: 'en', prefix: '/en' }, fr: { lang: 'fr', prefix: '/fr' } };
+    const result = getLocale(locales);
     expect(result.key).to.equal('');
   });
 
-  it('uses the lang meta tag when present', () => {
+  it('uses lang from metadata when present', () => {
     const meta = document.createElement('meta');
-    meta.name = 'lang';
-    meta.content = '/de';
-    document.head.append(meta);
-    const result = getLocale({ '': {}, '/de': { lang: 'de' } });
-    expect(result.key).to.equal('/de');
+    meta.setAttribute('name', 'lang');
+    meta.setAttribute('content', 'fr');
+    document.head.appendChild(meta);
+
+    const locales = { '': { lang: 'en' }, fr: { lang: 'fr', prefix: '/fr' } };
+    const result = getLocale(locales);
+    expect(result.key).to.equal('fr');
+    expect(result.lang).to.equal('fr');
+    expect(result.prefix).to.equal('/fr');
+    expect(document.documentElement.lang).to.equal('fr');
   });
 
-  it('sets document lang when the locale has a lang property', () => {
-    const meta = document.createElement('meta');
-    meta.name = 'lang';
-    meta.content = '/de';
-    document.head.append(meta);
-    getLocale({ '': {}, '/de': { lang: 'de' } });
-    expect(document.documentElement.lang).to.equal('de');
+  it('uses lang from localStorage when no metadata', () => {
+    localStorage.setItem('lang', 'de');
+    const locales = { '': { lang: 'en' }, de: { lang: 'de', prefix: '/de' } };
+    const result = getLocale(locales);
+    expect(result.key).to.equal('de');
   });
 
-  it('returns extra locale properties alongside key', () => {
+  it('does not set documentElement.lang when locale has no lang property', () => {
     const meta = document.createElement('meta');
-    meta.name = 'lang';
-    meta.content = '/de';
-    document.head.append(meta);
-    const result = getLocale({ '': {}, '/de': { lang: 'de', region: 'DE' } });
-    expect(result.region).to.equal('DE');
-  });
+    meta.setAttribute('name', 'lang');
+    meta.setAttribute('content', 'unknown');
+    document.head.appendChild(meta);
 
-  it('falls back to localStorage lang', () => {
-    localStorage.setItem('lang', '/de');
-    const result = getLocale({ '': {}, '/de': { lang: 'de' } });
-    expect(result.key).to.equal('/de');
+    const locales = { '': { lang: 'en' } };
+    getLocale(locales);
+    expect(document.documentElement.lang).to.equal('');
   });
 });
 
-// ─── setConfig / getConfig ───────────────────────────────────────────────────
+// ─── env ────────────────────────────────────────────────────────────────────
+
+describe('env', () => {
+  it('is a string', () => {
+    expect(env).to.be.a('string');
+  });
+
+  it('is one of prod, stage, or dev', () => {
+    expect(['prod', 'stage', 'dev']).to.include(env);
+  });
+
+  // Note: Since env is computed at module load time based on window.location.host,
+  // we can't easily test all branches without reloading the module in different contexts.
+  // The test environment (localhost) will typically result in 'dev'.
+});
+
+// ─── setConfig / getConfig ──────────────────────────────────────────────────
 
 describe('setConfig / getConfig', () => {
-  it('returns a config object with provided values', async () => {
-    const config = await setConfig({ ...BASE_CONFIG, hostnames: ['example.com'] });
-    expect(config.hostnames).to.deep.equal(['example.com']);
+  const originalFetch = window.fetch;
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub();
+    window.fetch = fetchStub;
+    localStorage.clear();
+    document.head.innerHTML = '';
   });
 
-  it('defaults linkBlocks to an empty array when not provided', async () => {
-    const config = await setConfig({ locales: { '': {} } });
-    expect(config.linkBlocks).to.deep.equal([]);
+  afterEach(() => {
+    window.fetch = originalFetch;
+    localStorage.clear();
+    document.head.innerHTML = '';
   });
 
-  it('preserves provided linkBlocks', async () => {
-    const linkBlocks = [{ video: 'youtube.com' }];
-    const config = await setConfig({ ...BASE_CONFIG, linkBlocks });
-    expect(config.linkBlocks).to.deep.equal(linkBlocks);
+  it('getConfig returns error object when config not set', () => {
+    const config = getConfig();
+    expect(config).to.have.property('error');
+    expect(config.error).to.include('not set');
   });
 
-  it('includes a codeBase derived from the module URL', async () => {
-    const config = await setConfig(BASE_CONFIG);
-    expect(config.codeBase).to.include('/nx');
+  it('setConfig returns a config object with defaults', async () => {
+    const config = await setConfig();
+    expect(config).to.have.property('env');
+    expect(config).to.have.property('iconSize', '20');
+    expect(config).to.have.property('linkBlocks');
+    expect(config.linkBlocks).to.deep.equal([{ fragment: '/fragments/' }]);
+    expect(config).to.have.property('providers');
+    expect(config).to.have.property('codeBase');
+    expect(config).to.have.property('nxBase');
+    expect(config).to.have.property('log');
+    expect(config).to.have.property('locales');
+    expect(config).to.have.property('locale');
+    expect(config).to.have.property('strings');
   });
 
-  it('getConfig returns the last config set by setConfig', async () => {
-    await setConfig({ ...BASE_CONFIG, hostnames: ['test.com'] });
-    expect(getConfig().hostnames).to.deep.equal(['test.com']);
+  it('setConfig merges provided config with defaults', async () => {
+    const customLog = sinon.stub();
+    const config = await setConfig({
+      iconSize: '32',
+      log: customLog,
+      myCustomProp: 'test',
+    });
+    expect(config.iconSize).to.equal('32');
+    expect(config.log).to.equal(customLog);
+    expect(config.myCustomProp).to.equal('test');
+  });
+
+  it('getConfig returns set config after setConfig', async () => {
+    await setConfig({ test: 'value' });
+    const config = getConfig();
+    expect(config.test).to.equal('value');
+    expect(config).to.not.have.property('error');
+  });
+
+  it('setConfig loads localized strings for non-default locale', async () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'lang');
+    meta.setAttribute('content', 'fr');
+    document.head.appendChild(meta);
+
+    fetchStub.resolves({
+      ok: true,
+      json: () => Promise.resolve({
+        data: [
+          { key: 'hello', value: 'bonjour' },
+          { key: 'goodbye', value: 'au revoir' },
+        ],
+      }),
+    });
+
+    const locales = { '': { lang: 'en' }, fr: { lang: 'fr' } };
+    const config = await setConfig({ locales });
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.firstCall.args[0]).to.equal('/fr/placeholders.json');
+    expect(config.strings.get('hello')).to.equal('bonjour');
+    expect(config.strings.get('goodbye')).to.equal('au revoir');
+  });
+
+  it('setConfig handles fetch failure for strings gracefully', async () => {
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'lang');
+    meta.setAttribute('content', 'fr');
+    document.head.appendChild(meta);
+
+    fetchStub.rejects(new Error('Network error'));
+
+    const logStub = sinon.stub();
+    const locales = { '': { lang: 'en' }, fr: { lang: 'fr' } };
+    const config = await setConfig({ locales, log: logStub });
+
+    expect(config.strings.size).to.equal(0);
+    expect(logStub.calledOnce).to.be.true;
+    expect(logStub.firstCall.args[0]).to.include('Could not load strings');
+  });
+
+  it('setConfig skips loading strings for default locale', async () => {
+    const locales = { '': { lang: 'en' }, fr: { lang: 'fr' } };
+    await setConfig({ locales });
+    expect(fetchStub.called).to.be.false;
+  });
+
+  it('setConfig derives nxBase from import.meta.url', async () => {
+    const config = await setConfig();
+    expect(config.nxBase).to.be.a('string');
+    expect(config.nxBase).to.not.include('/scripts/nx.js');
   });
 });
 
-// ─── loadBlock ───────────────────────────────────────────────────────────────
+// ─── loc ────────────────────────────────────────────────────────────────────
+
+describe('loc', () => {
+  it('returns localized string when key exists', async () => {
+    await setConfig({ locales: { '': {} } });
+    // Manually add strings after config is set (since setConfig overwrites strings)
+    const config = getConfig();
+    config.strings.set('test-welcome-key', 'Welcome Message!');
+    config.strings.set('test-logout-key', 'Sign out');
+
+    const result = loc`test-welcome-key`;
+    expect(result).to.equal('Welcome Message!');
+  });
+
+  it('returns key when localized string not found', async () => {
+    await setConfig({ locales: { '': {} } });
+    expect(loc`totally-unknown-key-xyz`).to.equal('totally-unknown-key-xyz');
+  });
+
+  it('supports value-based usage', async () => {
+    await setConfig({ locales: { '': {} } });
+    const config = getConfig();
+    config.strings.set('test-value-key', 'Value Message!');
+
+    const key = 'test-value-key';
+    const result = loc`${key}`;
+    expect(result).to.equal('Value Message!');
+  });
+});
+
+// ─── loadBlock ──────────────────────────────────────────────────────────────
 
 describe('loadBlock', () => {
-  before(async () => { await setConfig(BASE_CONFIG); });
-
-  it('sets blockName on the dataset', async () => {
-    const block = document.createElement('div');
-    block.className = 'my-block';
-    const result = await loadBlock(block);
-    expect(result.dataset.blockName).to.equal('my-block');
-  });
-
-  it('returns the block element even when the module import fails', async () => {
-    const block = document.createElement('div');
-    block.className = 'nonexistent-block';
-    const result = await loadBlock(block);
-    expect(result).to.equal(block);
-  });
-
-  it('uses the first class name as the block name', async () => {
-    const block = document.createElement('div');
-    block.className = 'first-name second-name';
-    await loadBlock(block);
-    expect(block.dataset.blockName).to.equal('first-name');
-  });
-});
-
-// ─── decorateHash (via decorateLink) ─────────────────────────────────────────
-
-describe('decorateHash', () => {
-  let config;
-
-  before(async () => {
-    config = await setConfig({
-      ...BASE_CONFIG,
-      locales: { '': {}, '/de': { lang: 'de' } },
+  beforeEach(async () => {
+    await setConfig({
+      providers: { custom: 'https://example.com' },
+      nxBase: '/nx2',
+      log: sinon.stub(),
     });
   });
 
-  afterEach(() => document.body.querySelectorAll('a').forEach((el) => el.remove()));
+  it('loads block from nxBase when no provider match', async () => {
+    const block = document.createElement('div');
+    block.classList.add('myblock');
 
-  it('sets target=_blank and strips the hash for #_blank', () => {
+    // Since we can't easily mock dynamic imports, we'll test what we can
+    // The block should have dataset.blockName set even if import fails
+    try {
+      await loadBlock(block);
+    } catch {
+      // Expected to fail in test environment
+    }
+
+    expect(block.dataset.blockName).to.equal('myblock');
+  });
+
+  it('sets dataset.blockName for provider-prefixed blocks', async () => {
+    const block = document.createElement('div');
+    block.classList.add('custom-widget');
+
+    try {
+      await loadBlock(block);
+    } catch {
+      // Expected to fail in test environment
+    }
+
+    expect(block.dataset.blockName).to.equal('custom-widget');
+  });
+
+  it('calls log on error', async () => {
+    const config = getConfig();
+    const block = document.createElement('div');
+    block.classList.add('nonexistent');
+
+    await loadBlock(block);
+    expect(config.log.called).to.be.true;
+  });
+
+  it('returns the block element', async () => {
+    const block = document.createElement('div');
+    block.classList.add('test');
+    const result = await loadBlock(block);
+    expect(result).to.equal(block);
+  });
+});
+
+// ─── decorateLink ───────────────────────────────────────────────────────────
+
+describe('decorateLink', () => {
+  let config;
+
+  beforeEach(async () => {
+    config = await setConfig({
+      hostnames: ['example.com', 'www.example.com'],
+      linkBlocks: [
+        { fragment: '/fragments/' },
+        { dialog: '/dialogs/' },
+      ],
+      log: sinon.stub(),
+    });
+  });
+
+  it('strips origin from internal links', () => {
+    const a = document.createElement('a');
+    a.href = 'https://example.com/path/page';
+    decorateLink(config, a);
+    expect(a.href).to.not.include('https://example.com');
+    expect(a.href).to.include('/path/page');
+  });
+
+  it('does not modify external links', () => {
+    const a = document.createElement('a');
+    a.href = 'https://external.com/path';
+    const originalHref = a.href;
+    decorateLink(config, a);
+    expect(a.href).to.equal(originalHref);
+  });
+
+  it('adds _blank target when hash contains #_blank', () => {
     const a = document.createElement('a');
     a.href = 'https://example.com/page#_blank';
-    document.body.append(a);
     decorateLink(config, a);
     expect(a.target).to.equal('_blank');
     expect(a.href).to.not.include('#_blank');
   });
 
-  it('#_dnt strips the hash from the URL', () => {
+  it('adds fragment auto-block class for fragment paths', () => {
     const a = document.createElement('a');
-    a.href = 'https://example.com/page#_dnt';
-    document.body.append(a);
+    a.href = 'https://example.com/fragments/header';
+    const result = decorateLink(config, a);
+    expect(a.classList.contains('fragment')).to.be.true;
+    expect(a.classList.contains('auto-block')).to.be.true;
+    expect(result).to.equal(a);
+  });
+
+  it('adds dialog auto-block class for fragment with hash', () => {
+    const a = document.createElement('a');
+    a.href = 'https://example.com/fragments/modal#dialog';
+    const result = decorateLink(config, a);
+    expect(a.classList.contains('dialog')).to.be.true;
+    expect(a.classList.contains('auto-block')).to.be.true;
+    expect(result).to.equal(a);
+  });
+
+  it('returns null when #_dnb hash is present', () => {
+    const a = document.createElement('a');
+    a.href = 'https://example.com/page#_dnb';
+    const result = decorateLink(config, a);
+    expect(result).to.be.null;
+  });
+
+  it('returns null when no pattern matches', () => {
+    const a = document.createElement('a');
+    a.href = 'https://example.com/normal/page';
+    const result = decorateLink(config, a);
+    expect(result).to.be.null;
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    const logStub = sinon.stub();
+    const testConfig = { ...config, log: logStub };
+    const a = document.createElement('a');
+    // Use an href that will throw when creating URL object
+    Object.defineProperty(a, 'href', {
+      get: () => { throw new Error('Invalid URL'); },
+      configurable: true,
+    });
+    const result = decorateLink(testConfig, a);
+    expect(logStub.called).to.be.true;
+    expect(result).to.be.null;
+  });
+
+  it('removes hash modifiers from href', () => {
+    const a = document.createElement('a');
+    a.href = 'https://example.com/page#_blank#_dnt';
     decorateLink(config, a);
+    expect(a.href).to.not.include('#_blank');
     expect(a.href).to.not.include('#_dnt');
   });
-
-  it('#_dnb prevents linkBlock matching and returns null', () => {
-    const lbConfig = { ...config, linkBlocks: [{ video: 'youtube.com' }] };
-    const a = document.createElement('a');
-    a.href = 'https://youtube.com/watch?v=123#_dnb';
-    document.body.append(a);
-    const result = decorateLink(lbConfig, a);
-    expect(result).to.be.null;
-    expect(a.classList.contains('video')).to.be.false;
-  });
 });
 
-// ─── decorateLink ────────────────────────────────────────────────────────────
-
-describe('decorateLink', () => {
-  let config;
-
-  before(async () => {
-    config = await setConfig(BASE_CONFIG);
-  });
-
-  afterEach(() => document.body.querySelectorAll('a, p').forEach((el) => el.remove()));
-
-  it('strips the origin from a hostname-matched link', () => {
-    const hostConfig = { ...config, hostnames: ['localhost'] };
-    const a = document.createElement('a');
-    a.href = 'http://localhost:2000/some/page';
-    document.body.append(a);
-    decorateLink(hostConfig, a);
-    expect(a.getAttribute('href')).to.equal('/some/page');
-  });
-
-  it('adds auto-block and pattern class for a matching linkBlock', () => {
-    const lbConfig = { ...config, linkBlocks: [{ video: 'youtube.com' }] };
-    const a = document.createElement('a');
-    a.href = 'https://youtube.com/watch?v=123';
-    document.body.append(a);
-    const result = decorateLink(lbConfig, a);
-    expect(result).to.equal(a);
-    expect(a.classList.contains('video')).to.be.true;
-    expect(a.classList.contains('auto-block')).to.be.true;
-  });
-
-  it('returns null when no linkBlock pattern matches', () => {
-    const a = document.createElement('a');
-    a.href = 'https://example.com/page';
-    document.body.append(a);
-    expect(decorateLink(config, a)).to.be.null;
-  });
-
-  it('returns null and logs when the href is invalid', () => {
-    const errors = [];
-    const logConfig = { ...config, log: (...args) => errors.push(args) };
-    const a = document.createElement('a');
-    a.href = 'not a valid url';
-    a.getAttribute = () => 'not a valid url';
-    document.body.append(a);
-    const result = decorateLink(logConfig, a);
-    expect(result).to.be.null;
-  });
-});
-
-// ─── loadArea ────────────────────────────────────────────────────────────────
+// ─── loadArea ───────────────────────────────────────────────────────────────
 
 describe('loadArea', () => {
-  let area;
-
-  before(async () => { await setConfig(BASE_CONFIG); });
-
-  beforeEach(() => {
-    area = document.createElement('div');
-    document.body.append(area);
+  beforeEach(async () => {
+    await setConfig({
+      hostnames: ['example.com'],
+      linkBlocks: [{ fragment: '/fragments/' }],
+      log: sinon.stub(),
+      locales: { '': { lang: 'en' } },
+    });
+    document.body.innerHTML = '';
+    document.body.className = '';
+    sessionStorage.clear();
+    localStorage.clear();
   });
 
-  afterEach(() => area.remove());
-
-  it('adds .section class to each top-level div', async () => {
-    const section = document.createElement('div');
-    area.append(section);
-    await loadArea({ area });
-    expect(section.classList.contains('section')).to.be.true;
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.className = '';
+    sessionStorage.clear();
+    localStorage.clear();
   });
 
-  it('wraps non-div children in a .default-content div', async () => {
-    const section = document.createElement('div');
-    const p = document.createElement('p');
-    p.textContent = 'text';
-    section.append(p);
-    area.append(section);
-    await loadArea({ area });
-    const wrapper = section.querySelector('.default-content');
-    expect(wrapper).to.exist;
-    expect(wrapper.contains(p)).to.be.true;
+  it('decorates sections in the provided area', async () => {
+    // Add header and app-frame class to prevent early return in loadArea
+    document.body.classList.add('app-frame');
+    const header = document.createElement('header');
+    const nxNav = document.createElement('nx-nav');
+    header.appendChild(nxNav);
+    document.body.appendChild(header);
+
+    const main = document.createElement('main');
+    main.innerHTML = `
+      <div>
+        <h1>Section 1</h1>
+        <p>Content</p>
+      </div>
+      <div>
+        <h2>Section 2</h2>
+      </div>
+    `;
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    const sections = document.querySelectorAll('.section');
+    expect(sections.length).to.equal(2);
+    sections.forEach((section) => {
+      expect(section.dataset.status).to.be.undefined;
+    });
   });
 
-  it('wraps div children in a .block-content div', async () => {
-    const section = document.createElement('div');
-    const block = document.createElement('div');
-    block.className = 'some-block';
-    section.append(block);
-    area.append(section);
-    await loadArea({ area });
-    expect(section.querySelector('.block-content')).to.exist;
+  it('groups block-content and default-content', async () => {
+    const main = document.createElement('main');
+    main.innerHTML = `
+      <div>
+        <h1>Text</h1>
+        <p>More text</p>
+        <div class="block">Block content</div>
+        <span>After block</span>
+      </div>
+    `;
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    const section = document.querySelector('.section');
+    const defaultContent = section.querySelector('.default-content');
+    const blockContent = section.querySelector('.block-content');
+
+    expect(defaultContent).to.not.be.null;
+    expect(blockContent).to.not.be.null;
+    expect(defaultContent.children.length).to.be.greaterThan(0);
   });
 
-  it('groups consecutive same-type children together', async () => {
-    const section = document.createElement('div');
-    section.innerHTML = '<p>text</p><p>text2</p><div class="b"></div>';
-    area.append(section);
-    await loadArea({ area });
-    expect(section.querySelectorAll('.default-content').length).to.equal(1);
-    expect(section.querySelectorAll('.block-content').length).to.equal(1);
+  it('decorates links and identifies auto-blocks', async () => {
+    const main = document.createElement('main');
+    main.innerHTML = `
+      <div>
+        <p><a href="https://example.com/fragments/test">Fragment link</a></p>
+      </div>
+    `;
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    const link = document.querySelector('a');
+    expect(link.classList.contains('fragment')).to.be.true;
+    expect(link.classList.contains('auto-block')).to.be.true;
   });
 
-  it('prepends a high-res source to picture elements', async () => {
-    const section = document.createElement('div');
-    const pic = document.createElement('picture');
-    const source = document.createElement('source');
-    source.setAttribute('srcset', '/img/photo.jpg?width=750&quality=80');
-    pic.append(source);
-    section.append(pic);
-    area.append(section);
-    await loadArea({ area });
-    const sources = pic.querySelectorAll('source');
-    expect(sources[0].getAttribute('media')).to.equal('(min-width: 1440px)');
-    expect(sources[0].getAttribute('srcset')).to.include('width=3000');
+  it('replaces placeholders with localized strings', async () => {
+    await setConfig({
+      hostnames: ['example.com'],
+      linkBlocks: [{ fragment: '/fragments/' }],
+      locales: { '': { lang: 'en' } },
+      log: sinon.stub(),
+    });
+
+    // Add strings after config is set (since setConfig overwrites strings)
+    const config = getConfig();
+    config.strings.set('test-unique-greeting', 'Hello Unique World');
+
+    document.body.classList.add('app-frame');
+    const header = document.createElement('header');
+    const nxNav = document.createElement('nx-nav');
+    header.appendChild(nxNav);
+    document.body.appendChild(header);
+
+    const main = document.createElement('main');
+    main.innerHTML = '<div><p>Welcome: {test-unique-greeting}</p></div>';
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    const text = document.querySelector('p').textContent;
+    expect(text).to.equal('Welcome: Hello Unique World');
   });
 
-  it('identifies and loads linkBlock auto-blocks', async () => {
-    await setConfig({ ...BASE_CONFIG, linkBlocks: [{ video: 'youtube.com' }] });
-    const section = document.createElement('div');
-    const p = document.createElement('p');
-    const a = document.createElement('a');
-    a.href = 'https://youtube.com/watch?v=abc';
-    p.append(a);
-    section.append(p);
-    area.append(section);
-    await loadArea({ area });
-    expect(a.classList.contains('video')).to.be.true;
+  it('sets session flag when sessionStorage has session', async () => {
+    sessionStorage.setItem('session', 'true');
+    const main = document.createElement('main');
+    main.innerHTML = '<div><h1>Test</h1></div>';
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    expect(document.body.classList.contains('session')).to.be.true;
   });
 
-  it('removes section data-status after loading', async () => {
-    await setConfig(BASE_CONFIG);
-    const section = document.createElement('div');
-    area.append(section);
-    await loadArea({ area });
-    expect(section.dataset.status).to.be.undefined;
+  it('does not set session for non-document areas', async () => {
+    sessionStorage.setItem('session', 'true');
+    const fragment = document.createElement('div');
+    fragment.innerHTML = '<div><h1>Test</h1></div>';
+
+    await loadArea({ area: fragment });
+
+    expect(document.body.classList.contains('session')).to.be.false;
+  });
+
+  it('calls decorateArea hook if provided in config', async () => {
+    const decorateAreaStub = sinon.stub();
+    await setConfig({
+      decorateArea: decorateAreaStub,
+      locales: { '': { lang: 'en' } },
+      log: sinon.stub(),
+    });
+
+    const main = document.createElement('main');
+    main.innerHTML = '<div><h1>Test</h1></div>';
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    expect(decorateAreaStub.calledOnce).to.be.true;
+    expect(decorateAreaStub.firstCall.args[0]).to.have.property('area', document);
+  });
+
+  it('processes sections with blocks', async () => {
+    const main = document.createElement('main');
+    main.innerHTML = `
+      <div>
+        <div class="testblock">
+          <div>Block content</div>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(main);
+
+    await loadArea({ area: document });
+
+    const section = document.querySelector('.section');
+    expect(section.blocks).to.be.an('array');
+  });
+
+  it('handles areas without main element', async () => {
+    const fragment = document.createElement('div');
+    fragment.innerHTML = `
+      <div>
+        <h1>Fragment Section</h1>
+      </div>
+    `;
+
+    await loadArea({ area: fragment });
+
+    const section = fragment.querySelector('.section');
+    expect(section).to.not.be.null;
   });
 });
 
-// ─── decorateDoc (via loadArea with document) ────────────────────────────────
+// ─── Integration tests ──────────────────────────────────────────────────────
 
-describe('decorateDoc', () => {
-  before(async () => { await setConfig(BASE_CONFIG); });
+describe('Integration: config and localization', () => {
+  const originalFetch = window.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.head.innerHTML = '';
+    window.fetch = sinon.stub();
+  });
 
   afterEach(() => {
-    document.body.classList.remove('dark', 'light');
-    document.head.querySelectorAll('meta[name="header"]').forEach((el) => el.remove());
-    localStorage.removeItem('color-scheme');
-    localStorage.removeItem('lazyhash');
+    window.fetch = originalFetch;
+    localStorage.clear();
+    document.head.innerHTML = '';
   });
 
-  it('applies a color scheme class from localStorage', async () => {
-    localStorage.setItem('color-scheme', 'dark');
-    await loadArea();
-    expect(document.body.classList.contains('dark')).to.be.true;
-  });
-
-  it('removes the header element when header meta is "off"', async () => {
+  it('full flow: setConfig with locale, then use loc function', async () => {
     const meta = document.createElement('meta');
-    meta.name = 'header';
-    meta.content = 'off';
-    document.head.append(meta);
-    const header = document.createElement('header');
-    document.body.prepend(header);
-    await loadArea();
-    expect(document.querySelector('header')).to.be.null;
+    meta.setAttribute('name', 'lang');
+    meta.setAttribute('content', 'es');
+    document.head.appendChild(meta);
+
+    window.fetch.resolves({
+      ok: true,
+      json: () => Promise.resolve({
+        data: [{ key: 'welcome', value: 'Bienvenido' }],
+      }),
+    });
+
+    const locales = {
+      '': { lang: 'en' },
+      es: { lang: 'es', prefix: '/es' },
+    };
+
+    await setConfig({ locales });
+    expect(loc`welcome`).to.equal('Bienvenido');
+    expect(document.documentElement.lang).to.equal('es');
   });
 });

--- a/nx2/test/unit/nx/utils/utils.test.js
+++ b/nx2/test/unit/nx/utils/utils.test.js
@@ -1,0 +1,290 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setConfig } from '../../../../scripts/nx.js';
+import { setMockIms, resetMockIms } from '../../../mocks/ims.js';
+import {
+  SUPPORTED_FILES,
+  DA_ADMIN,
+  DA_COLLAB,
+  DA_CONTENT,
+  DA_PREVIEW,
+  DA_ETC,
+  HLX_ADMIN,
+  AEM_API,
+  ALLOWED_TOKEN,
+  hashChange,
+  loadStyle,
+} from '../../../../utils/utils.js';
+import { daFetch, signout } from '../../../../utils/api.js';
+
+// ─── SUPPORTED_FILES ────────────────────────────────────────────────────────
+
+describe('SUPPORTED_FILES', () => {
+  it('maps html to text/html', () => {
+    expect(SUPPORTED_FILES.html).to.equal('text/html');
+  });
+
+  it('maps json to application/json', () => {
+    expect(SUPPORTED_FILES.json).to.equal('application/json');
+  });
+
+  it('maps svg to image/svg+xml', () => {
+    expect(SUPPORTED_FILES.svg).to.equal('image/svg+xml');
+  });
+
+  it('contains all expected extensions', () => {
+    const expected = ['html', 'jpeg', 'json', 'jpg', 'png', 'gif', 'mp4', 'pdf', 'svg', 'ico'];
+    expect(Object.keys(SUPPORTED_FILES)).to.include.members(expected);
+  });
+});
+
+// ─── Environment constants ──────────────────────────────────────────────────
+
+describe('DA environment constants', () => {
+  it('DA_ADMIN is an http(s) URL', () => {
+    expect(DA_ADMIN).to.be.a('string');
+    expect(DA_ADMIN).to.match(/^https?:\/\//);
+  });
+
+  it('DA_COLLAB is a websocket URL', () => {
+    expect(DA_COLLAB).to.be.a('string');
+    expect(DA_COLLAB).to.match(/^wss?:\/\//);
+  });
+
+  it('DA_CONTENT is an http(s) URL', () => {
+    expect(DA_CONTENT).to.match(/^https?:\/\//);
+  });
+
+  it('DA_PREVIEW is an http(s) URL', () => {
+    expect(DA_PREVIEW).to.match(/^https?:\/\//);
+  });
+
+  it('HLX_ADMIN is admin.hlx.page', () => {
+    expect(HLX_ADMIN).to.equal('https://admin.hlx.page');
+  });
+
+  it('AEM_API is api.aem.live', () => {
+    expect(AEM_API).to.equal('https://api.aem.live');
+  });
+
+  it('ALLOWED_TOKEN includes all DA origins plus HLX and AEM', () => {
+    expect(ALLOWED_TOKEN).to.include(DA_ADMIN);
+    expect(ALLOWED_TOKEN).to.include(DA_COLLAB);
+    expect(ALLOWED_TOKEN).to.include(DA_CONTENT);
+    expect(ALLOWED_TOKEN).to.include(DA_PREVIEW);
+    expect(ALLOWED_TOKEN).to.include(DA_ETC);
+    expect(ALLOWED_TOKEN).to.include(AEM_API);
+    expect(ALLOWED_TOKEN).to.include(HLX_ADMIN);
+  });
+});
+
+// ─── hashChange ─────────────────────────────────────────────────────────────
+
+describe('hashChange', () => {
+  let savedHash;
+
+  beforeEach(() => {
+    savedHash = window.location.hash;
+  });
+
+  afterEach(() => {
+    history.replaceState(null, '', savedHash || ' ');
+  });
+
+  it('calls subscriber immediately with current parsed hash', () => {
+    window.location.hash = '#/testorg/testsite';
+    let result;
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(result).to.not.be.null;
+    expect(result.org).to.equal('testorg');
+    expect(result.site).to.equal('testsite');
+    expect(result.path).to.be.null;
+    unsub();
+  });
+
+  it('returns null for empty hash', () => {
+    history.replaceState(null, '', ' ');
+    let result = 'unset';
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(result).to.be.null;
+    unsub();
+  });
+
+  it('parses org only (no site or path)', () => {
+    window.location.hash = '#/myorg';
+    let result;
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(result.org).to.equal('myorg');
+    expect(result.site).to.be.null;
+    expect(result.path).to.be.null;
+    unsub();
+  });
+
+  it('parses org, site, and deep path', () => {
+    window.location.hash = '#/myorg/mysite/folder/page';
+    let result;
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(result.org).to.equal('myorg');
+    expect(result.site).to.equal('mysite');
+    expect(result.path).to.equal('folder/page');
+    unsub();
+  });
+
+  it('always includes a view property', () => {
+    window.location.hash = '#/org';
+    let result;
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(result).to.have.property('view');
+    expect(result.view).to.be.a('string');
+    unsub();
+  });
+
+  it('strips /index suffix from hash via replaceState', () => {
+    window.location.hash = '#/org/site/path/index';
+    let result;
+    const unsub = hashChange.subscribe((state) => { result = state; });
+    expect(window.location.hash).to.not.include('index');
+    expect(result.org).to.equal('org');
+    expect(result.site).to.equal('site');
+    unsub();
+  });
+
+  it('unsubscribe stops future notifications', (done) => {
+    let callCount = 0;
+    const unsub = hashChange.subscribe(() => { callCount += 1; });
+    expect(callCount).to.equal(1);
+    unsub();
+
+    window.location.hash = '#/anotherorg/anothersite';
+    setTimeout(() => {
+      expect(callCount).to.equal(1);
+      done();
+    }, 100);
+  });
+
+  it('notifies subscribers on hashchange', (done) => {
+    const results = [];
+    const unsub = hashChange.subscribe((state) => { results.push(state); });
+
+    window.location.hash = '#/eventorg/eventsite';
+
+    setTimeout(() => {
+      const last = results[results.length - 1];
+      expect(last).to.not.be.null;
+      expect(last.org).to.equal('eventorg');
+      expect(last.site).to.equal('eventsite');
+      unsub();
+      done();
+    }, 100);
+  });
+});
+
+// ─── loadStyle ──────────────────────────────────────────────────────────────
+
+describe('loadStyle', () => {
+  it('returns the same promise for repeated calls (caching)', () => {
+    const p1 = loadStyle('/nx2/test/mocks/test.js');
+    const p2 = loadStyle('/nx2/test/mocks/test.js');
+    expect(p1).to.equal(p2);
+  });
+
+  it('replaces .js with .css in the path', async () => {
+    const sheet = await loadStyle('/nx2/test/mocks/test.js');
+    expect(sheet).to.be.instanceOf(CSSStyleSheet);
+  });
+});
+
+// ─── api ────────────────────────────────────────────────────────────────────
+
+const mockResp = (body = {}, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+  headers: { get: () => null },
+});
+
+describe('api', () => {
+  const originalFetch = window.fetch;
+  let fetchStub;
+
+  before(async () => {
+    await setConfig({ locales: { '': {} }, log: () => {} });
+  });
+
+  beforeEach(() => {
+    fetchStub = sinon.stub();
+    window.fetch = fetchStub;
+    resetMockIms();
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+  });
+
+  // ─── daFetch ──────────────────────────────────────────────────────────────
+
+  describe('daFetch', () => {
+    it('attaches Authorization header for allowed origins', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({ url: `${DA_ADMIN}/some/path` });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.headers.Authorization).to.equal('Bearer test-token');
+    });
+
+    it('skips token for non-allowed origins', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({ url: 'https://random-site.com/api' });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.headers.Authorization).to.be.undefined;
+    });
+
+    it('returns empty object when user is anonymous', async () => {
+      setMockIms({ anonymous: true });
+      const resp = await daFetch({ url: `${DA_ADMIN}/test` });
+      expect(resp).to.deep.equal({});
+      expect(fetchStub.called).to.be.false;
+    });
+
+    it('adds x-content-source-authorization for HLX_ADMIN', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({ url: `${HLX_ADMIN}/some/path` });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.headers['x-content-source-authorization']).to.equal('Bearer test-token');
+      expect(opts.headers.Authorization).to.equal('Bearer test-token');
+    });
+
+    it('adds x-content-source-authorization for AEM_API', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({ url: `${AEM_API}/some/path` });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.headers['x-content-source-authorization']).to.equal('Bearer test-token');
+    });
+
+    it('defaults to GET method', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({ url: `${DA_ADMIN}/test` });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('passes through custom opts', async () => {
+      fetchStub.resolves(mockResp());
+      await daFetch({
+        url: `${DA_ADMIN}/test`,
+        opts: { method: 'POST', headers: {}, body: 'data' },
+      });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.method).to.equal('POST');
+      expect(opts.body).to.equal('data');
+    });
+  });
+
+  // ─── signout ──────────────────────────────────────────────────────────────
+
+  describe('signout', () => {
+    it('is a callable function', () => {
+      expect(signout).to.be.a('function');
+    });
+  });
+});

--- a/nx2/test/wtr.config.mjs
+++ b/nx2/test/wtr.config.mjs
@@ -11,6 +11,7 @@ function customReporter() {
   return {
     async reportTestFileResults({ logger, sessionsForTestFile }) {
       sessionsForTestFile.forEach((session) => {
+        if (!session.testResults?.tests) return;
         session.testResults.tests.forEach((test) => {
           if (!test.passed && !test.skipped) {
             logger.log(test);
@@ -24,7 +25,7 @@ function customReporter() {
 export default {
   coverageConfig: {
     include: [
-      '**/nx/**',
+      '**/nx2/**',
       '**/scripts/**',
     ],
     exclude: [
@@ -49,7 +50,8 @@ export default {
           {
             "imports": {
               "da-lit": "/nx2/deps/lit/dist/index.js",
-              "/nx2/public/sl/components.js": "/nx2/test/mocks/sl-components.js"
+              "/nx2/public/sl/components.js": "/nx2/test/mocks/sl-components.js",
+              "/nx2/utils/ims.js": "/nx2/test/mocks/ims.js"
             }
           }
         </script>
@@ -69,7 +71,7 @@ export default {
           const oldXHROpen = XMLHttpRequest.prototype.open;
           XMLHttpRequest.prototype.open = async function (...args) {
             let [method, url, asyn] = args;
-            if (!resource.startsWith('/') && url.startsWith('http://localhost')) {
+            if (!url.startsWith('/') && !url.startsWith('http://localhost')) {
               console.error(
                 '** XMLHttpRequest request for an external resource is disallowed in unit tests, please find a way to mock! https://github.com/orgs/adobecom/discussions/127 provides guidance on how to fix the issue.',
                 url

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -1,0 +1,33 @@
+import { HLX_ADMIN, AEM_API, DA_ADMIN, ALLOWED_TOKEN } from './utils.js';
+import { loadIms, handleSignIn } from './ims.js';
+
+export const daFetch = async ({ url, opts = { method: 'GET' }, redirect = false }) => {
+  const { accessToken } = await loadIms();
+  if (!accessToken) {
+    handleSignIn();
+    return {};
+  }
+
+  opts.headers = opts.headers || {};
+
+  const canToken = ALLOWED_TOKEN.some((origin) => new URL(url).origin === origin);
+  if (canToken) {
+    opts.headers.Authorization = `Bearer ${accessToken.token}`;
+    if ([HLX_ADMIN, AEM_API].some((origin) => new URL(url).origin === origin)) {
+      opts.headers['x-content-source-authorization'] = `Bearer ${accessToken.token}`;
+      opts.headers.Authorization = `Bearer ${accessToken.token}`;
+    }
+  }
+
+  const resp = await fetch(url, opts);
+  const { status } = resp;
+  if (status === 401 || status === 403) {
+    if (redirect) window.location = `${window.location.origin}/not-found`;
+  }
+
+  return resp;
+};
+
+export const signout = () => {
+  daFetch(`${DA_ADMIN}/logout`);
+};


### PR DESCRIPTION
- Extract API fetch utilities with token handling (daFetch, signout)
- Add configurable DA service endpoints (admin, collab, content, preview)
- Support environment overrides via query params and localStorage
- Refactor env detection from function to constant in both nx and nx2
- Add getColorScheme utility for consistent theme detection
- Extract shared utilities (loadStyle, hashChange observer)
- Add comprehensive test coverage for nx.js and utils modules
- Add IMS mocking infrastructure for tests
- Add error handling for locale string loading
- Remove unused HashController in favor of hashChange subscriber
- Update test configuration to cover nx2 modules
