### PR TITLE
fix: Listen for correct message before init

### DIFF
--- a/nx/utils/sdk.js
+++ b/nx/utils/sdk.js
@@ -45,12 +45,19 @@ function getSelection() {
 }
 
 const DA_SDK = (() => new Promise((resolve) => {
+  let initialized = false;
   window.addEventListener('message', (e) => {
-    if (e.data) {
-      if (e.data.ready) {
-        [port2] = e.ports;
-        setTitle(document.title);
-      }
+    if (!e.data) return;
+
+    // The parent's init message carries a transferred MessagePort and
+    // `ready: true`. Filtering on both lets us ignore stray messages from
+    // browser extensions, devtools content scripts, IMS, analytics, etc.,
+    // any of which can otherwise win the race in the ~750ms before the
+    // parent posts and resolve the SDK with a context-less payload.
+    if (!initialized && e.data.ready && e.ports?.length) {
+      initialized = true;
+      [port2] = e.ports;
+      setTitle(document.title);
 
       if (e.data.token) {
         setImsDetails(e.data.token);
@@ -67,6 +74,13 @@ const DA_SDK = (() => new Promise((resolve) => {
       };
 
       resolve({ ...e.data, actions });
+      return;
+    }
+
+    // Subsequent messages (e.g., token refresh) — keep IMS details current
+    // but do not re-resolve or rebind port2.
+    if (initialized && e.data.token) {
+      setImsDetails(e.data.token);
     }
   });
 }))();


### PR DESCRIPTION
Since DA_SDK has a generic eventlistener for "message" sometimes other messages can fire before the nx one does.   This makes sure that we are getting the correct message.
