### PR TITLE
feat: reusable picker

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -1,0 +1,69 @@
+# nx-picker
+
+A dropdown picker with a built-in trigger button, keyboard navigation, and a checkmark on the selected item. Supports dividers.
+
+## Usage
+
+The trigger is built-in — the component renders its own button showing the current selection.
+
+```html
+<nx-picker id="my-picker" placement="below"></nx-picker>
+```
+
+```js
+import "/path/to/picker/picker.js";
+
+const picker = document.querySelector("#my-picker");
+picker.items = [
+  { value: "all",      label: "All" },
+  { value: "content",  label: "Content" },
+  { value: "seo",      label: "SEO" },
+  { divider: true },
+  { value: "review",   label: "Review" },
+];
+picker.value = "all";
+
+picker.addEventListener("change", (e) => {
+  console.log(e.detail.value); // 'all' | 'content' | 'seo' | 'review'
+});
+```
+
+## Item shapes
+
+Each entry in the `items` array is one of:
+
+```js
+// Regular item
+{ value: 'content', label: 'Content' }
+
+// Visual divider
+{ divider: true }
+```
+
+## API
+
+### Properties
+
+| Property    | Type                  | Description                                                                        |
+| ----------- | --------------------- | ---------------------------------------------------------------------------------- |
+| `items`     | `Array`               | List of item descriptors (see shapes above).                                       |
+| `value`     | `String`              | The currently selected item value. Drives the trigger label and the checkmark.     |
+| `placement` | `String`              | Default placement when opened: `below` (default), `above`, or `auto`.             |
+| `open`      | `Boolean` (read-only) | Whether the picker is currently open.                                              |
+
+### Methods
+
+| Method  | Signature | Description                        |
+| ------- | --------- | ---------------------------------- |
+| `show`  | `()`      | Opens the picker.                  |
+| `close` | `()`      | Closes the picker.                 |
+
+### Events
+
+| Event    | Detail      | Description                                                                              |
+| -------- | ----------- | ---------------------------------------------------------------------------------------- |
+| `change` | `{ value }` | Fired when the user clicks or keyboard-confirms an item. `value` matches the item field. |
+
+## Keyboard behaviour
+
+When the picker is open, arrow keys move focus between items and Enter selects the active item. Escape closes the picker.

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -3,6 +3,7 @@ import ChatController from './chat-controller.js';
 import { renderMessage, renderThinking } from './renderers.js';
 import './welcome/welcome.js';
 import '../shared/menu/menu.js';
+import '../shared/picker/picker.js';
 import { loadStyle, hashChange } from '../../utils/utils.js';
 import { loadChatIcons } from './utils.js';
 import { ADD_MENU_ITEMS, CHAT_ICONS } from './constants.js';
@@ -117,7 +118,20 @@ class NxChat extends LitElement {
   }
 
   render() {
+    // todo: for preview only, remove before merge
     return html`
+      <nx-picker
+        .items=${[
+        { value: 'all', label: 'All' },
+        { value: 'content', label: 'Content' },
+        { value: 'seo', label: 'SEO' },
+        { value: 'style', label: 'Style' },
+        { divider: true },
+        { value: 'review', label: 'Review' },
+      ]}
+        .value=${'all'}
+        @change=${(e) => console.log('picker changed:', e.detail.value)}
+      ></nx-picker>
       <div class="chat-messages-container" role="log" aria-live="polite">
         ${!this.messages?.length && !this.thinking
         ? html`<nx-chat-welcome .context=${this._context} .onSend=${(p) => this._sendPrompt(p)}></nx-chat-welcome>`

--- a/nx2/blocks/shared/menu/menu.js
+++ b/nx2/blocks/shared/menu/menu.js
@@ -2,6 +2,7 @@ import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle } from '../../../utils/utils.js';
 import '../popover/popover.js';
 import { loadHrefSvg } from '../../../utils/svg.js';
+import { listKeydown } from '../utils/list-nav.js';
 
 const ICONS_BASE = new URL('../../img/icons/', import.meta.url).href;
 const styles = await loadStyle(import.meta.url);
@@ -58,13 +59,16 @@ class NxMenu extends LitElement {
 
   _onMenuToggle(e) {
     if (e.newState !== 'open') return;
-    this._active = undefined;
     this._trigger?.toggleAttribute('data-active', true);
     this._trigger?.setAttribute('aria-expanded', 'true');
+    const first = this.items?.find((i) => !i.divider && !i.section);
+    this._active = first?.id;
+    this.updateComplete.then(() => {
+      this.shadowRoot.querySelector(`[data-id="${this._active}"]`)?.focus();
+    });
   }
 
   show({ anchor, placement } = {}) {
-    this._active = undefined;
     this._popover?.show({
       anchor,
       placement: placement ?? this.getAttribute('placement') ?? 'below',
@@ -84,8 +88,6 @@ class NxMenu extends LitElement {
       this.close();
       return;
     }
-    trigger.toggleAttribute('data-active', true);
-    trigger.setAttribute('aria-expanded', 'true');
     this.show({ anchor: trigger });
   }
 
@@ -100,23 +102,14 @@ class NxMenu extends LitElement {
   }
 
   _onKeydown(e) {
-    const selectable = this.items?.filter((i) => !i.divider && !i.section) ?? [];
-    if (!selectable.length) return;
-
-    const curIdx = selectable.findIndex((i) => i.id === this._active);
-
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      this._active = selectable[(curIdx + 1) % selectable.length].id;
-      this.shadowRoot.querySelector(`[data-id="${this._active}"]`)?.focus();
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      this._active = selectable[(curIdx <= 0 ? selectable.length : curIdx) - 1].id;
-      this.shadowRoot.querySelector(`[data-id="${this._active}"]`)?.focus();
-    } else if (e.key === 'Enter' && this._active !== undefined) {
-      e.preventDefault();
-      this._select(selectable.find((i) => i.id === this._active));
-    }
+    listKeydown(e, {
+      items: this.items,
+      active: this._active,
+      key: 'id',
+      shadowRoot: this.shadowRoot,
+      setActive: (val) => { this._active = val; },
+      onSelect: (item) => this._select(item),
+    });
   }
 
   _renderItem(item) {

--- a/nx2/blocks/shared/picker/picker.css
+++ b/nx2/blocks/shared/picker/picker.css
@@ -1,0 +1,87 @@
+:host {
+  display: contents;
+  font-family: var(--s2-font-family);
+  font-size: var(--s2-body-size-xs);
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.picker-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: var(--s2-spacing-75) var(--s2-spacing-100);
+  border: none;
+  background: none;
+  color: var(--s2-gray-900);
+  font-family: inherit;
+  font-size: var(--s2-body-size-s);
+  cursor: pointer;
+  outline: none;
+  width: fit-content;
+
+  &[data-active] {
+    background: var(--s2-gray-200);
+    border-color: var(--s2-gray-400);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--s2-focus-ring-color, currentColor);
+    outline-offset: 2px;
+  }
+
+  .picker-chevron {
+    width: 10px;
+    height: 10px;
+    flex-shrink: 0;
+    background-color: var(--s2-gray-800);
+    mask-image: url("/nx2/img/icons/S2_Icon_ChevronLeft_10_N.svg");
+    transform: rotate(90deg);
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+  }
+}
+
+.picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s2-spacing-100);
+  width: 100%;
+  padding: var(--s2-spacing-75) var(--s2-spacing-100);
+  border: none;
+  border-radius: var(--s2-corner-radius-200);
+  background: none;
+  color: var(--s2-gray-900);
+  font-family: inherit;
+  font-size: var(--s2-body-size-s);
+  margin-bottom: 2px;
+  cursor: pointer;
+  box-sizing: border-box;
+  outline: none;
+
+  &:hover,
+  &.picker-item-active {
+    background: var(--s2-gray-200);
+  }
+}
+
+.picker-check {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--s2-gray-900);
+}
+
+.picker-divider {
+  margin: calc(var(--s2-spacing-100) - 2px) var(--s2-spacing-200)
+    var(--s2-spacing-100);
+  border: none;
+  border-top: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-75);
+}

--- a/nx2/blocks/shared/picker/picker.js
+++ b/nx2/blocks/shared/picker/picker.js
@@ -1,0 +1,133 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+import '../popover/popover.js';
+import { listKeydown } from '../utils/list-nav.js';
+
+const styles = await loadStyle(import.meta.url);
+
+// todo: replace with s2 icon once tools PR is merged
+const CHECKMARK = html`<svg class="picker-check" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+  <path d="M4 10l4.5 4.5L16 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;
+
+class NxPicker extends LitElement {
+  static properties = {
+    items: { attribute: false },
+    value: {},
+    _active: { state: true },
+  };
+
+  get _popover() { return this.shadowRoot.querySelector('nx-popover'); }
+
+  get _button() { return this.shadowRoot.querySelector('.picker-trigger'); }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [styles];
+  }
+
+  get open() { return this._popover?.open ?? false; }
+
+  get _selectedLabel() {
+    return this.items?.find((i) => i.value === this.value)?.label ?? '';
+  }
+
+  show() {
+    this._popover?.show({
+      anchor: this._button,
+      placement: this.getAttribute('placement') ?? 'below',
+    });
+  }
+
+  close() { this._popover?.close(); }
+
+  _toggle() {
+    if (this.open) {
+      this.close();
+      return;
+    }
+    this.show();
+  }
+
+  _onClose() {
+    this._button?.toggleAttribute('data-active', false);
+    this._button?.setAttribute('aria-expanded', 'false');
+  }
+
+  _onPopoverToggle(e) {
+    if (e.newState !== 'open') return;
+    this._active = this.value;
+    this.updateComplete.then(() => {
+      this.shadowRoot.querySelector(`[data-value="${this._active}"]`)?.focus();
+    });
+  }
+
+  _select(item) {
+    this.value = item.value;
+    this.close();
+    this.dispatchEvent(new CustomEvent('change', { detail: { value: item.value }, bubbles: true, composed: true }));
+  }
+
+  _onKeydown(e) {
+    listKeydown(e, {
+      items: this.items,
+      active: this._active,
+      key: 'value',
+      shadowRoot: this.shadowRoot,
+      setActive: (val) => { this._active = val; },
+      onSelect: (item) => this._select(item),
+    });
+  }
+
+  _renderItem(item) {
+    if (item.divider) return html`<li role="separator"><hr class="picker-divider"></li>`;
+    if (!item.label || item.value === undefined) return nothing;
+
+    const selected = item.value === this.value;
+    const active = item.value === this._active;
+
+    return html`
+      <li role="none">
+        <button
+          role="option"
+          aria-selected=${selected}
+          data-value=${item.value}
+          class="picker-item ${active ? 'picker-item-active' : ''}"
+          type="button"
+          @click=${() => this._select(item)}
+          @mouseenter=${() => { this._active = item.value; }}
+          @focus=${() => { this._active = item.value; }}
+        >
+          <span class="picker-item-label">${item.label}</span>
+          ${selected ? CHECKMARK : nothing}
+        </button>
+      </li>
+    `;
+  }
+
+  render() {
+    return html`
+      <button
+        class="picker-trigger"
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded="false"
+        @click=${this._toggle}
+      >
+        <span class="picker-trigger-label">${this._selectedLabel}</span>
+        <span class="picker-chevron" aria-hidden="true"></span>
+      </button>
+      <nx-popover
+        @toggle=${this._onPopoverToggle}
+        @keydown=${this._onKeydown}
+        @close=${this._onClose}
+      >
+        <ul role="listbox">
+          ${this.items?.map((item) => this._renderItem(item))}
+        </ul>
+      </nx-popover>
+    `;
+  }
+}
+
+customElements.define('nx-picker', NxPicker);

--- a/nx2/blocks/shared/utils/list-nav.js
+++ b/nx2/blocks/shared/utils/list-nav.js
@@ -1,0 +1,23 @@
+export function listKeydown(e, {
+  items, active, key, shadowRoot, setActive, onSelect,
+}) {
+  const selectable = items?.filter((i) => !i.divider && !i.section) ?? [];
+  if (!selectable.length) return;
+
+  const curIdx = selectable.findIndex((i) => i[key] === active);
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    const next = selectable[(curIdx + 1) % selectable.length][key];
+    setActive(next);
+    shadowRoot.querySelector(`[data-${key}="${next}"]`)?.focus();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    const prev = selectable[(curIdx <= 0 ? selectable.length : curIdx) - 1][key];
+    setActive(prev);
+    shadowRoot.querySelector(`[data-${key}="${prev}"]`)?.focus();
+  } else if (e.key === 'Enter' && active !== undefined) {
+    e.preventDefault();
+    onSelect(selectable.find((i) => i[key] === active));
+  }
+}


### PR DESCRIPTION
New reusable picker -> details in docs.

Preview available at https://da.live/canvas?nx=nx-picker&nxver=2#/hannessolo/author-kit/demo at the top of the chat ui.

Notes: 
- Shared util for keyboard navigation extracted to be reused by picker and menu. 
- Dummy code in chat.js enabled only for preview -> to be removed prior to merge.
- Checkmark for picker to be adapted to use svg icon once tools PR is merged
