### PR TITLE
feat: add memory display for skills lab

### DIFF
--- a/nx/blocks/browse/da-skills-lab-view.css
+++ b/nx/blocks/browse/da-skills-lab-view.css
@@ -63,7 +63,7 @@
 
 /* Column 1: skill id + markdown editor + actions (single surface for edit/read). */
 .skills-lab-col-form {
-  flex: 1 1 40%;
+  flex: 1 1 35%;
   min-width: 240px;
   max-width: min(700px, 48%);
   min-height: 0;
@@ -72,7 +72,7 @@
 
 /* Column 2: tools (tabs: generated vs available registry). */
 .skills-lab-col-tools {
-  flex: 1 1 20%;
+  flex: 1 1 25%;
   min-width: 220px;
   min-height: 0;
   display: flex;
@@ -101,7 +101,7 @@
 
 /* Column 3: tabbed catalog (wider). */
 .skills-lab-col-catalog {
-  flex: 1 1 20%;
+  flex: 1 1 25%;
   min-width: 280px;
   min-height: 0;
   display: flex;
@@ -701,6 +701,10 @@
   text-align: center;
   color: #888;
   font-size: 14px;
+}
+
+.skills-lab-memory-rendered {
+  padding: 8px 12px;
 }
 
 /* ---- Mobile / narrow viewport (chat + editor + discover first; collapsible catalogs) ---- */

--- a/nx/blocks/browse/da-skills-lab-view.js
+++ b/nx/blocks/browse/da-skills-lab-view.js
@@ -8,6 +8,7 @@ import { daFetch } from '../../utils/daFetch.js';
 import { saveSkill, deleteSkill } from '../skills-editor/utils/utils.js';
 import { loadGeneratedTools } from '../canvas/src/generated-tools/utils.js';
 import '../canvas/src/generated-tools/generated-tools.js';
+import { renderMessageContent } from '../canvas/src/chat-renderers.js';
 import {
   consumeSkillsLabSuggestionHandoff,
   DA_SKILLS_LAB_CLEAR_FORM_FROM_CHAT_EVENT,
@@ -148,6 +149,8 @@ class DaSkillsLabView extends LitElement {
     _newAgentName: { state: true },
     _agentSaveBusy: { state: true },
     _formMsg: { state: true },
+    /** Markdown content of .da/agent/memory.md; null = not loaded or absent. */
+    _memory: { state: true },
   };
 
   constructor() {
@@ -187,6 +190,7 @@ class DaSkillsLabView extends LitElement {
     this._newAgentName = '';
     this._agentSaveBusy = false;
     this._formMsg = '';
+    this._memory = null;
     /** Same-tab handoff when chat stores session while already on `/apps/skills`. */
     this._onWindowSuggestHandoff = () => {
       this._applySuggestionHandoff(consumeSkillsLabSuggestionHandoff());
@@ -249,12 +253,21 @@ class DaSkillsLabView extends LitElement {
     if (changed.has('_loading') && !this._loading) {
       queueMicrotask(() => this._onCollapsibleVp());
     }
+    if (changed.has('_catalogTab') && this._catalogTab === 'memory' && this._memory === null) {
+      this._loadMemory();
+    }
+  }
+
+  async _loadMemory() {
+    const resp = await daFetch(`${DA_ORIGIN}/source/${this.org}/${this.site}/.da/agent/memory.md`);
+    this._memory = resp.ok ? ((await resp.text()) || null) : null;
   }
 
   async _reload() {
     if (!this.org || !this.site) return;
     this._loading = true;
     this._error = '';
+    this._memory = null;
     try {
       const cfg = await fetchDaConfigSheets(this.org, this.site);
       this._mcpRows = cfg.mcpRows || [];
@@ -1002,6 +1015,14 @@ class DaSkillsLabView extends LitElement {
                 </div>`)}
             `;
 
+    const catalogMemory = html`
+          <h3 class="skills-lab-section-h">Project Memory</h3>
+          <p class="skills-lab-form-hint skills-lab-card-meta">.da/agent/memory.md</p>
+          ${this._memory === null
+        ? html`<p class="skills-lab-form-hint">No project memory yet. The DA agent writes here as it learns about your site.</p>`
+        : html`<div class="skills-lab-chat-rendered skills-lab-memory-rendered">${renderMessageContent(this._memory)}</div>`}
+        `;
+
     let catalogBody = catalogMcps;
     if (this._catalogTab === 'skills') {
       catalogBody = catalogSkills;
@@ -1009,6 +1030,8 @@ class DaSkillsLabView extends LitElement {
       catalogBody = catalogAgents;
     } else if (this._catalogTab === 'prompts') {
       catalogBody = catalogPrompts;
+    } else if (this._catalogTab === 'memory') {
+      catalogBody = catalogMemory;
     }
 
     return html`
@@ -1187,8 +1210,9 @@ class DaSkillsLabView extends LitElement {
               ${tabBtn('agents', 'Agents')}
               ${tabBtn('prompts', 'Prompts')}
               ${tabBtn('mcp', 'MCPs')}
+              ${tabBtn('memory', 'Memory')}
             </div>
-            ${filterBar}
+            ${this._catalogTab !== 'memory' ? filterBar : nothing}
             <div class="skills-lab-catalog-scroll">
               ${catalogBody}
             </div>


### PR DESCRIPTION
Adds a read only view of the projects memory

<img width="1091" height="869" alt="Screenshot 2026-04-19 at 14 15 14" src="https://github.com/user-attachments/assets/122311ae-62a3-43c6-b5b6-7073c18cc0ec" />


Test URLs:
- https://da.live/apps/skills?nx=skils-memory#/aemsites/summit-portal
