### PR TITLE
feat: setup tools panel

### DIFF
--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -18,7 +18,7 @@ The following sections highlight some principles in more detail.
 - The nx2 scripts and utils provide URL/state helpers, auth, and block loading (`nx2/scripts/nx.js`, `nx2/utils/`).
 - Feature code lives in **`nx2/blocks/`** — currently including **`canvas`** (the edit experience; not a separate edit block), **`chat`**, shell pieces (**`nav`**, **`sidenav`**, **`profile`**), **`fragment`** / **`dialog`**, and small helpers (**`action-button`**, **`canvas-actions`**).
 - Shared shell behavior for app-frame side regions is implemented in **`nx2/utils/panel.js`** (DOM panel chrome, resize, show/hide, persistence), not as a separate `blocks/panel` Lit shell.
-- **`blocks/tool-panel`** provides the managed panel shell (`nx-tool-panel`): a picker to switch between consumers, a header-actions zone for first-party consumers, and a close button. Consumer content is lazy-loaded on first activation. Like chat, `nx-tool-panel` is position-agnostic — host blocks instantiate it and set its `consumers` array inside their own `getContent`.
+- **`blocks/tool-panel`** provides the managed panel shell (`nx-tool-panel`): a picker to switch between views, a header-actions zone for first-party views, and a close button. Consumer content is lazy-loaded on first activation. Like chat, `nx-tool-panel` is position-agnostic — host blocks instantiate it and set its `views` array inside their own `getContent`.
 - **`blocks/chat`** has no public entry-point wrapper — host blocks mount `nx-chat` directly inside their own `getContent`.
 - When **`blocks/shared`** (or equivalent) exists, it should contain small, reusable pieces that make no assumptions about where they are invoked from.
 - Root **`Utils`** contains helpers such as the extension SDK client and DA API wrappers (`daFetch.js`: origins + `daFetch`).
@@ -77,11 +77,11 @@ The distinction between panel types is a **caller convention**, not a framework 
 
 **Headless** — `getContent` returns a component that owns its entire layout: header, actions, close button. Used when a single, known first-party component permanently occupies the panel
 
-**Managed** — `getContent` imports and instantiates `nx-tool-panel`, sets its `consumers` array, and returns it. `nx-tool-panel` then owns the header with a consumer picker, actions zone, and close button. Used when multiple consumers share a panel (e.g. tools and extensions).
+**Managed** — `getContent` imports and instantiates `nx-tool-panel`, sets its `views` array, and returns it. `nx-tool-panel` then owns the header with a consumer picker, actions zone, and close button. Used when multiple views share a panel (e.g. tools and extensions).
 
 ### Consumer contract (managed panels)
 
-Each consumer is a descriptor object passed in the `consumers` array:
+Each consumer is a descriptor object passed in the `views` array:
 
 ```js
 {
@@ -94,10 +94,10 @@ Each consumer is a descriptor object passed in the `consumers` array:
 
 Each consumer registered with a managed panel declares whether it is **first-party** or not:
 
-- **First-party consumers** (`firstParty: true`) are authored by the workspace team, fully trusted, and may expose header actions by implementing a `getHeaderActions()` method on the element returned by `load()`. The method should return an `HTMLElement` (or `null`/`undefined` to add nothing). It is called each time the consumer becomes active.
-- **Third-party / fragment consumers** are not authored by the team. They receive only the content area; they cannot add anything to the header. This is the default for extensions and external fragments.
+- **First-party views** (`firstParty: true`) are authored by the workspace team, fully trusted, and may expose header actions by implementing a `getHeaderActions()` method on the element returned by `load()`. The method should return an `HTMLElement` (or `null`/`undefined` to add nothing). It is called each time the consumer becomes active.
+- **Third-party / fragment views** are not authored by the team. They receive only the content area; they cannot add anything to the header. This is the default for extensions and external fragments.
 
-Consumer content is lazy-loaded on first activation and preserved across open/close cycles — switching consumers or hiding the panel does not reload content.
+Consumer content is lazy-loaded on first activation and preserved across open/close cycles — switching views or hiding the panel does not reload content.
 
 ---
 
@@ -117,7 +117,7 @@ The edit experience is implemented as the **`canvas`** block — there is not a 
 - Decorates the canvas region with **`nx-canvas-header`** (Lit toolbar: e.g. split icons for panel edges, undo/redo affordances).
 - Listens for panel open events from **`nx-canvas-header`** and opens the matching panel via **`panel.js`**. Owns a `CANVAS_PANELS` config object keyed by position — each entry carries a default `width` and a `getContent` callback. `openCanvasPanel(position)` does a config lookup and calls `openPanel` directly; no dependency on block-specific helpers like `openChatPanel`.
 - Owns the panel configuration for its context: which positions are supported and what `getContent` each panel uses. Browse or other page-level blocks define their own panel configurations independently.
-- Side regions use the same panel model: **`before`** / **`after`** asides can host in-context browser, history, metadata, outline, etc., registered as consumers through the managed panel — toggled from the header chrome or other entry points as the product defines.
+- Side regions use the same panel model: **`before`** / **`after`** asides can host in-context browser, history, metadata, outline, etc., registered as views through the managed panel — toggled from the header chrome or other entry points as the product defines.
 - Adopts **`canvas.css`** once on the document for light-DOM rules that apply outside the header shadow root.
 
 ### Browse Block
@@ -166,6 +166,6 @@ Chat receives host-pushed context (URL-derived workspace state + accumulated ite
 
 **Configured extensions** — we did not author them. Absent by default, sandboxed, minimal contract only.
 
-In the panel system this maps directly: core features are first-party consumers and may add actions to the managed panel header; configured extensions are third-party consumers and receive only the content area.
+In the panel system this maps directly: core features are first-party views and may add actions to the managed panel header; configured extensions are third-party views and receive only the content area.
 
 The API for third-party extensions is defined by the extensions SDK.

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -16,8 +16,10 @@ The following sections highlight some principles in more detail.
 ### Repository Layout
 - Experience workspace work lives under **`nx2/`** (alongside the CDN-mapped `nx/` tree).
 - The nx2 scripts and utils provide URL/state helpers, auth, and block loading (`nx2/scripts/nx.js`, `nx2/utils/`).
-- Feature code lives in **`nx2/blocks/`** — currently including **`canvas`** (the edit experience; not a separate edit block), **`chat`**, shell pieces (**`nav`**, **`sidenav`**, **`profile`**), **`fragment`** / **`dialog`**, and small helpers (**`action-button`**, **`canvas-actions`**). **`tool-panel`** is a placeholder block; tool UI is intended to ship inside loaded fragments.
+- Feature code lives in **`nx2/blocks/`** — currently including **`canvas`** (the edit experience; not a separate edit block), **`chat`**, shell pieces (**`nav`**, **`sidenav`**, **`profile`**), **`fragment`** / **`dialog`**, and small helpers (**`action-button`**, **`canvas-actions`**).
 - Shared shell behavior for app-frame side regions is implemented in **`nx2/utils/panel.js`** (DOM panel chrome, resize, show/hide, persistence), not as a separate `blocks/panel` Lit shell.
+- **`blocks/tool-panel`** provides the managed panel shell (`nx-tool-panel`): a picker to switch between consumers, a header-actions zone for first-party consumers, and a close button. Consumer content is lazy-loaded on first activation. Like chat, `nx-tool-panel` is position-agnostic — host blocks instantiate it and set its `consumers` array inside their own `getContent`.
+- **`blocks/chat`** has no public entry-point wrapper — host blocks mount `nx-chat` directly inside their own `getContent`.
 - When **`blocks/shared`** (or equivalent) exists, it should contain small, reusable pieces that make no assumptions about where they are invoked from.
 - Root **`Utils`** contains helpers such as the extension SDK client and DA API wrappers (`daFetch.js`: origins + `daFetch`).
 
@@ -49,7 +51,7 @@ nx2
 ├── blocks
 │   ├── canvas          (edit: nx-canvas-header, panel toggles, main editing layout)
 │   ├── chat
-│   ├── tool-panel      (placeholder; content from fragments)
+│   ├── tool-panel      (managed panel shell: picker, header-actions zone, consumer lifecycle)
 │   └── …               (e.g. browse when added as its own block)
 │
 └── utils
@@ -65,31 +67,37 @@ Skills Lab — external app at da.live/apps/skills, linked from Chat
 ## Side panels (app-frame)
 
 - Panels are **`aside.panel`** elements with **`data-position="before"`** (to the left of `main`) or **`"after"`** (to the right). Width is stored on the element; **`setPanelsGrid()`** updates CSS grid template vars on `body` when panels are visible.
-- **`openPanelWithFragment`** loads markup via **`loadPanelContent`** (fragment URLs or, for legacy paths, block modules), then **`showPanel`** mounts the shell and appends content into **`.panel-body`**.
-- **`hidePanel` / `unhidePanel`** toggle visibility without removing the node; hidden panels are omitted from the grid.
-- **`localStorage`** key **`nx-panels`** stores `{ before?, after? }` with width and fragment URL. **`restorePanels()`** is invoked from **`loadArea`** in **`nx2/scripts/nx.js`** when that key is present so panels return across reloads.
+- **`hidePanel` / `showPanel`** toggle visibility without removing the node; hidden panels are omitted from the grid. (`unhidePanel` is a legacy alias for `showPanel`.) Any consumer can close its panel by dispatching an **`nx-panel-close`** event — the panel frame handles it.
+- **`localStorage`** key **`nx-panels`** stores `{ before?, after? }` with width and (for fragment-based panels) fragment URL. **`restorePanels()`** is invoked from **`loadArea`** in **`nx2/scripts/nx.js`** for fragment-based panels; page blocks (e.g. canvas) restore their own typed panels directly on load.
+- **`openPanel({ position, width, getContent })`** is the single entry point for opening a panel programmatically. The caller provides a `getContent` async function that returns the element to mount in the panel body. This means the caller is fully responsible for what goes inside — whether that is a headless component like `nx-chat` or a managed shell like `nx-tool-panel`. `openPanel` handles the show/create/skip-if-visible logic and nothing else.
 
-### Panel header and custom actions
+### Two panel types
 
-When a panel is opened via `canvas.js`, **`addPanelHeader`** prepends a header bar (`.panel-header`) to `.panel-body` and fires an **`nx-panel-slot`** event on `.panel-body`:
+The distinction between panel types is a **caller convention**, not a framework concept.
+
+**Headless** — `getContent` returns a component that owns its entire layout: header, actions, close button. Used when a single, known first-party component permanently occupies the panel
+
+**Managed** — `getContent` imports and instantiates `nx-tool-panel`, sets its `consumers` array, and returns it. `nx-tool-panel` then owns the header with a consumer picker, actions zone, and close button. Used when multiple consumers share a panel (e.g. tools and extensions).
+
+### Consumer contract (managed panels)
+
+Each consumer is a descriptor object passed in the `consumers` array:
 
 ```js
-panelBody.dispatchEvent(new CustomEvent('nx-panel-slot', {
-  detail: { slot: header.querySelector('.panel-header-custom') },
-}));
+{
+  id: 'my-tool',       // unique string key
+  label: 'My Tool',    // shown in the picker
+  firstParty: true,    // omit or false for third-party
+  load: async () => element, // called once on first activation; must return an HTMLElement
+}
 ```
 
-Fragment content loaded into a panel can listen for this event in `connectedCallback` to register buttons into the header's left-side container:
+Each consumer registered with a managed panel declares whether it is **first-party** or not:
 
-```js
-// in connectedCallback
-this.closest('.panel-body')?.addEventListener('nx-panel-slot', (e) => {
-  this._panelSlot = e.detail.slot;
-  this._mountActions(); // called once both slot and icons are ready
-}, { once: true });
-```
+- **First-party consumers** (`firstParty: true`) are authored by the workspace team, fully trusted, and may expose header actions by implementing a `getHeaderActions()` method on the element returned by `load()`. The method should return an `HTMLElement` (or `null`/`undefined` to add nothing). It is called each time the consumer becomes active.
+- **Third-party / fragment consumers** are not authored by the team. They receive only the content area; they cannot add anything to the header. This is the default for extensions and external fragments.
 
-Buttons appended to the slot should use `className = 'panel-header-action'` to pick up the shared button styling defined in `nx-panel-header.css`. The `[hidden]` attribute is respected — set `btn.hidden = true/false` to show/hide conditionally.
+Consumer content is lazy-loaded on first activation and preserved across open/close cycles — switching consumers or hiding the panel does not reload content.
 
 ---
 
@@ -107,8 +115,9 @@ The edit experience is implemented as the **`canvas`** block — there is not a 
 
 - Owns the editing workspace: breadcrumbs, view mode (doc/wysiwyg/split), and layout state as those features land; composes editing-focused layouts around **`main`**.
 - Decorates the canvas region with **`nx-canvas-header`** (Lit toolbar: e.g. split icons for panel edges, undo/redo affordances).
-- Listens for **`nx-canvas-toggle-panel`** (`detail.position`: **`before`** | **`after`**) and calls **`toggleCanvasPanel`** in **`canvas.js`**: show or hide the matching **`aside.panel`**, or **`openPanelWithFragment`** with the configured fragment URL (e.g. chat before main, tool panel after main).
-- Side regions use the same panel model: **`before`** / **`after`** asides can host in-context browser, history, metadata, outline, etc., loaded as fragments or blocks through **`panel.js`** — toggled from the header chrome or other entry points as the product defines.
+- Listens for panel open events from **`nx-canvas-header`** and opens the matching panel via **`panel.js`**. Owns a `CANVAS_PANELS` config object keyed by position — each entry carries a default `width` and a `getContent` callback. `openCanvasPanel(position)` does a config lookup and calls `openPanel` directly; no dependency on block-specific helpers like `openChatPanel`.
+- Owns the panel configuration for its context: which positions are supported and what `getContent` each panel uses. Browse or other page-level blocks define their own panel configurations independently.
+- Side regions use the same panel model: **`before`** / **`after`** asides can host in-context browser, history, metadata, outline, etc., registered as consumers through the managed panel — toggled from the header chrome or other entry points as the product defines.
 - Adopts **`canvas.css`** once on the document for light-DOM rules that apply outside the header shadow root.
 
 ### Browse Block
@@ -120,7 +129,7 @@ The edit experience is implemented as the **`canvas`** block — there is not a 
 - Owns conversation state, tool execution, agent communication, and context item accumulator
 - Consumes workspace context (org, site, path, view) as read-only
 - Runs in Browse and in the edit (`canvas`) view with the same UI; only view context sent to the backend changes
-- In the app-frame experiment, the chat surface may be loaded as fragment content inside a **`before`** panel opened from the canvas header.
+- Chat is position-agnostic — host blocks (canvas, browse) decide to mount it in the `before` panel via their own `getContent`. Once mounted, chat owns its full internal layout: header, context-sensitive actions, and the close control.
 
 ### Shared Block
 Provides shared functionality for Browse, the edit (`canvas`) experience, and Chat. Examples, non-exhaustive:
@@ -156,5 +165,7 @@ Chat receives host-pushed context (URL-derived workspace state + accumulated ite
 **Core features** — we authored them. Always present, fully trusted, full context access. Configuration controls their behavior, never their existence.
 
 **Configured extensions** — we did not author them. Absent by default, sandboxed, minimal contract only.
+
+In the panel system this maps directly: core features are first-party consumers and may add actions to the managed panel header; configured extensions are third-party consumers and receive only the content area.
 
 The API for third-party extensions is defined by the extensions SDK.

--- a/nx2/blocks/browse/browse.css
+++ b/nx2/blocks/browse/browse.css
@@ -28,7 +28,44 @@
     min-width: 0;
   }
 
+  .browse-bar {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 40px;
+    padding: 0 var(--s2-spacing-100);
+
+    path {
+      fill: currentcolor;
+    }
+  }
+
+  .browse-panel-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: var(--s2-corner-radius-400);
+    background: transparent;
+    color: var(--s2-gray-800);
+    cursor: pointer;
+
+    svg {
+      display: block;
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    &:hover {
+      background-color: var(--s2-gray-75);
+    }
+  }
+
   .browse-hint {
+    margin: 0 var(--s2-spacing-300);
     padding: var(--s2-spacing-200);
     border-radius: var(--s2-corner-radius-300);
     background-color: var(--s2-gray-75);

--- a/nx2/blocks/browse/browse.js
+++ b/nx2/blocks/browse/browse.js
@@ -1,5 +1,7 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle, hashChange } from '../../utils/utils.js';
+import { loadHrefSvg, ICONS_BASE } from '../../utils/svg.js';
+import { getPanelStore, openPanel } from '../../utils/panel.js';
 import { listFolder } from './browse-api.js';
 import {
   contextToPathContext,
@@ -11,6 +13,7 @@ import '../shared/breadcrumb/breadcrumb.js';
 import './list/list.js';
 
 const styles = await loadStyle(import.meta.url);
+const panelIcon = await loadHrefSvg(`${ICONS_BASE}S2_Icon_SplitLeft_20_N.svg`);
 
 const documentLayoutStyles = await loadStyle(
   new URL('overrides.css', import.meta.url).href,
@@ -30,6 +33,14 @@ class NxBrowse extends LitElement {
     if (this.isConnected) {
       this._syncList();
     }
+  }
+
+  _openPanel(position) {
+    this.dispatchEvent(new CustomEvent('nx-browse-open-panel', {
+      bubbles: true,
+      composed: true,
+      detail: { position },
+    }));
   }
 
   connectedCallback() {
@@ -103,8 +114,21 @@ class NxBrowse extends LitElement {
   render() {
     const ctx = this._pathContext;
 
+    const bar = html`
+      <div class="browse-bar">
+        <button
+          type="button"
+          part="toggle-before"
+          class="browse-panel-toggle"
+          aria-label="Open panel"
+          @click=${() => this._openPanel('before')}
+        >${panelIcon ?? nothing}</button>
+      </div>
+    `;
+
     if (!ctx) {
       return html`
+        ${bar}
         <div class="browse-hint" role="status">
           <p class="browse-hint-title">Nothing to show here yet</p>
           <p class="browse-hint-detail">
@@ -117,7 +141,7 @@ class NxBrowse extends LitElement {
     const title = ctx.pathSegments.at(-1) ?? '';
 
     if (!this._listError && this._items === undefined) {
-      return nothing;
+      return bar;
     }
 
     const header = html`
@@ -131,6 +155,7 @@ class NxBrowse extends LitElement {
 
     if (this._listError) {
       return html`
+        ${bar}
         ${header}
         <div class="browse-hint browse-hint-error" role="alert">
           <p class="browse-hint-title">Could not load this folder</p>
@@ -142,6 +167,7 @@ class NxBrowse extends LitElement {
     const currentPathKey = ctx.pathSegments.join('/');
 
     return html`
+      ${bar}
       ${header}
       <nx-browse-list
         .items=${this._items}
@@ -158,5 +184,26 @@ if (!customElements.get('nx-browse')) {
 
 export default function decorate(block) {
   block.textContent = '';
-  block.append(document.createElement('nx-browse'));
+  const browse = document.createElement('nx-browse');
+  block.append(browse);
+
+  const openBrowseChatPanel = () => {
+    const store = getPanelStore();
+    const width = store.before?.width ?? '400px';
+    openPanel({
+      position: 'before',
+      width,
+      getContent: async () => {
+        await import('../chat/chat.js');
+        return document.createElement('nx-chat');
+      },
+    });
+  };
+
+  browse.addEventListener('nx-browse-open-panel', (e) => {
+    if (e.detail.position === 'before') openBrowseChatPanel();
+  });
+
+  const store = getPanelStore();
+  if (store.before) openBrowseChatPanel();
 }

--- a/nx2/blocks/browse/overrides.css
+++ b/nx2/blocks/browse/overrides.css
@@ -16,3 +16,9 @@ main:has(nx-browse) .browse {
   overflow: hidden;
   min-height: 0;
 }
+
+/* Hide the toggle when the before panel is already visible */
+html:has(aside.panel[data-position="before"]:not([hidden]))
+  nx-browse::part(toggle-before) {
+  display: none;
+}

--- a/nx2/blocks/canvas/canvas.css
+++ b/nx2/blocks/canvas/canvas.css
@@ -10,22 +10,6 @@ html:has(aside.panel[data-position="after"]:not([hidden])) nx-canvas-header::par
   display: none;
 }
 
-.fragment-content:has(nx-chat) {
-  height: 100%;
-
-  & .section {
-    height: 100%;
-  }
-
-  & .block-content {
-    height: 100%;
-  }
-}
-
-nx-chat {
-  height: 100%;
-}
-
 /* Single visible editor: Layout (doc) or Content (WYSIWYG); inactive uses [hidden] */
 .nx-canvas-editor-mount {
   display: flex;

--- a/nx2/blocks/canvas/canvas.js
+++ b/nx2/blocks/canvas/canvas.js
@@ -1,5 +1,5 @@
 import { loadStyle, hashChange } from '../../utils/utils.js';
-import { hidePanel, unhidePanel, openPanelWithFragment } from '../../utils/panel.js';
+import { getPanelStore, openPanel } from '../../utils/panel.js';
 import './nx-canvas-header/nx-canvas-header.js';
 import './nx-editor-doc/nx-editor-doc.js';
 import './nx-editor-wysiwyg/nx-editor-wysiwyg.js';
@@ -12,11 +12,6 @@ function buildCanvasDocPath(state) {
   if (!org || !site || !path) return null;
   return `${org}/${site}/${path}`;
 }
-
-const FRAGMENTS = {
-  before: 'https://da.live/fragments/exp-workspace/chat',
-  after: 'https://da.live/fragments/exp-workspace/tool',
-};
 
 const CANVAS_EDITOR_VIEW_KEY = 'nx-canvas-editor-view';
 
@@ -97,41 +92,39 @@ function syncCanvasEditorsToHash({ mountRoot, header, state }) {
   notifyCanvasEditorActive(mountRoot, header.editorView);
 }
 
-async function addPanelHeader(aside) {
-  const { default: createPanelHeader } = await import('./nx-panel-header/nx-panel-header.js');
-  const header = await createPanelHeader({
-    position: aside.dataset.position,
-    onClose: () => hidePanel(aside),
-  });
-  const panelBody = aside.querySelector('.panel-body');
-  panelBody.prepend(header);
-
-  // to enable adding actions to the header
-  panelBody.dispatchEvent(new CustomEvent('nx-panel-slot', {
-    detail: { slot: header.querySelector('.panel-header-custom') },
-  }));
-}
+const CANVAS_PANELS = {
+  before: {
+    width: '400px',
+    getContent: async () => {
+      await import('../chat/chat.js');
+      return document.createElement('nx-chat');
+    },
+  },
+  after: {
+    width: '400px',
+    getContent: async () => {
+      const { loadFragment } = await import('../fragment/fragment.js');
+      await import('../tool-panel/tool-panel.js');
+      const toolPanel = document.createElement('nx-tool-panel');
+      toolPanel.consumers = [
+        {
+          id: 'tools',
+          label: 'Tools',
+          firstParty: false,
+          load: () => loadFragment('https://da.live/fragments/exp-workspace/tool'),
+        },
+      ];
+      return toolPanel;
+    },
+  },
+};
 
 async function openCanvasPanel(position) {
-  // Case 1: Panel is visible
-  const existing = document.querySelector(`aside.panel[data-position="${position}"]`);
-  if (existing && !existing.hidden) return;
-
-  // Case 2: Panel is hidden
-  if (existing?.hidden) {
-    unhidePanel(existing);
-    return;
-  }
-
-  // Case 3: Panel does not exist yet
-  const aside = await openPanelWithFragment({
-    width: '400px',
-    beforeMain: position === 'before',
-    fragment: FRAGMENTS[position],
-  });
-
-  // Add header to panel after crating
-  addPanelHeader(aside);
+  const config = CANVAS_PANELS[position];
+  if (!config) return;
+  const store = getPanelStore();
+  const width = store[position]?.width ?? config.width;
+  await openPanel({ position, width, getContent: config.getContent });
 }
 
 function installCanvasHeader(block) {
@@ -159,11 +152,8 @@ export default async function decorate(block) {
     syncCanvasEditorsToHash({ mountRoot, header, state });
   });
 
-  document.addEventListener('nx-panels-restored', () => {
-    document.querySelectorAll('aside.panel').forEach((aside) => {
-      if (FRAGMENTS[aside.dataset.position] === aside.dataset.fragment) {
-        addPanelHeader(aside);
-      }
-    });
-  });
+  // Restore any panels that were open in the previous session.
+  const store = getPanelStore();
+  if (store.before) openCanvasPanel('before');
+  if (store.after) openCanvasPanel('after');
 }

--- a/nx2/blocks/canvas/canvas.js
+++ b/nx2/blocks/canvas/canvas.js
@@ -103,17 +103,9 @@ const CANVAS_PANELS = {
   after: {
     width: '400px',
     getContent: async () => {
-      const { loadFragment } = await import('../fragment/fragment.js');
       await import('../tool-panel/tool-panel.js');
       const toolPanel = document.createElement('nx-tool-panel');
-      toolPanel.consumers = [
-        {
-          id: 'tools',
-          label: 'Tools',
-          firstParty: false,
-          load: () => loadFragment('https://da.live/fragments/exp-workspace/tool'),
-        },
-      ];
+      toolPanel.views = [];
       return toolPanel;
     },
   },

--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -8,7 +8,6 @@
   font-family: var(--s2-font-family);
   color: var(--s2-gray-800);
   font-weight: var(--s2-body-font-weight);
-  margin: 0 auto;
   box-sizing: border-box;
   align-items: center;
 

--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -1,6 +1,8 @@
 :host {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   gap: var(--s2-spacing-300);
   padding: var(--s2-spacing-200) 0;
   font-family: var(--s2-font-family);
@@ -21,6 +23,10 @@
     padding: var(--s2-spacing-75);
     border-radius: var(--s2-corner-radius-300);
     background-color: var(--s2-gray-300);
+  }
+
+  path {
+    fill: currentcolor;
   }
 
   button {
@@ -63,6 +69,56 @@
     resize: none;
     border: none;
     outline: none;
+  }
+}
+
+.chat-actions svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0 var(--s2-spacing-300);
+  box-sizing: border-box;
+  justify-content: flex-end;
+  gap: var(--s2-spacing-300);
+
+  .chat-header-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--s2-spacing-75);
+    min-width: 24px;
+    min-height: 24px;
+    border: none;
+    border-radius: var(--s2-corner-radius-400);
+    background: transparent;
+    color: var(--s2-gray-800);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--s2-body-size-s);
+
+    &.clear-btn {
+      padding: 0 var(--s2-spacing-100);
+    }
+
+    svg {
+      display: block;
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    &:hover {
+      background-color: var(--s2-gray-75);
+    }
+
+    &[hidden] {
+      display: none;
+    }
   }
 }
 
@@ -222,11 +278,6 @@
     justify-content: center;
     align-items: center;
     display: none;
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
   }
 
   .chat-add {

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -50,18 +50,8 @@ class NxChat extends LitElement {
     this._controller?.clear();
   }
 
-  // Runs when the panel header slot is ready
-  _mountClearBtn() {
-    if (!this._panelSlot || this._clearBtn) return;
-    const btn = document.createElement('button');
-    btn.className = 'panel-header-action';
-    btn.setAttribute('aria-label', 'Clear chat');
-    btn.hidden = !this.messages?.length;
-    if (icons.clear) btn.append(icon('clear'));
-    btn.append(Object.assign(document.createElement('span'), { textContent: 'Clear' }));
-    btn.addEventListener('click', () => this.clear());
-    this._clearBtn = btn;
-    this._panelSlot.append(btn);
+  _closePanel() {
+    this.dispatchEvent(new CustomEvent('nx-panel-close', { bubbles: true, composed: true }));
   }
 
   async _loadPrompts() {
@@ -77,11 +67,6 @@ class NxChat extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [styles];
-
-    this.closest('.panel-body')?.addEventListener('nx-panel-slot', ({ detail }) => {
-      this._panelSlot = detail.slot;
-      this._mountClearBtn();
-    }, { once: true });
 
     this._controller = new ChatController({
       onToolDone: () => {
@@ -147,8 +132,6 @@ class NxChat extends LitElement {
     if (changed.has('thinking') && !this.thinking && changed.get('thinking')) {
       this.shadowRoot.querySelector('.chat-input')?.focus();
     }
-    if (this._clearBtn) this._clearBtn.hidden = !this.messages?.length;
-
     if (changed.has('toolCards')) {
       if (this._pendingApproval()) {
         document.addEventListener('keydown', this._onApprovalKeydown);
@@ -228,6 +211,21 @@ class NxChat extends LitElement {
           .onSend=${(p) => this._sendPrompt(p)}
         ></nx-prompts>
       </nx-popover>
+      <div class="chat-header">
+        <button
+          type="button"
+          class="chat-header-btn clear-btn"
+          aria-label="Clear chat"
+          ?hidden=${!this.messages?.length}
+          @click=${() => this.clear()}
+        >${icon('clear')}<span>Clear</span></button>
+        <button
+          type="button"
+          class="chat-header-btn"
+          aria-label="Close chat panel"
+          @click=${this._closePanel}
+        >${icon('close')}</button>
+      </div>
       <div class="chat-scroll-container">
         <div class="chat-messages-container" role="log" aria-live="polite">
           ${!this.messages?.length && !this.thinking

--- a/nx2/blocks/chat/constants.js
+++ b/nx2/blocks/chat/constants.js
@@ -13,7 +13,7 @@ const ADD_MENU_ITEMS = [
 ];
 
 const CHAT_ICONS = {
-  add: 'Add', clear: 'RemoveCircle', send: 'ArrowUpSend', stop: 'Stop', up: 'ChevronUp',
+  add: 'Add', clear: 'RemoveCircle', close: 'SplitLeft', send: 'ArrowUpSend', stop: 'Stop', up: 'ChevronUp',
 };
 
 /**

--- a/nx2/blocks/tool-panel/tool-panel.css
+++ b/nx2/blocks/tool-panel/tool-panel.css
@@ -1,0 +1,66 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: var(--s2-font-family);
+  overflow: hidden;
+}
+
+.tool-panel-header {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  min-height: 48px;
+  padding: 0 var(--s2-spacing-100);
+  border-bottom: 1px solid var(--s2-gray-200);
+}
+
+.tool-panel-header-actions {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-75);
+  justify-content: flex-end;
+  padding-right: var(--s2-spacing-75);
+}
+
+.tool-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: var(--s2-corner-radius-400);
+  background: transparent;
+  color: var(--s2-gray-800);
+  cursor: pointer;
+
+  svg {
+    display: block;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    background-color: var(--s2-gray-75);
+  }
+}
+
+.tool-panel-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+
+  > * {
+    flex: 1;
+    min-height: 0;
+  }
+
+  > [hidden] {
+    display: none;
+  }
+}

--- a/nx2/blocks/tool-panel/tool-panel.js
+++ b/nx2/blocks/tool-panel/tool-panel.js
@@ -1,3 +1,92 @@
-export default function decorate() {
-  // placeholder
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../utils/utils.js';
+import { loadHrefSvg, ICONS_BASE } from '../../utils/svg.js';
+import '../shared/picker/picker.js';
+
+const style = await loadStyle(import.meta.url);
+const closeIcon = await loadHrefSvg(`${ICONS_BASE}S2_Icon_SplitRight_20_N.svg`);
+
+class NxToolPanel extends LitElement {
+  static properties = {
+    consumers: { attribute: false },
+    activeId: { type: String },
+  };
+
+  _loaded = {};
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [style];
+  }
+
+  async firstUpdated() {
+    if (this.consumers?.length && !this.activeId) {
+      await this._activate(this.consumers[0].id);
+    }
+  }
+
+  async updated(changed) {
+    if (changed.has('consumers') && this.consumers?.length && !this.activeId) {
+      await this._activate(this.consumers[0].id);
+    }
+    if (changed.has('activeId')) {
+      this._syncContent();
+      this._syncHeaderActions();
+    }
+  }
+
+  async _activate(id) {
+    const consumer = this.consumers?.find((c) => c.id === id);
+    if (!consumer) return;
+    if (!this._loaded[id]) {
+      this._loaded[id] = await consumer.load();
+    }
+    this.activeId = id;
+  }
+
+  _syncContent() {
+    const content = this.shadowRoot.querySelector('.tool-panel-content');
+    if (!content) return;
+    Object.entries(this._loaded).forEach(([id, el]) => {
+      el.hidden = id !== this.activeId;
+      if (id === this.activeId && !content.contains(el)) content.append(el);
+    });
+  }
+
+  _syncHeaderActions() {
+    const zone = this.shadowRoot.querySelector('.tool-panel-header-actions');
+    if (!zone) return;
+    zone.textContent = '';
+    const consumer = this.consumers?.find((c) => c.id === this.activeId);
+    if (!consumer?.firstParty) return;
+    const el = this._loaded[this.activeId];
+    const actions = el?.getHeaderActions?.();
+    if (actions) zone.append(actions);
+  }
+
+  _close() {
+    this.dispatchEvent(new CustomEvent('nx-panel-close', { bubbles: true, composed: true }));
+  }
+
+  render() {
+    const items = this.consumers?.map((c) => ({ value: c.id, label: c.label })) ?? [];
+
+    return html`
+      <div class="tool-panel-header">
+        <button type="button" class="tool-panel-close" aria-label="Close panel" @click=${this._close}>
+          ${closeIcon ?? nothing}
+        </button>
+        <nx-picker
+          .items=${items}
+          .value=${this.activeId}
+          placement="below-start"
+          @change=${(e) => this._activate(e.detail.value)}
+        ></nx-picker>
+        <div class="tool-panel-header-actions"></div>
+      </div>
+      <div class="tool-panel-content"></div>
+    `;
+  }
 }
+
+customElements.define('nx-tool-panel', NxToolPanel);

--- a/nx2/blocks/tool-panel/tool-panel.js
+++ b/nx2/blocks/tool-panel/tool-panel.js
@@ -8,7 +8,7 @@ const closeIcon = await loadHrefSvg(`${ICONS_BASE}S2_Icon_SplitRight_20_N.svg`);
 
 class NxToolPanel extends LitElement {
   static properties = {
-    consumers: { attribute: false },
+    views: { attribute: false },
     activeId: { type: String },
   };
 
@@ -20,14 +20,14 @@ class NxToolPanel extends LitElement {
   }
 
   async firstUpdated() {
-    if (this.consumers?.length && !this.activeId) {
-      await this._activate(this.consumers[0].id);
+    if (this.views?.length && !this.activeId) {
+      await this._activate(this.views[0].id);
     }
   }
 
   async updated(changed) {
-    if (changed.has('consumers') && this.consumers?.length && !this.activeId) {
-      await this._activate(this.consumers[0].id);
+    if (changed.has('views') && this.views?.length && !this.activeId) {
+      await this._activate(this.views[0].id);
     }
     if (changed.has('activeId')) {
       this._syncContent();
@@ -36,7 +36,7 @@ class NxToolPanel extends LitElement {
   }
 
   async _activate(id) {
-    const consumer = this.consumers?.find((c) => c.id === id);
+    const consumer = this.views?.find((c) => c.id === id);
     if (!consumer) return;
     if (!this._loaded[id]) {
       this._loaded[id] = await consumer.load();
@@ -57,7 +57,7 @@ class NxToolPanel extends LitElement {
     const zone = this.shadowRoot.querySelector('.tool-panel-header-actions');
     if (!zone) return;
     zone.textContent = '';
-    const consumer = this.consumers?.find((c) => c.id === this.activeId);
+    const consumer = this.views?.find((c) => c.id === this.activeId);
     if (!consumer?.firstParty) return;
     const el = this._loaded[this.activeId];
     const actions = el?.getHeaderActions?.();
@@ -69,7 +69,7 @@ class NxToolPanel extends LitElement {
   }
 
   render() {
-    const items = this.consumers?.map((c) => ({ value: c.id, label: c.label })) ?? [];
+    const items = this.views?.map((c) => ({ value: c.id, label: c.label })) ?? [];
 
     return html`
       <div class="tool-panel-header">

--- a/nx2/utils/panel.js
+++ b/nx2/utils/panel.js
@@ -110,6 +110,12 @@ function resizePointerDown(downEvent) {
   handle.addEventListener('pointercancel', onPointerUp);
 }
 
+export function hidePanel(aside) {
+  removePanelState(aside.dataset.position);
+  aside.hidden = true;
+  setPanelsGrid();
+}
+
 function buildPanelDOM(aside) {
   const edge = aside.dataset.position === 'before' ? 'trailing' : 'leading';
 
@@ -131,8 +137,10 @@ function buildPanelDOM(aside) {
   shell.append(body);
   wrapper.append(shell, handle);
   aside.append(wrapper);
-}
 
+  // Allow any consumer inside the panel to close it by firing nx-panel-close.
+  aside.addEventListener('nx-panel-close', () => hidePanel(aside));
+}
 export function createPanel({ width = '400px', beforeMain = false, content, fragment } = {}) {
   const aside = document.createElement('aside');
   aside.classList.add('panel');
@@ -157,13 +165,7 @@ export function createPanel({ width = '400px', beforeMain = false, content, frag
   return aside;
 }
 
-export function hidePanel(aside) {
-  removePanelState(aside.dataset.position);
-  aside.hidden = true;
-  setPanelsGrid();
-}
-
-export function unhidePanel(aside) {
+export function showPanel(aside) {
   aside.hidden = false;
   savePanelState(aside.dataset.position, {
     width: aside.dataset.width,
@@ -172,9 +174,10 @@ export function unhidePanel(aside) {
   setPanelsGrid();
 }
 
-export { getPanelStore };
+// unhidePanel: legacy alias for showPanel, kept pending a full rename across all callers.
+export { getPanelStore, showPanel as unhidePanel };
 
-export function showPanel(opts) {
+function mountPanel(opts) {
   const aside = createPanel(opts);
   setPanelsGrid();
   return aside;
@@ -194,7 +197,7 @@ export async function loadPanelContent(value) {
 export async function openPanelWithFragment({ width = '400px', beforeMain = false, fragment } = {}) {
   const { content, fragment: persistedFragment } = await loadPanelContent(fragment);
   if (!content) return undefined;
-  return showPanel({ width, beforeMain, content, fragment: persistedFragment });
+  return mountPanel({ width, beforeMain, content, fragment: persistedFragment });
 }
 
 export async function restorePanels() {
@@ -205,9 +208,22 @@ export async function restorePanels() {
       const { content, fragment: frag } = await loadPanelContent(fragment);
       if (content) {
         const beforeMain = position === 'before';
-        showPanel({ width, beforeMain, content, fragment: frag });
+        mountPanel({ width, beforeMain, content, fragment: frag });
       }
     }
   }
   document.dispatchEvent(new CustomEvent('nx-panels-restored'));
+}
+
+export async function openPanel({ position, width = '400px', getContent } = {}) {
+  const existing = document.querySelector(`aside.panel[data-position="${position}"]`);
+  if (existing && !existing.hidden) return existing;
+  if (existing?.hidden) {
+    showPanel(existing);
+    return existing;
+  }
+
+  const beforeMain = position === 'before';
+  const content = await getContent();
+  return mountPanel({ width, beforeMain, content });
 }

--- a/nx2/utils/panel.js
+++ b/nx2/utils/panel.js
@@ -224,6 +224,6 @@ export async function openPanel({ position, width = '400px', getContent } = {}) 
   }
 
   const beforeMain = position === 'before';
-  const content = await getContent();
+  const content = await getContent?.();
   return mountPanel({ width, beforeMain, content });
 }


### PR DESCRIPTION
- Refactors the panel system to remove the nx-panel-header intermediate layer and simplify panel open/close
- Introduces NxToolPanel (was a placeholder): managed shell with a consumer picker, lazy-loaded consumer content, first-party header-actions zone, and close button
- Updates chat to fully own the panel content including header with close
- Updates browse to have chat toggle similar to canvas

Preview: 
https://da.live/canvas?nx=ew-panels&nxver=2#/exp-workspace/frescopa/index
https://da.live/browse?nx=ew-panels&nxver=2#/aem-sandbox/block-collection/drafts
