### PR TITLE
fix: avoid using fragment panels

### DIFF
--- a/nx2/blocks/canvas/canvas.js
+++ b/nx2/blocks/canvas/canvas.js
@@ -157,7 +157,7 @@ export default async function decorate(block) {
     syncCanvasEditorsToHash({ mountRoot, header, state });
   });
 
-  // Restore panels opened by canvas (no fragment URL). Fragment-based entries are legacy
+  // Restore panels opened by canvas (no fragment URL)
   // data handled by restorePanels() in nx.js.
   const store = getPanelStore();
   if (store.before && !store.before.fragment) openCanvasPanel('before');

--- a/nx2/blocks/canvas/canvas.js
+++ b/nx2/blocks/canvas/canvas.js
@@ -157,8 +157,9 @@ export default async function decorate(block) {
     syncCanvasEditorsToHash({ mountRoot, header, state });
   });
 
-  // Restore any panels that were open in the previous session.
+  // Restore panels opened by canvas (no fragment URL). Fragment-based entries are legacy
+  // data handled by restorePanels() in nx.js.
   const store = getPanelStore();
-  if (store.before) openCanvasPanel('before');
-  if (store.after) openCanvasPanel('after');
+  if (store.before && !store.before.fragment) openCanvasPanel('before');
+  if (store.after && !store.after.fragment) openCanvasPanel('after');
 }


### PR DESCRIPTION
Previous panel stored as fragment and current implementation are creating duplicates -> fix to avoid using previously stored fragments within canvas

Preview: https://da.live/canvas?nx=ew-panels&nxver=2#/exp-workspace/frescopa/index
