### PR TITLE
fix: prevent config data loss and broken chat skill imports

### DIFF
--- a/nx/blocks/browse/skills-lab-api.js
+++ b/nx/blocks/browse/skills-lab-api.js
@@ -116,12 +116,30 @@ export function clearSkillsLabSuggestionSession() {
 }
 
 /**
+ * Rebuild `:names` and `:type` so the config page renders every sheet as a tab.
+ * Keys starting with `:` or `private-` are metadata / private and excluded from `:names`.
+ */
+function syncConfigMeta(cfg) {
+  const names = Object.keys(cfg).filter(
+    (k) => !k.startsWith(':') && !k.startsWith('private-') && typeof cfg[k] === 'object',
+  );
+  if (names.length > 1) {
+    cfg[':names'] = names;
+    cfg[':type'] = 'multi-sheet';
+  } else if (names.length === 1) {
+    cfg[':names'] = names;
+    cfg[':type'] = 'multi-sheet';
+  }
+}
+
+/**
  * POST merged config back (preserves existing sheets; adds/updates mcp-servers).
  * @param {string} org
  * @param {string} site
  * @param {object} fullConfig - complete multi-sheet object from GET
  */
 export async function saveDaConfig(org, site, fullConfig) {
+  syncConfigMeta(fullConfig);
   const path = site ? `${org}/${site}` : org;
   const body = new FormData();
   body.append('config', JSON.stringify(fullConfig));

--- a/nx/blocks/canvas/src/chat.js
+++ b/nx/blocks/canvas/src/chat.js
@@ -13,16 +13,18 @@ import {
 import { renderMessageContent } from './chat-renderers.js';
 import { initIms, daFetch } from '../../../utils/daFetch.js';
 import { DA_ORIGIN } from '../../../public/utils/constants.js';
-import { loadSkills, saveSkill, deleteSkill } from '../../skills-editor/utils/utils.js';
 import {
   clearSkillsLabSuggestionSession,
   DA_SKILLS_LAB_CLEAR_FORM_FROM_CHAT_EVENT,
   DA_SKILLS_LAB_FORM_COLUMN_DISMISS_EVENT,
   DA_SKILLS_LAB_SUGGESTION_HANDOFF_EVENT,
+  deleteSkillFromConfig,
+  loadSkillsFromConfig,
   materializeDaConfigAfter404,
   skillRowEnabled,
   skillRowStatus,
   setSkillsLabSuggestionHandoff,
+  upsertSkillInConfig,
 } from '../../browse/skills-lab-api.js';
 import { loadGeneratedTools } from './generated-tools/utils.js';
 import './generated-tools/generated-tools.js';
@@ -1100,7 +1102,7 @@ class Chat extends LitElement {
     const key = `${org}/${site}`;
     this._skillsLoading = true;
     try {
-      const skills = await loadSkills(org, site);
+      const skills = await loadSkillsFromConfig(org, site);
       this._skills = skills;
       this._skillsRepoKey = key;
       const ids = Object.keys(skills);
@@ -1172,14 +1174,14 @@ class Chat extends LitElement {
 
   async _saveCurrentSkill() {
     const { org, site } = getContextFromHash();
-    const prefix = site ? `/${org}/${site}` : `/${org}`;
+    if (!org || !site) return;
     const textarea = this.shadowRoot?.querySelector('.skill-editor-textarea');
     const content = textarea?.value ?? '';
 
     if (this._newSkillMode) {
       const id = this._newSkillName.trim();
       if (!id) return;
-      const result = await saveSkill(prefix, id, content, { status: 'draft' });
+      const result = await upsertSkillInConfig(org, site, id, content, { status: 'draft' });
       if (result.error) return;
       this._skills = { ...this._skills, [id]: content };
       this._selectedSkill = id;
@@ -1199,7 +1201,7 @@ class Chat extends LitElement {
       }
       this._dispatchRepoFilesChangedForSite();
     } else if (this._selectedSkill) {
-      const result = await saveSkill(prefix, this._selectedSkill, content, { status: 'draft' });
+      const result = await upsertSkillInConfig(org, site, this._selectedSkill, content, { status: 'draft' });
       if (result.error) return;
       this._skills = { ...this._skills, [this._selectedSkill]: content };
       this._skillEditorDirty = false;
@@ -1210,8 +1212,8 @@ class Chat extends LitElement {
   async _deleteCurrentSkill() {
     if (!this._selectedSkill) return;
     const { org, site } = getContextFromHash();
-    const prefix = site ? `/${org}/${site}` : `/${org}`;
-    const result = await deleteSkill(prefix, this._selectedSkill);
+    if (!org || !site) return;
+    const result = await deleteSkillFromConfig(org, site, this._selectedSkill);
     if (result.error) return;
     const next = { ...this._skills };
     delete next[this._selectedSkill];


### PR DESCRIPTION
- `saveDaConfig` now syncs `:names` / `:type` metadata before writing to KV, so sheets like `skills` and `generated-tools` are no longer silently dropped when the `/config` page saves edits.
- `chat.js` imports skill CRUD functions directly from `skills-lab-api.js` instead of `skills-editor/utils/utils.js`, removing a transitive CodeMirror dependency that broke the entire chat module on non-skills pages (editor, browse, etc.).

## Why
- **Data loss**: the `da-live` config editor only re-serialises sheets listed in `:names`. Our code added `skills` / `generated-tools` data without updating `:names`, so a subsequent config page save would erase those sheets.
- **Broken chat overlay**: importing from `skills-editor/utils/utils.js` pulled in CodeMirror at module-load time. On pages where the CodeMirror path couldn't resolve, the whole `chat.js` module failed silently — no chat overlay, no slash commands, no skill suggestions for any user on that page.

## What Changed
| File | Change |
|------|--------|
| `nx/blocks/browse/skills-lab-api.js` | Added `syncConfigMeta()` called by `saveDaConfig()` to keep `:names` / `:type` in sync with actual sheet keys |
| `nx/blocks/canvas/src/chat.js` | Replaced imports of `loadSkills` / `saveSkill` / `deleteSkill` from `skills-editor/utils/utils.js` with direct `loadSkillsFromConfig` / `upsertSkillInConfig` / `deleteSkillFromConfig` from `skills-lab-api.js`; inlined the thin wrapper logic |

## Test Plan
- [x] `npm test` — all 388 unit tests pass
- [x] `eslint` passes on both changed files
- [ ] Verify `/config` page shows `skills` and `generated-tools` tabs after a skill is saved via Skills Editor
- [ ] Verify chat overlay loads correctly on editor pages (not just `/apps/skills`)
- [ ] Verify slash commands and skill suggestions work for other users/sites

## Risks / Follow-ups
- Low risk — the `:names` sync is additive and only runs on our save path, not the config page's own save flow.
- The `+` menu fix is intentionally **not** included here (separate PR already open for that).
