### PR TITLE
fix: correct attributes for external extensions

### DIFF
--- a/nx/blocks/canvas/src/space.js
+++ b/nx/blocks/canvas/src/space.js
@@ -648,8 +648,14 @@ class Space extends LitElement {
     if (!this._orgRepo) return null;
     const { org, repo } = this._orgRepo;
     const pathParts = (this._selectedPath || '').split('/').filter(Boolean);
-    const path = pathParts.length > 2 ? `/${pathParts.slice(2).join('/')}` : '';
-    return { org, site: repo, path, view: this._viewMode };
+    const rawPath = pathParts.length > 2 ? `/${pathParts.slice(2).join('/')}` : '';
+    const path = rawPath.replace(/\.html$/, '');
+    const name = pathParts.length > 0 ? pathParts[pathParts.length - 1].replace(/\.html$/, '') : '';
+    const selectedPath = this._selectedPath || '';
+    const fullpath = selectedPath.startsWith('/') ? selectedPath : `/${selectedPath}`;
+    return {
+      org, site: repo, path, fullpath, name, view: this._viewMode,
+    };
   }
 
   _handleExtensionsToggle() {


### PR DESCRIPTION
Quick fix to make external extensions working by giving them the right attributes

<img width="1177" height="774" alt="Screenshot 2026-04-19 at 14 44 46" src="https://github.com/user-attachments/assets/ca3a8adc-effd-4955-8e2b-271193923ef4" />


Test URLs:
- https://da.live/canvas?nx=extentsions#/aemsites/summit-portal/customers/a/aaa/index.html