### PR TITLE
fix: publish icon

### DIFF
--- a/nx/blocks/canvas/src/space.js
+++ b/nx/blocks/canvas/src/space.js
@@ -917,7 +917,7 @@ class Space extends LitElement {
       <sp-action-menu label="Publish menu" class="space-publish-menu-trigger">
         <span class="space-publish-menu-content" slot="icon">
           ${this._publishLoading ? html`<sp-progress-circle class="space-publish-spinner" indeterminate size="s" aria-label="Loading"></sp-progress-circle>` : ''}
-          <sp-icon-publish class="space-publish-icon"></sp-icon-publish>
+          ${this._publishLoading ? nothing : html`<sp-icon-publish class="space-publish-icon"></sp-icon-publish>`}
         </span>
         <sp-menu-item @click="${this._onPreview}">Preview</sp-menu-item>
         <sp-menu-item @click="${this._onPublish}">Publish</sp-menu-item>


### PR DESCRIPTION
On publish/preview the paperplain icon should be hidden

<img width="589" height="438" alt="Screenshot 2026-04-19 at 14 50 39" src="https://github.com/user-attachments/assets/3c20acb8-64b9-49ae-9d88-56dd3d369138" />


Test URLs:
- https://da.live/canvas?nx=publish-icon#/aemsites/summit-portal/customers/a/aaa/index.html
