### PR TITLE
fix: Diff - handle block groups

### DIFF
--- a/nx/blocks/loc/regional-diff/regional-diff.js
+++ b/nx/blocks/loc/regional-diff/regional-diff.js
@@ -321,11 +321,18 @@ function wrapElement(targetElement, wrapperElementTag) {
   return wrapperElement;
 }
 
-function getGroupInnerHtml(blockGroup) {
+const SECTION_DIV_BREAK = '</div><div>';
+const DIFF_INNER_SECTION_MARK = '<hr />';
+
+/**
+ * @param {Array<Element | typeof sectionBlock>} blockGroup
+ * @param {{ sectionSeparator?: string }} [options]
+ */
+function getGroupInnerHtml(blockGroup, { sectionSeparator = SECTION_DIV_BREAK } = {}) {
   let htmlText = '';
   blockGroup.forEach((block) => {
     if (block.isSection) {
-      htmlText += '</div><div>';
+      htmlText += sectionSeparator;
       return;
     }
     htmlText += block.outerHTML;
@@ -333,51 +340,116 @@ function getGroupInnerHtml(blockGroup) {
   return htmlText;
 }
 
-function getBlockgroupHtml(blockGroup, type) {
-  if (type === ADDED) {
-    blockGroup[0]?.setAttribute(ADDED_TAG, '');
-  }
+function diffEntryNeedsSectionBreakBefore(diff, index) {
+  if (index === 0) return false;
+  const prev = diff[index - 1];
+  return Boolean(prev && !prev.block?.isSection);
+}
 
-  // Modified block groups automatically get sections at start and end
-  const htmlText = getGroupInnerHtml(blockGroup);
+function diffEntryNeedsSectionBreakAfter(diff, index, consumedCount) {
+  const afterIndex = index + consumedCount;
+  if (afterIndex >= diff.length) return false;
+  const after = diff[afterIndex];
+  return Boolean(after && !after.block?.isSection);
+}
 
-  if (type === ADDED) {
-    return `<div>${htmlText}</div>`;
-  }
+function appendPairedDiffedBlockGroupsHtml({
+  htmlText, deletedGroup, addedGroup,
+}) {
+  const diffSep = { sectionSeparator: DIFF_INNER_SECTION_MARK };
+  const deletedInner = getGroupInnerHtml(deletedGroup, diffSep);
+  addedGroup[0]?.setAttribute(ADDED_TAG, '');
+  const addedInner = getGroupInnerHtml(addedGroup, diffSep);
+  return `${htmlText}<${DELETED_TAG}>${deletedInner}</${DELETED_TAG}>${addedInner}`;
+}
+
+function appendSingleDiffedBlockGroupHtml({ htmlText, type, blockGroup }) {
+  const diffSep = { sectionSeparator: DIFF_INNER_SECTION_MARK };
   if (type === DELETED) {
-    return `<${DELETED_TAG} class="da-group"><div>${htmlText}</div></${DELETED_TAG}>`;
+    const inner = getGroupInnerHtml(blockGroup, diffSep);
+    return `${htmlText}<${DELETED_TAG}>${inner}</${DELETED_TAG}>`;
   }
-  return htmlText;
+  blockGroup[0]?.setAttribute(ADDED_TAG, '');
+  const inner = getGroupInnerHtml(blockGroup, diffSep);
+  return `${htmlText}${inner}`;
 }
 
 function buildHtmlFromDiff(diff, modified, acceptedHashes = [], rejectedHashes = []) {
   let htmlText = '<div>';
-  diff.forEach((item, i) => {
+  for (let i = 0; i < diff.length; i += 1) {
+    const item = diff[i];
     let modifiedBlock = item.block;
     const hash = item.hash.substring(0, HASH_LENGTH);
+
     if (item.block.isSection && i !== 0) {
-      htmlText += '</div><div>';
-      return;
+      htmlText += SECTION_DIV_BREAK;
+      // eslint-disable-next-line no-continue
+      continue;
     }
 
     if (Array.isArray(item.block)) {
-      htmlText += getBlockgroupHtml(item.block, item.type, acceptedHashes, rejectedHashes);
-      return;
+      if (item.type === SAME) {
+        htmlText += getGroupInnerHtml(item.block);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      const next = diff[i + 1];
+      const isPairedDiff = item.type === DELETED
+        && next?.type === ADDED
+        && Array.isArray(next.block);
+
+      if (isPairedDiff) {
+        if (diffEntryNeedsSectionBreakBefore(diff, i)) {
+          htmlText += SECTION_DIV_BREAK;
+        }
+        htmlText = appendPairedDiffedBlockGroupsHtml({
+          htmlText,
+          deletedGroup: item.block,
+          addedGroup: next.block,
+        });
+        if (diffEntryNeedsSectionBreakAfter(diff, i, 2)) {
+          htmlText += SECTION_DIV_BREAK;
+        }
+        i += 1;
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      if (diffEntryNeedsSectionBreakBefore(diff, i)) {
+        htmlText += SECTION_DIV_BREAK;
+      }
+      htmlText = appendSingleDiffedBlockGroupHtml({
+        htmlText,
+        type: item.type,
+        blockGroup: item.block,
+      });
+      if (diffEntryNeedsSectionBreakAfter(diff, i, 1)) {
+        htmlText += SECTION_DIV_BREAK;
+      }
+      // eslint-disable-next-line no-continue
+      continue;
     }
 
     if (item.type === ADDED) {
-      if (rejectedHashes.includes(hash)) return;
+      if (rejectedHashes.includes(hash)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       if (!acceptedHashes.includes(hash)) {
         modifiedBlock.setAttribute(ADDED_TAG, '');
       }
     } else if (item.type === DELETED) {
-      if (rejectedHashes.includes(hash)) return;
+      if (rejectedHashes.includes(hash)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       if (!acceptedHashes.includes(hash)) {
         modifiedBlock = wrapElement(item.block, DELETED_TAG);
       }
     }
     htmlText += modifiedBlock.outerHTML;
-  });
+  }
   htmlText += '</div>';
 
   modified.documentElement.querySelector('main').innerHTML = htmlText;

--- a/test/loc/mocks/basic-block-group-au.html
+++ b/test/loc/mocks/basic-block-group-au.html
@@ -1,0 +1,64 @@
+<main>
+  <div>
+    <div class="marquee light">
+      <div>
+        <div>
+          <p>#f5f5f5</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h1>
+            Make every financial experience personal
+          </h1>
+          <p>
+            Businesses in the financial services industry must redefine their customer experiences through personalization at scale. By delivering hyper personalized experiences that are contextual, intelligent, and secure, your company can meet almost any customer need in the very moment it’s required. Here’s how Adobe can help.
+          </p>
+          <p>
+            <a href="https://main--bacom--adobecom.aem.live/fragments/solutions/modal/financial-services-video#watch">
+              <em>:play: Watch video</em>
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Recommended for you</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Changed for AU - Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/loc/mocks/basic-block-group-merged.html
+++ b/test/loc/mocks/basic-block-group-merged.html
@@ -1,0 +1,102 @@
+<main>
+  <div>
+    <div class="marquee light">
+      <div>
+        <div>
+          <p>#f5f5f5</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h1>
+            Make every financial experience personal
+          </h1>
+          <p>
+            Businesses in the financial services industry must redefine their customer experiences through personalization at scale. By delivering hyper personalized experiences that are contextual, intelligent, and secure, your company can meet almost any customer need in the very moment it’s required. Here’s how Adobe can help.
+          </p>
+          <p>
+            <a href="https://main--bacom--adobecom.aem.live/fragments/solutions/modal/financial-services-video#watch">
+              <em>:play: Watch video</em>
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="block-group-start" da-diff-added="">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Added</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <da-diff-deleted>
+      <div class="block-group-start">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <div class="text center">
+        <div>
+          <div>
+            <h3>Recommended for you</h3>
+          </div>
+        </div>
+      </div>
+      <div class="text left">
+        <div>
+          <div>
+            <h3>Inside a block group!</h3>
+          </div>
+        </div>
+      </div>
+      <div class="section-metadata">
+        <div>
+          <div>
+            <p>style</p>
+          </div>
+          <div>
+            <p>XL spacing</p>
+          </div>
+        </div>
+      </div>
+      <div class="block-group-end">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </da-diff-deleted>
+  </div>
+</main>

--- a/test/loc/mocks/basic-block-group-us.html
+++ b/test/loc/mocks/basic-block-group-us.html
@@ -1,0 +1,64 @@
+<main>
+  <div>
+    <div class="marquee light">
+      <div>
+        <div>
+          <p>#f5f5f5</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h1>
+            Make every financial experience personal
+          </h1>
+          <p>
+            Businesses in the financial services industry must redefine their customer experiences through personalization at scale. By delivering hyper personalized experiences that are contextual, intelligent, and secure, your company can meet almost any customer need in the very moment it’s required. Here’s how Adobe can help.
+          </p>
+          <p>
+            <a href="https://main--bacom--adobecom.aem.live/fragments/solutions/modal/financial-services-video#watch">
+              <em>:play: Watch video</em>
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Recommended for you</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-added-only-au.html
+++ b/test/loc/mocks/block-group-added-only-au.html
@@ -1,0 +1,28 @@
+<main>
+  <div>
+    <h2>Added Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Added Block Group</h3>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-added-only-merged.html
+++ b/test/loc/mocks/block-group-added-only-merged.html
@@ -1,0 +1,32 @@
+<main>
+  <div>
+    <h2>Added Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+  </div>
+  <div>
+    <div class="block-group-start" da-diff-added="">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Added Block Group</h3>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-added-only-us.html
+++ b/test/loc/mocks/block-group-added-only-us.html
@@ -1,0 +1,9 @@
+<main>
+  <div>
+    <h2>Added Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-au.html
+++ b/test/loc/mocks/block-group-au.html
@@ -1,0 +1,57 @@
+<main>
+  <div>
+    <h2>Block group Test</h2>
+  </div>
+  <div>
+    <p>Text before the block group in same section, section will be inserted before the block group start</p>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>My Aussie Block Group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Aussie content inside section in a block group</h3>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <h4>Last section with block group end</h4>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <p>Text after the block group in same section, section will be inserted after the block group end</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-deleted-only-au.html
+++ b/test/loc/mocks/block-group-deleted-only-au.html
@@ -1,0 +1,9 @@
+<main>
+  <div>
+    <h2>Deleted Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-deleted-only-merged.html
+++ b/test/loc/mocks/block-group-deleted-only-merged.html
@@ -1,0 +1,34 @@
+<main>
+  <div>
+    <h2>Deleted Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+  </div>
+  <div>
+    <da-diff-deleted>
+      <div class="block-group-start">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <div class="text center">
+        <div>
+          <div>
+            <h3>Deleted Block Group</h3>
+          </div>
+        </div>
+      </div>
+      <div class="block-group-end">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </da-diff-deleted>
+  </div>
+  <div>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-deleted-only-us.html
+++ b/test/loc/mocks/block-group-deleted-only-us.html
@@ -1,0 +1,28 @@
+<main>
+  <div>
+    <h2>Deleted Only Test</h2>
+  </div>
+  <div>
+    <p>Text before</p>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>Deleted Block Group</h3>
+        </div>
+      </div>
+    </div>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <p>Text after</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-merged.html
+++ b/test/loc/mocks/block-group-merged.html
@@ -1,0 +1,107 @@
+<main>
+  <div>
+    <h2>Block group Test</h2>
+  </div>
+  <div>
+    <p>Text before the block group in same section, section will be inserted before the block group start</p>
+  </div>
+  <div>
+    <da-diff-deleted>
+      <div class="block-group-start">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+      <div class="text center">
+        <div>
+          <div>
+            <h3>My Block Group</h3>
+          </div>
+        </div>
+      </div>
+      <div class="text left">
+        <div>
+          <div>
+            <h3>Inside a block group!</h3>
+          </div>
+        </div>
+      </div>
+      <div class="section-metadata">
+        <div>
+          <div>
+            <p>style</p>
+          </div>
+          <div>
+            <p>XL spacing</p>
+          </div>
+        </div>
+      </div>
+      <hr>
+      <div class="text left">
+        <div>
+          <div>
+            <h3>Content inside section in a block group</h3>
+          </div>
+        </div>
+      </div>
+      <hr>
+      <h4>Last section with block group end</h4>
+      <div class="block-group-end">
+        <div>
+          <div></div>
+          <div></div>
+        </div>
+      </div>
+    </da-diff-deleted>
+    <div class="block-group-start" da-diff-added="">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>My Aussie Block Group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+    <hr>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Aussie content inside section in a block group</h3>
+        </div>
+      </div>
+    </div>
+    <hr>
+    <h4>Last section with block group end</h4>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <p>Text after the block group in same section, section will be inserted after the block group end</p>
+  </div>
+</main>

--- a/test/loc/mocks/block-group-us.html
+++ b/test/loc/mocks/block-group-us.html
@@ -1,0 +1,57 @@
+<main>
+  <div>
+    <h2>Block group Test</h2>
+  </div>
+  <div>
+    <p>Text before the block group in same section, section will be inserted before the block group start</p>
+    <div class="block-group-start">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <div class="text center">
+      <div>
+        <div>
+          <h3>My Block Group</h3>
+        </div>
+      </div>
+    </div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Inside a block group!</h3>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>
+          <p>style</p>
+        </div>
+        <div>
+          <p>XL spacing</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="text left">
+      <div>
+        <div>
+          <h3>Content inside section in a block group</h3>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <h4>Last section with block group end</h4>
+    <div class="block-group-end">
+      <div>
+        <div></div>
+        <div></div>
+      </div>
+    </div>
+    <p>Text after the block group in same section, section will be inserted after the block group end</p>
+  </div>
+</main>

--- a/test/loc/regional-diff.test.js
+++ b/test/loc/regional-diff.test.js
@@ -134,6 +134,39 @@ describe('Regional diff', () => {
     expect(cleanHtmlWhitespace(mainEl.outerHTML))
       .to.equal(cleanHtmlWhitespace(expectedDiffedMain));
   });
+
+  it('Handle block group differences with sections', async () => {
+    const original = document.implementation.createHTMLDocument();
+    original.body.innerHTML = await readFile({ path: './mocks/block-group-us.html' });
+    const modified = document.implementation.createHTMLDocument();
+    modified.body.innerHTML = await readFile({ path: './mocks/block-group-au.html' });
+    const mainEl = await regionalDiff(original, modified);
+    const expectedDiffedMain = await readFile({ path: './mocks/block-group-merged.html' });
+    expect(cleanHtmlWhitespace(mainEl.outerHTML))
+      .to.equal(cleanHtmlWhitespace(expectedDiffedMain));
+  });
+
+  it('Handle block group only added in modified document', async () => {
+    const original = document.implementation.createHTMLDocument();
+    original.body.innerHTML = await readFile({ path: './mocks/block-group-added-only-us.html' });
+    const modified = document.implementation.createHTMLDocument();
+    modified.body.innerHTML = await readFile({ path: './mocks/block-group-added-only-au.html' });
+    const mainEl = await regionalDiff(original, modified);
+    const expectedDiffedMain = await readFile({ path: './mocks/block-group-added-only-merged.html' });
+    expect(cleanHtmlWhitespace(mainEl.outerHTML))
+      .to.equal(cleanHtmlWhitespace(expectedDiffedMain));
+  });
+
+  it('Handle block group only deleted from modified document', async () => {
+    const original = document.implementation.createHTMLDocument();
+    original.body.innerHTML = await readFile({ path: './mocks/block-group-deleted-only-us.html' });
+    const modified = document.implementation.createHTMLDocument();
+    modified.body.innerHTML = await readFile({ path: './mocks/block-group-deleted-only-au.html' });
+    const mainEl = await regionalDiff(original, modified);
+    const expectedDiffedMain = await readFile({ path: './mocks/block-group-deleted-only-merged.html' });
+    expect(cleanHtmlWhitespace(mainEl.outerHTML))
+      .to.equal(cleanHtmlWhitespace(expectedDiffedMain));
+  });
 });
 
 describe('normalizeLinks', () => {


### PR DESCRIPTION
Block group diffs were breaking content when accepting the changes.  We now properly handle block-groups.

Note that if there is any content in a section before a block-group-start then it will be placed it it's own section before the block-group.   Same for content after block-group-end in the same section.

