### PR TITLE
fix: [dasc] Use dialog & overlay and handle non structured content documents. 

### DIFF
--- a/nx/blocks/form/form.css
+++ b/nx/blocks/form/form.css
@@ -41,29 +41,11 @@ sl-textarea {
     align-self: flex-start;
   }
 
-  /* Schema picker card */
-  .da-form-schema-panel {
-    box-sizing: border-box;
-    border-radius: var(--sl-border-radius-large, 8px);
-    background: var(--sl-color-neutral-0, #fff);
-    border: 1px solid var(--sl-color-neutral-200, #e2e8f0);
-    box-shadow: none;
-    padding: var(--sl-spacing-2x-large, 24px);
-  }
-
   .da-form-schema-hint {
     margin: 0 0 var(--sl-spacing-medium, 12px);
     font-size: var(--sl-font-size-small, 0.875rem);
     line-height: var(--sl-line-height-normal, 1.5);
     color: var(--sl-color-neutral-600, #64748b);
-  }
-
-  .da-form-schema-heading {
-    margin: 0 0 var(--sl-spacing-x-large, 16px);
-    font-size: var(--sl-font-size-x-large, 1.25rem);
-    font-weight: 700;
-    line-height: 1.3;
-    color: var(--sl-color-neutral-900, #0f172a);
   }
 
   .da-form-schema-form {

--- a/nx/blocks/form/form.css
+++ b/nx/blocks/form/form.css
@@ -21,12 +21,6 @@ sl-textarea {
     justify-content: center;
   }
 
-  .da-form-title {
-    line-height: 1;
-    font-weight: 700;
-    margin: 0 0 8px;
-  }
-
   .da-form-editor {
     flex: 1 1 700px;
     width: 700px;
@@ -47,32 +41,14 @@ sl-textarea {
     align-self: flex-start;
   }
 
-  /* Schema picker — centered card: title, labeled select, full-width Start */
-  .da-form-schema-shell {
-    flex: 1 1 700px;
-    width: 700px;
-    min-width: 0;
-    max-width: 700px;
-  }
-
-  &.da-form-wrapper-centered .da-form-schema-shell {
-    flex: 0 1 480px;
-    width: min(480px, 100%);
-    max-width: 480px;
-  }
-
-  .da-form-schema-card {
+  /* Schema picker card */
+  .da-form-schema-panel {
     box-sizing: border-box;
-    border-radius: var(--sl-border-radius-x-large, 12px);
+    border-radius: var(--sl-border-radius-large, 8px);
     background: var(--sl-color-neutral-0, #fff);
-    box-shadow:
-      rgb(0 0 0 / 8%) 0 4px 24px,
-      rgb(0 0 0 / 6%) 0 1px 3px;
-    padding: var(--sl-spacing-3x-large, 36px);
-  }
-
-  .da-form-schema-card .da-form-title {
-    margin: 0 0 var(--sl-spacing-2x-small, 4px);
+    border: 1px solid var(--sl-color-neutral-200, #e2e8f0);
+    box-shadow: none;
+    padding: var(--sl-spacing-2x-large, 24px);
   }
 
   .da-form-schema-hint {
@@ -93,31 +69,17 @@ sl-textarea {
   .da-form-schema-form {
     display: flex;
     flex-direction: column;
-    gap: var(--sl-spacing-x-large, 16px);
+    gap: var(--sl-spacing-medium, 12px);
     align-items: stretch;
   }
 
-  /* Empty-state CTA only (no schemas) */
-  .da-form-schema-field {
-    padding: var(--sl-spacing-large, 16px) var(--sl-spacing-medium, 12px);
+  .da-form-schema-form .da-form-schema-hint {
     margin: 0;
-    border: 2px dashed var(--sl-color-neutral-300, #cbd5e1);
-    border-radius: var(--sl-border-radius-large, 8px);
-    text-align: left;
-    background: var(--sl-color-neutral-50, #f8fafc);
-    transition:
-      border-color 0.15s ease,
-      background-color 0.15s ease;
-
-    &:hover {
-      border-color: var(--sl-color-primary-600, #2563eb);
-      background: var(--sl-color-primary-50, #eff6ff);
-    }
   }
 
-  .da-form-schema-field-link {
-    text-align: center;
-    padding: var(--sl-spacing-large, 16px);
+  .da-form-schema-actions {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .da-form-schema-select {
@@ -126,41 +88,20 @@ sl-textarea {
   }
 
   sl-button.da-form-schema-start {
-    display: block;
-    width: 100%;
+    display: inline-block;
+    width: auto;
   }
 
   sl-button.da-form-schema-start::part(wrap) {
-    display: block;
-    width: 100%;
+    display: inline-block;
+    width: auto;
   }
 
   sl-button.da-form-schema-start::part(base) {
-    width: 100%;
+    width: auto;
+    min-width: 96px;
     box-sizing: border-box;
     justify-content: center;
     border-radius: var(--s2-radius-100, 8px);
-  }
-
-  .da-form-schema-cta {
-    display: inline-block;
-    padding: var(--sl-spacing-small, 8px) var(--sl-spacing-large, 16px);
-    background: var(--sl-color-primary-600, #2563eb);
-    color: var(--sl-color-neutral-0, #fff);
-    border: none;
-    border-radius: var(--sl-border-radius-medium, 6px);
-    font-weight: var(--sl-font-weight-semibold, 600);
-    font-size: var(--sl-font-size-small, 0.875rem);
-    text-decoration: none;
-    cursor: pointer;
-    transition: background 0.15s ease;
-
-    &:hover {
-      background: var(--sl-color-primary-700, #1d4ed8);
-    }
-
-    &:active {
-      background: var(--sl-color-primary-800, #1e40af);
-    }
   }
 }

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -14,6 +14,7 @@ import 'https://da.live/blocks/edit/da-title/da-title.js';
 import './views/editor.js';
 import './views/sidebar.js';
 import './views/preview.js';
+import './views/dialog.js';
 
 // External Web Components
 await import('../../public/sl/components.js');
@@ -31,6 +32,7 @@ class FormEditor extends LitElement {
     details: { attribute: false },
     formModel: { state: true },
     _schemas: { state: true },
+    _isUnstructuredDoc: { state: true },
     _activeNavPointer: { state: true },
     _scrollEditorIntoView: { state: true },
     _scrollNavItemIntoView: { state: true },
@@ -39,6 +41,7 @@ class FormEditor extends LitElement {
 
   constructor() {
     super();
+    this._isUnstructuredDoc = false;
     this._pendingSchemaId = '';
   }
 
@@ -49,6 +52,16 @@ class FormEditor extends LitElement {
   }
 
   async fetchDoc() {
+    if (this.details?.depth <= 2) {
+      this._isUnstructuredDoc = true;
+      this.formModel = null;
+      this._pendingSchemaId = '';
+      this._activeNavPointer = undefined;
+      this._scrollEditorIntoView = undefined;
+      this._scrollNavItemIntoView = undefined;
+      return;
+    }
+
     const resultPromise = loadHtml(this.details);
 
     const [schemas, result] = await Promise.all([schemasPromise, resultPromise]);
@@ -56,6 +69,7 @@ class FormEditor extends LitElement {
     if (schemas) this._schemas = schemas;
 
     if (!result.html) {
+      this._isUnstructuredDoc = false;
       this.formModel = null;
       this._pendingSchemaId = '';
       this._activeNavPointer = undefined;
@@ -65,10 +79,24 @@ class FormEditor extends LitElement {
     }
 
     const path = this.details.fullpath;
+    const model = new FormModel({ path, html: result.html, schemas });
+    const metadata = JSON.parse(model.getSerializedJson()).metadata ?? {};
+
+    if (Object.keys(metadata).length === 0) {
+      this._isUnstructuredDoc = true;
+      this.formModel = null;
+      this._pendingSchemaId = '';
+      this._activeNavPointer = undefined;
+      this._scrollEditorIntoView = undefined;
+      this._scrollNavItemIntoView = undefined;
+      return;
+    }
+
+    this._isUnstructuredDoc = false;
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
     this._scrollNavItemIntoView = undefined;
-    this.formModel = new FormModel({ path, html: result.html, schemas });
+    this.formModel = model;
   }
 
   _onPendingSchemaChange(e) {
@@ -93,7 +121,13 @@ class FormEditor extends LitElement {
   }
 
   _confirmSchemaStart() {
+    this.renderRoot.querySelector('da-form-dialog')?.close();
     this._applySelectedSchema(this._pendingSchemaId);
+  }
+
+  _goToRepoRoot() {
+    const query = window.location.search ?? '';
+    window.location.href = `https://da.live${query}#/${this.details.owner}/${this.details.repo}`;
   }
 
   get schemaEditorHref() {
@@ -181,8 +215,7 @@ class FormEditor extends LitElement {
     const emptyLabel = hasSchemas ? 'Select a schema' : 'No schemas available yet';
 
     return html`
-      <div class="da-form-schema-panel">
-        <h2 class="da-form-schema-heading">Choose a schema</h2>
+      <da-form-dialog title="Choose a schema">
         <div class="da-form-schema-form">
           <sl-select
             hoist
@@ -198,7 +231,7 @@ class FormEditor extends LitElement {
             `)}
           </sl-select>
           <p class="da-form-schema-hint">
-            Need a new schema? Create one in
+            To create a new schema, open
             <a href=${this.schemaEditorHref} target="_blank" rel="noopener noreferrer">Schema Editor</a>.
           </p>
           <div class="da-form-schema-actions">
@@ -206,31 +239,49 @@ class FormEditor extends LitElement {
               class="da-form-schema-start"
               ?disabled=${!this._pendingSchemaId}
               @click=${this._confirmSchemaStart}
-            >Start</sl-button>
+            >Create</sl-button>
           </div>
         </div>
-      </div>`;
+      </da-form-dialog>`;
+  }
+
+  renderUnstructuredDialog() {
+    const message = 'The item at this path is not a structured content.';
+
+    return html`
+      <da-form-dialog title="Document not found">
+        <p class="da-form-schema-hint">
+          ${message}
+        </p>
+        <div class="da-form-schema-actions">
+          <sl-button class="da-form-schema-start" title="" @click=${this._goToRepoRoot}>Return to Home</sl-button>
+        </div>
+      </da-form-dialog>`;
   }
 
   renderFormEditor() {
+    if (this._isUnstructuredDoc) {
+      return this.renderUnstructuredDialog();
+    }
+
+    if (this.formModel === null) {
+      return this.renderSchemaSelector();
+    }
+
     return html`
       <div class="da-form-editor">
-        ${this.formModel === null
-        ? this.renderSchemaSelector()
-        : html`
-            <da-form-editor
-              @update=${this.handleUpdate}
-              @add-item=${this.handleAddItem}
-              @insert-item=${this.handleInsertItem}
-              @remove-item=${this.handleRemoveItem}
-              @move-array-item=${this.handleMoveArrayItem}
-              @nav-pointer-select=${this._handleNavPointerSelectFromEditor}
-              .formModel=${this.formModel}
-              .activeNavPointer=${this._activeNavPointer}
-              .scrollEditorIntoView=${this._scrollEditorIntoView}
-            ></da-form-editor>
-            <da-form-preview .formModel=${this.formModel}></da-form-preview>
-          `}
+        <da-form-editor
+          @update=${this.handleUpdate}
+          @add-item=${this.handleAddItem}
+          @insert-item=${this.handleInsertItem}
+          @remove-item=${this.handleRemoveItem}
+          @move-array-item=${this.handleMoveArrayItem}
+          @nav-pointer-select=${this._handleNavPointerSelectFromEditor}
+          .formModel=${this.formModel}
+          .activeNavPointer=${this._activeNavPointer}
+          .scrollEditorIntoView=${this._scrollEditorIntoView}
+        ></da-form-editor>
+        <da-form-preview .formModel=${this.formModel}></da-form-preview>
       </div>`;
   }
 

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -96,6 +96,10 @@ class FormEditor extends LitElement {
     this._applySelectedSchema(this._pendingSchemaId);
   }
 
+  get schemaEditorHref() {
+    return `https://da.live/apps/schema#/${this.details.owner}/${this.details.repo}`;
+  }
+
   _handleNavPointerSelectFromSidebar(e) {
     const { pointer } = e.detail ?? {};
     if (!pointer || pointer === this._activeNavPointer) return;
@@ -172,24 +176,32 @@ class FormEditor extends LitElement {
   }
 
   renderSchemaSelector() {
+    const schemaEntries = Object.entries(this._schemas || {});
+    const hasSchemas = schemaEntries.length > 0;
+    const emptyLabel = hasSchemas ? 'Select a schema' : 'No schemas available yet';
+
     return html`
-      <div class="da-form-schema-shell">
-        <div class="da-form-schema-card">
-          <h2 class="da-form-schema-heading">Choose a schema</h2>
-          <div class="da-form-schema-form">
-            <sl-select
-              hoist
-              class="da-form-schema-select"
-              label="Schema"
-              placeholder="Select a schema"
-              .value=${this._pendingSchemaId}
-              @change=${this._onPendingSchemaChange}
-            >
-              <option value="">Select a schema</option>
-              ${Object.entries(this._schemas).map(([key, value]) => html`
-                <option value="${key}">${value.title}</option>
-              `)}
-            </sl-select>
+      <div class="da-form-schema-panel">
+        <h2 class="da-form-schema-heading">Choose a schema</h2>
+        <div class="da-form-schema-form">
+          <sl-select
+            hoist
+            class="da-form-schema-select"
+            label="Schema"
+            placeholder=${emptyLabel}
+            .value=${this._pendingSchemaId}
+            @change=${this._onPendingSchemaChange}
+          >
+            <option value="">${emptyLabel}</option>
+            ${schemaEntries.map(([key, value]) => html`
+              <option value="${key}">${value.title}</option>
+            `)}
+          </sl-select>
+          <p class="da-form-schema-hint">
+            Need a new schema? Create one in
+            <a href=${this.schemaEditorHref} target="_blank" rel="noopener noreferrer">Schema Editor</a>.
+          </p>
+          <div class="da-form-schema-actions">
             <sl-button
               class="da-form-schema-start"
               ?disabled=${!this._pendingSchemaId}
@@ -201,41 +213,24 @@ class FormEditor extends LitElement {
   }
 
   renderFormEditor() {
-    if (this.formModel === null) {
-      if (this._schemas) return this.renderSchemaSelector();
-
-      return html`
-        <div class="da-form-schema-shell">
-          <div class="da-form-schema-card">
-            <p class="da-form-title">Please create a schema</p>
-            <p class="da-form-schema-hint">
-              This project has no schemas yet. Open the schema editor to add one, then return here.
-            </p>
-            <div class="da-form-schema-field da-form-schema-field-link">
-              <a
-                class="da-form-schema-cta"
-                href="https://main--da-live--adobe.aem.live/apps/schema?nx=schema#/${this.details.owner}/${this.details.repo}"
-              >Open schema editor</a>
-            </div>
-          </div>
-        </div>
-      `;
-    }
-
     return html`
       <div class="da-form-editor">
-        <da-form-editor
-          @update=${this.handleUpdate}
-          @add-item=${this.handleAddItem}
-          @insert-item=${this.handleInsertItem}
-          @remove-item=${this.handleRemoveItem}
-          @move-array-item=${this.handleMoveArrayItem}
-          @nav-pointer-select=${this._handleNavPointerSelectFromEditor}
-          .formModel=${this.formModel}
-          .activeNavPointer=${this._activeNavPointer}
-          .scrollEditorIntoView=${this._scrollEditorIntoView}
-        ></da-form-editor>
-        <da-form-preview .formModel=${this.formModel}></da-form-preview>
+        ${this.formModel === null
+        ? this.renderSchemaSelector()
+        : html`
+            <da-form-editor
+              @update=${this.handleUpdate}
+              @add-item=${this.handleAddItem}
+              @insert-item=${this.handleInsertItem}
+              @remove-item=${this.handleRemoveItem}
+              @move-array-item=${this.handleMoveArrayItem}
+              @nav-pointer-select=${this._handleNavPointerSelectFromEditor}
+              .formModel=${this.formModel}
+              .activeNavPointer=${this._activeNavPointer}
+              .scrollEditorIntoView=${this._scrollEditorIntoView}
+            ></da-form-editor>
+            <da-form-preview .formModel=${this.formModel}></da-form-preview>
+          `}
       </div>`;
   }
 

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -32,33 +32,31 @@ class FormEditor extends LitElement {
     details: { attribute: false },
     formModel: { state: true },
     _schemas: { state: true },
-    _isUnstructuredDoc: { state: true },
+    _showWarningDialog: { state: true },
     _activeNavPointer: { state: true },
     _scrollEditorIntoView: { state: true },
     _scrollNavItemIntoView: { state: true },
     _pendingSchemaId: { state: true },
   };
 
-  constructor() {
-    super();
-    this._isUnstructuredDoc = false;
-    this._pendingSchemaId = '';
-  }
+  _showWarningDialog = false;
+
+  _pendingSchemaId = '';
 
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
-    this.fetchDoc(this.details);
+    this.fetchDoc();
+  }
+
+  _setUnavailableState({ showWarning }) {
+    this._showWarningDialog = showWarning;
+    this.formModel = null;
   }
 
   async fetchDoc() {
     if (this.details?.depth <= 2) {
-      this._isUnstructuredDoc = true;
-      this.formModel = null;
-      this._pendingSchemaId = '';
-      this._activeNavPointer = undefined;
-      this._scrollEditorIntoView = undefined;
-      this._scrollNavItemIntoView = undefined;
+      this._setUnavailableState({ showWarning: true });
       return;
     }
 
@@ -69,12 +67,7 @@ class FormEditor extends LitElement {
     if (schemas) this._schemas = schemas;
 
     if (!result.html) {
-      this._isUnstructuredDoc = false;
-      this.formModel = null;
-      this._pendingSchemaId = '';
-      this._activeNavPointer = undefined;
-      this._scrollEditorIntoView = undefined;
-      this._scrollNavItemIntoView = undefined;
+      this._setUnavailableState({ showWarning: false });
       return;
     }
 
@@ -83,19 +76,11 @@ class FormEditor extends LitElement {
     const metadata = JSON.parse(model.getSerializedJson()).metadata ?? {};
 
     if (Object.keys(metadata).length === 0) {
-      this._isUnstructuredDoc = true;
-      this.formModel = null;
-      this._pendingSchemaId = '';
-      this._activeNavPointer = undefined;
-      this._scrollEditorIntoView = undefined;
-      this._scrollNavItemIntoView = undefined;
+      this._setUnavailableState({ showWarning: true });
       return;
     }
 
-    this._isUnstructuredDoc = false;
-    this._activeNavPointer = undefined;
-    this._scrollEditorIntoView = undefined;
-    this._scrollNavItemIntoView = undefined;
+    this._showWarningDialog = false;
     this.formModel = model;
   }
 
@@ -114,9 +99,6 @@ class FormEditor extends LitElement {
     const emptyForm = { data, metadata };
 
     const path = this.details.fullpath;
-    this._activeNavPointer = undefined;
-    this._scrollEditorIntoView = undefined;
-    this._scrollNavItemIntoView = undefined;
     this.formModel = new FormModel({ path, json: emptyForm, schemas: this._schemas });
   }
 
@@ -245,7 +227,7 @@ class FormEditor extends LitElement {
       </da-form-dialog>`;
   }
 
-  renderUnstructuredDialog() {
+  renderWarningDialog() {
     const message = 'The item at this path is not a structured content.';
 
     return html`
@@ -260,8 +242,8 @@ class FormEditor extends LitElement {
   }
 
   renderFormEditor() {
-    if (this._isUnstructuredDoc) {
-      return this.renderUnstructuredDialog();
+    if (this._showWarningDialog) {
+      return this.renderWarningDialog();
     }
 
     if (this.formModel === null) {

--- a/nx/blocks/form/views/dialog.css
+++ b/nx/blocks/form/views/dialog.css
@@ -1,0 +1,38 @@
+.da-form-dialog {
+  padding: 0;
+  border: none;
+  border-radius: 16px;
+  box-shadow:
+    0 0 6px 0 rgb(0 0 0 / 24%),
+    0 3px 20px 0 rgb(0 0 0 / 16%),
+    0 4px 20px 0 rgb(0 0 0 / 24%);
+}
+
+.da-form-dialog::backdrop {
+  background-color: rgb(0 0 0 / 60%);
+}
+
+.da-form-dialog-inner {
+  padding: 18px 20px 20px;
+  width: min(480px, 90vw);
+  box-sizing: border-box;
+  max-height: 85vh;
+  overflow: auto;
+  background: var(--sl-color-neutral-0, #fff);
+}
+
+.da-form-dialog-title {
+  margin: 0;
+  line-height: 1;
+  font-weight: 700;
+  font-size: var(--sl-font-size-large, 1.125rem);
+  padding: 0 0 20px;
+}
+
+hr {
+  margin: 0 0 20px;
+}
+
+.da-form-dialog-content {
+  padding: 0 0 20px;
+}

--- a/nx/blocks/form/views/dialog.js
+++ b/nx/blocks/form/views/dialog.js
@@ -1,0 +1,56 @@
+import { LitElement, html } from 'da-lit';
+
+const { default: getStyle } = await import('../../../utils/styles.js');
+const style = await getStyle(import.meta.url);
+
+class FormDialog extends LitElement {
+  static properties = {
+    title: { type: String },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [style];
+  }
+
+  disconnectedCallback() {
+    this.close();
+    super.disconnectedCallback();
+  }
+
+  firstUpdated() {
+    if (!this._dialog.open) this._dialog.showModal();
+  }
+
+  close() {
+    if (this._dialog?.open) this._dialog.close();
+  }
+
+  _onCancel(e) {
+    // Keep this dialog non-dismissible for current usage.
+    e.preventDefault();
+  }
+
+  get _dialog() {
+    return this.shadowRoot.querySelector('dialog');
+  }
+
+  render() {
+    return html`
+      <dialog
+        class="da-form-dialog"
+        @cancel=${this._onCancel}
+      >
+        <div class="da-form-dialog-inner">
+          <p class="da-form-dialog-title">${this.title}</p>
+          <hr />
+          <div class="da-form-dialog-content">
+            <slot></slot>
+          </div>
+        </div>
+      </dialog>
+    `;
+  }
+}
+
+customElements.define('da-form-dialog', FormDialog);


### PR DESCRIPTION
Fixed the following items:

* Implemented a proper dialog aligned with the current da-dialog UX
* Handled cases where:
    * An existing non-structured content path is opened in the form editor
    * A folder path is opened
* Linked the schema editor within the schema selector dialog

Test URLs:
https://da.live/form?nx=fix-link-schema-editor#/kozmaadrian/si/schema-selector-test

New content:

<img width="1028" height="671" alt="Screenshot 2026-04-29 at 5 08 26 pm" src="https://github.com/user-attachments/assets/a6c98d7a-5089-4684-8cb3-a3a87a30992d" />

Invalid content, or invalid path

<img width="887" height="667" alt="Screenshot 2026-04-29 at 5 06 31 pm" src="https://github.com/user-attachments/assets/0b5de42c-1581-4e1d-93d1-d0dd74089f21" />






