### PR TITLE
MWPW-194048 Icons with hyphens are not retained in GlaaS flow

### DIFF
--- a/nx/blocks/loc/connectors/glaas/dnt.js
+++ b/nx/blocks/loc/connectors/glaas/dnt.js
@@ -256,8 +256,10 @@ function resetIcons(doc) {
   const icons = doc.querySelectorAll('span.icon');
   icons.forEach((icon) => {
     const parent = icon.parentElement;
-    const name = icon.classList[1].split('-')[1];
-    const textIcon = document.createTextNode(`:${name}:`);
+    const iconClass = [...icon.classList].find((cls) => cls.startsWith('icon-'));
+    if (!iconClass) return;
+    const name = iconClass.split('-').slice(1).join('-');
+    const textIcon = doc.createTextNode(`:${name}:`);
     parent.replaceChild(textIcon, icon);
   });
 }


### PR DESCRIPTION
When the page has icons with hyphens these are not retained. Copied the resetIcons code from loc/dnt.js to glaas/dnt.js

Fix #MWPW-194048
