### PR TITLE
fix: [dasc] Editor should only load when a valid document is available.

### DIFF
--- a/nx/blocks/form/form.css
+++ b/nx/blocks/form/form.css
@@ -47,6 +47,12 @@ sl-textarea {
     align-self: flex-start;
   }
 
+  da-dialog {
+    font-family: var(--font-family);
+    font-size: 16px;
+    line-height: var(--s2-line-height-200);
+  }
+
   .da-form-schema-shell {
     flex: 1 1 700px;
     width: 700px;
@@ -55,19 +61,9 @@ sl-textarea {
   }
 
   &.da-form-wrapper-centered .da-form-schema-shell {
-    flex: 0 1 480px;
-    width: min(480px, 100%);
-    max-width: 480px;
-  }
-
-  .da-form-warning-shell {
-    text-align: center;
-  }
-
-  &.da-form-wrapper-centered .da-form-warning-shell {
-    flex: 1 1 100%;
-    width: 100%;
-    max-width: 100%;
+    flex: 0 1 620px;
+    width: min(620px, 100%);
+    max-width: 620px;
   }
 
   .da-form-schema-card {
@@ -91,9 +87,11 @@ sl-textarea {
     color: var(--sl-color-neutral-600, #64748b);
   }
 
-  .da-form-warning-shell .da-form-schema-hint {
-    max-width: 700px;
-    margin-inline: auto;
+  da-dialog .da-form-schema-hint {
+    font-family: var(--font-family);
+    font-size: 16px;
+    line-height: var(--s2-line-height-200);
+    color: var(--s2-gray-800);
   }
 
   .da-form-schema-selector-hint {
@@ -151,18 +149,6 @@ sl-textarea {
 
   sl-button.da-form-schema-start {
     align-self: flex-end;
-  }
-
-  sl-button.da-form-schema-start::part(wrap) {
-    display: inline-flex;
-  }
-
-  sl-button.da-form-schema-start::part(base) {
-    width: auto;
-    min-width: 96px;
-    box-sizing: border-box;
-    justify-content: center;
-    border-radius: var(--s2-radius-100, 8px);
   }
 
   .da-form-schema-cta {

--- a/nx/blocks/form/form.css
+++ b/nx/blocks/form/form.css
@@ -60,6 +60,16 @@ sl-textarea {
     max-width: 480px;
   }
 
+  .da-form-warning-shell {
+    text-align: center;
+  }
+
+  &.da-form-wrapper-centered .da-form-warning-shell {
+    flex: 1 1 100%;
+    width: 100%;
+    max-width: 100%;
+  }
+
   .da-form-schema-card {
     box-sizing: border-box;
     border-radius: var(--sl-border-radius-x-large, 12px);
@@ -79,6 +89,11 @@ sl-textarea {
     font-size: var(--sl-font-size-small, 0.875rem);
     line-height: var(--sl-line-height-normal, 1.5);
     color: var(--sl-color-neutral-600, #64748b);
+  }
+
+  .da-form-warning-shell .da-form-schema-hint {
+    max-width: 700px;
+    margin-inline: auto;
   }
 
   .da-form-schema-selector-hint {

--- a/nx/blocks/form/form.css
+++ b/nx/blocks/form/form.css
@@ -47,7 +47,6 @@ sl-textarea {
     align-self: flex-start;
   }
 
-  /* Schema picker — centered card: title, labeled select, full-width Start */
   .da-form-schema-shell {
     flex: 1 1 700px;
     width: 700px;
@@ -80,6 +79,16 @@ sl-textarea {
     font-size: var(--sl-font-size-small, 0.875rem);
     line-height: var(--sl-line-height-normal, 1.5);
     color: var(--sl-color-neutral-600, #64748b);
+  }
+
+  .da-form-schema-selector-hint {
+    margin: 0;
+  }
+
+  .da-form-schema-text-link {
+    color: var(--sl-color-primary-700, #1d4ed8);
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
 
   .da-form-schema-heading {
@@ -126,17 +135,16 @@ sl-textarea {
   }
 
   sl-button.da-form-schema-start {
-    display: block;
-    width: 100%;
+    align-self: flex-end;
   }
 
   sl-button.da-form-schema-start::part(wrap) {
-    display: block;
-    width: 100%;
+    display: inline-flex;
   }
 
   sl-button.da-form-schema-start::part(base) {
-    width: 100%;
+    width: auto;
+    min-width: 96px;
     box-sizing: border-box;
     justify-content: center;
     border-radius: var(--s2-radius-100, 8px);

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -6,7 +6,12 @@ import FormModel from './data/model.js';
 // Internal utils
 import { getParentPointer } from './utils/pointer.js';
 import { schemas as schemasPromise } from './utils/schema.js';
-import { findNodeByPointer, loadHtml } from './utils/utils.js';
+import {
+  findNodeByPointer,
+  isEmptyDocumentHtml,
+  isStructuredContentHtml,
+  loadHtml,
+} from './utils/utils.js';
 
 import 'https://da.live/blocks/edit/da-title/da-title.js';
 
@@ -31,6 +36,7 @@ class FormEditor extends LitElement {
     details: { attribute: false },
     formModel: { state: true },
     _schemas: { state: true },
+    _hasUnsupportedContent: { state: true },
     _activeNavPointer: { state: true },
     _scrollEditorIntoView: { state: true },
     _scrollNavItemIntoView: { state: true },
@@ -40,12 +46,22 @@ class FormEditor extends LitElement {
   constructor() {
     super();
     this._pendingSchemaId = '';
+    this._hasUnsupportedContent = false;
   }
 
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
     this.fetchDoc(this.details);
+  }
+
+  _resetEditorState() {
+    this.formModel = null;
+    this._hasUnsupportedContent = false;
+    this._pendingSchemaId = '';
+    this._activeNavPointer = undefined;
+    this._scrollEditorIntoView = undefined;
+    this._scrollNavItemIntoView = undefined;
   }
 
   async fetchDoc() {
@@ -55,16 +71,25 @@ class FormEditor extends LitElement {
 
     if (schemas) this._schemas = schemas;
 
-    if (!result.html) {
-      this.formModel = null;
-      this._pendingSchemaId = '';
-      this._activeNavPointer = undefined;
-      this._scrollEditorIntoView = undefined;
-      this._scrollNavItemIntoView = undefined;
+    if (result.error || typeof result.html !== 'string') {
+      this._resetEditorState();
+      this._hasUnsupportedContent = true;
+      return;
+    }
+
+    if (isEmptyDocumentHtml(result.html)) {
+      this._resetEditorState();
+      return;
+    }
+
+    if (!isStructuredContentHtml(result.html)) {
+      this._resetEditorState();
+      this._hasUnsupportedContent = true;
       return;
     }
 
     const path = this.details.fullpath;
+    this._hasUnsupportedContent = false;
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
     this._scrollNavItemIntoView = undefined;
@@ -86,6 +111,7 @@ class FormEditor extends LitElement {
     const emptyForm = { data, metadata };
 
     const path = this.details.fullpath;
+    this._hasUnsupportedContent = false;
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
     this._scrollNavItemIntoView = undefined;
@@ -199,7 +225,12 @@ class FormEditor extends LitElement {
             </sl-select>
             <p class="da-form-schema-hint da-form-schema-selector-hint">
               To create a new schema, open
-              <a class="da-form-schema-text-link" href=${schemaEditorHref}>Schema Editor</a>.
+              <a
+                class="da-form-schema-text-link"
+                href=${schemaEditorHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >Schema Editor</a>.
             </p>
             <sl-button
               class="da-form-schema-start"
@@ -211,7 +242,23 @@ class FormEditor extends LitElement {
       </div>`;
   }
 
+  renderUnsupportedContentMessage() {
+    const fullpath = this.details?.fullpath ?? '';
+    const path = fullpath.endsWith('.html') ? fullpath.slice(0, -5) : fullpath;
+    return html`
+      <div class="da-form-schema-shell da-form-warning-shell">
+        <p class="da-form-title">Not supported</p>
+        <p class="da-form-schema-hint">
+          The resource under this path${path ? html` <code>${path}</code>` : ''} cannot be opened
+          as structured content.
+        </p>
+      </div>
+    `;
+  }
+
   renderFormEditor() {
+    if (this._hasUnsupportedContent) return this.renderUnsupportedContentMessage();
+
     if (this.formModel === null) {
       if (this._schemas) return this.renderSchemaSelector();
 
@@ -226,6 +273,8 @@ class FormEditor extends LitElement {
               <a
                 class="da-form-schema-cta"
                 href=${this._getSchemaEditorHref()}
+                target="_blank"
+                rel="noopener noreferrer"
               >Open Schema Editor</a>
             </div>
           </div>

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -38,6 +38,7 @@ class FormEditor extends LitElement {
     formModel: { state: true },
     _schemas: { state: true },
     _hasUnsupportedContent: { state: true },
+    _missingSchemaName: { state: true },
     _activeNavPointer: { state: true },
     _scrollEditorIntoView: { state: true },
     _scrollNavItemIntoView: { state: true },
@@ -48,6 +49,7 @@ class FormEditor extends LitElement {
     super();
     this._pendingSchemaId = '';
     this._hasUnsupportedContent = false;
+    this._missingSchemaName = undefined;
   }
 
   connectedCallback() {
@@ -59,6 +61,7 @@ class FormEditor extends LitElement {
   _resetEditorState() {
     this.formModel = null;
     this._hasUnsupportedContent = false;
+    this._missingSchemaName = undefined;
     this._pendingSchemaId = '';
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
@@ -91,10 +94,22 @@ class FormEditor extends LitElement {
 
     const path = this.details.fullpath;
     this._hasUnsupportedContent = false;
+    this._missingSchemaName = undefined;
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
     this._scrollNavItemIntoView = undefined;
-    this.formModel = new FormModel({ path, html: result.html, schemas });
+    const model = new FormModel({ path, html: result.html, schemas });
+    const json = JSON.parse(model.getSerializedJson());
+    const schemaName = json?.metadata?.schemaName;
+
+    if (!model.schema) {
+      this._resetEditorState();
+      this._hasUnsupportedContent = true;
+      this._missingSchemaName = schemaName ?? '';
+      return;
+    }
+
+    this.formModel = model;
   }
 
   _onPendingSchemaChange(e) {
@@ -113,6 +128,7 @@ class FormEditor extends LitElement {
 
     const path = this.details.fullpath;
     this._hasUnsupportedContent = false;
+    this._missingSchemaName = undefined;
     this._activeNavPointer = undefined;
     this._scrollEditorIntoView = undefined;
     this._scrollNavItemIntoView = undefined;
@@ -251,6 +267,9 @@ class FormEditor extends LitElement {
   renderUnsupportedContentMessage() {
     const fullpath = this.details?.fullpath ?? '';
     const path = fullpath.endsWith('.html') ? fullpath.slice(0, -5) : fullpath;
+    const schemaEditorHref = this._getSchemaEditorHref();
+    const hasMissingSchema = this._missingSchemaName !== undefined;
+    const schemaName = this._missingSchemaName || '(empty)';
     const action = {
       label: 'Return to Home',
       style: '',
@@ -258,15 +277,30 @@ class FormEditor extends LitElement {
     };
     return html`
       <da-dialog
-        title="Not supported"
+        title=${hasMissingSchema ? 'Schema not found' : 'Not supported'}
         size="large"
         @close=${this._goToRepoRoot}
         .action=${action}
       >
-        <p class="da-form-schema-hint">
-          The resource under this path${path ? html` <strong>${path}</strong>` : ''} cannot be opened
-          as structured content.
-        </p>
+        ${hasMissingSchema
+          ? html`
+            <p class="da-form-schema-hint">
+              The schema <strong>${schemaName}</strong> referenced by this resource
+              ${path ? html`at <strong>${path}</strong> ` : ''}does not exist. To create it, open
+              <a
+                class="da-form-schema-text-link"
+                href=${schemaEditorHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >Schema Editor</a>.
+            </p>
+          `
+          : html`
+            <p class="da-form-schema-hint">
+              The resource under this path${path ? html` <strong>${path}</strong>` : ''} cannot be
+              opened as structured content.
+            </p>
+          `}
       </da-dialog>
     `;
   }

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -96,6 +96,12 @@ class FormEditor extends LitElement {
     this._applySelectedSchema(this._pendingSchemaId);
   }
 
+  _getSchemaEditorHref() {
+    const { owner, repo } = this.details ?? {};
+    if (!owner || !repo) return 'https://da.live/apps/schema';
+    return `https://da.live/apps/schema#/${owner}/${repo}`;
+  }
+
   _handleNavPointerSelectFromSidebar(e) {
     const { pointer } = e.detail ?? {};
     if (!pointer || pointer === this._activeNavPointer) return;
@@ -172,6 +178,7 @@ class FormEditor extends LitElement {
   }
 
   renderSchemaSelector() {
+    const schemaEditorHref = this._getSchemaEditorHref();
     return html`
       <div class="da-form-schema-shell">
         <div class="da-form-schema-card">
@@ -190,11 +197,15 @@ class FormEditor extends LitElement {
                 <option value="${key}">${value.title}</option>
               `)}
             </sl-select>
+            <p class="da-form-schema-hint da-form-schema-selector-hint">
+              To create a new schema, open
+              <a class="da-form-schema-text-link" href=${schemaEditorHref}>Schema Editor</a>.
+            </p>
             <sl-button
               class="da-form-schema-start"
               ?disabled=${!this._pendingSchemaId}
               @click=${this._confirmSchemaStart}
-            >Start</sl-button>
+            >Create</sl-button>
           </div>
         </div>
       </div>`;
@@ -214,8 +225,8 @@ class FormEditor extends LitElement {
             <div class="da-form-schema-field da-form-schema-field-link">
               <a
                 class="da-form-schema-cta"
-                href="https://main--da-live--adobe.aem.live/apps/schema?nx=schema#/${this.details.owner}/${this.details.repo}"
-              >Open schema editor</a>
+                href=${this._getSchemaEditorHref()}
+              >Open Schema Editor</a>
             </div>
           </div>
         </div>

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -14,6 +14,7 @@ import {
 } from './utils/utils.js';
 
 import 'https://da.live/blocks/edit/da-title/da-title.js';
+import 'https://da.live/blocks/shared/da-dialog/da-dialog.js';
 
 // Internal Web Components
 import './views/editor.js';
@@ -128,6 +129,13 @@ class FormEditor extends LitElement {
     return `https://da.live/apps/schema#/${owner}/${repo}`;
   }
 
+  _goToRepoRoot() {
+    const { owner, repo } = this.details ?? {};
+    if (!owner || !repo) return;
+    const query = window.location.search ?? '';
+    window.location.href = `https://da.live${query}#/${owner}/${repo}`;
+  }
+
   _handleNavPointerSelectFromSidebar(e) {
     const { pointer } = e.detail ?? {};
     if (!pointer || pointer === this._activeNavPointer) return;
@@ -207,37 +215,35 @@ class FormEditor extends LitElement {
     const schemaEditorHref = this._getSchemaEditorHref();
     return html`
       <div class="da-form-schema-shell">
-        <div class="da-form-schema-card">
-          <h2 class="da-form-schema-heading">Choose a schema</h2>
-          <div class="da-form-schema-form">
-            <sl-select
-              hoist
-              class="da-form-schema-select"
-              label="Schema"
-              placeholder="Select a schema"
-              .value=${this._pendingSchemaId}
-              @change=${this._onPendingSchemaChange}
-            >
-              <option value="">Select a schema</option>
-              ${Object.entries(this._schemas).map(([key, value]) => html`
-                <option value="${key}">${value.title}</option>
-              `)}
-            </sl-select>
-            <p class="da-form-schema-hint da-form-schema-selector-hint">
-              To create a new schema, open
-              <a
-                class="da-form-schema-text-link"
-                href=${schemaEditorHref}
-                target="_blank"
-                rel="noopener noreferrer"
-              >Schema Editor</a>.
-            </p>
-            <sl-button
-              class="da-form-schema-start"
-              ?disabled=${!this._pendingSchemaId}
-              @click=${this._confirmSchemaStart}
-            >Create</sl-button>
-          </div>
+        <h2 class="da-form-schema-heading">Choose a schema</h2>
+        <div class="da-form-schema-form">
+          <sl-select
+            hoist
+            class="da-form-schema-select"
+            label="Schema"
+            placeholder="Select a schema"
+            .value=${this._pendingSchemaId}
+            @change=${this._onPendingSchemaChange}
+          >
+            <option value="">Select a schema</option>
+            ${Object.entries(this._schemas).map(([key, value]) => html`
+              <option value="${key}">${value.title}</option>
+            `)}
+          </sl-select>
+          <p class="da-form-schema-hint da-form-schema-selector-hint">
+            To create a new schema, open
+            <a
+              class="da-form-schema-text-link"
+              href=${schemaEditorHref}
+              target="_blank"
+              rel="noopener noreferrer"
+            >Schema Editor</a>.
+          </p>
+          <sl-button
+            class="da-form-schema-start"
+            ?disabled=${!this._pendingSchemaId}
+            @click=${this._confirmSchemaStart}
+          >Create</sl-button>
         </div>
       </div>`;
   }
@@ -245,14 +251,23 @@ class FormEditor extends LitElement {
   renderUnsupportedContentMessage() {
     const fullpath = this.details?.fullpath ?? '';
     const path = fullpath.endsWith('.html') ? fullpath.slice(0, -5) : fullpath;
+    const action = {
+      label: 'Return to Home',
+      style: '',
+      click: () => this._goToRepoRoot(),
+    };
     return html`
-      <div class="da-form-schema-shell da-form-warning-shell">
-        <p class="da-form-title">Not supported</p>
+      <da-dialog
+        title="Not supported"
+        size="large"
+        @close=${this._goToRepoRoot}
+        .action=${action}
+      >
         <p class="da-form-schema-hint">
-          The resource under this path${path ? html` <code>${path}</code>` : ''} cannot be opened
+          The resource under this path${path ? html` <strong>${path}</strong>` : ''} cannot be opened
           as structured content.
         </p>
-      </div>
+      </da-dialog>
     `;
   }
 

--- a/nx/blocks/form/utils/utils.js
+++ b/nx/blocks/form/utils/utils.js
@@ -173,6 +173,63 @@ export async function loadHtml(details) {
   return { html: (await resp.text()) };
 }
 
+function hasMeaningfulContent(el) {
+  if (!el) return false;
+  return Array.from(el.childNodes).some((node) => {
+    if (node.nodeType === 1) return true;
+    if (node.nodeType === 3) return node.textContent.trim().length > 0;
+    return false;
+  });
+}
+
+/**
+ * Check whether fetched document HTML only contains the default empty shell.
+ * @param {string} htmlString - Raw HTML string from source.
+ * @returns {boolean}
+ */
+export function isEmptyDocumentHtml(htmlString) {
+  if (typeof htmlString !== 'string') return false;
+
+  const doc = new DOMParser().parseFromString(htmlString, 'text/html');
+  const header = doc.querySelector('body > header');
+  const footer = doc.querySelector('body > footer');
+  const mainContainer = doc.querySelector('body > main > div');
+
+  // If structure differs from the expected shell, treat as non-empty.
+  if (!mainContainer) return false;
+
+  const hasHeaderContent = hasMeaningfulContent(header);
+  const hasFooterContent = hasMeaningfulContent(footer);
+  const hasMainContent = hasMeaningfulContent(mainContainer);
+
+  return !hasHeaderContent && !hasMainContent && !hasFooterContent;
+}
+
+/**
+ * Check whether fetched document HTML contains structured content.
+ * @param {string} htmlString - Raw HTML string from source.
+ * @returns {boolean}
+ */
+export function isStructuredContentHtml(htmlString) {
+  if (!htmlString) return false;
+
+  const doc = new DOMParser().parseFromString(htmlString, 'text/html');
+  const formBlock = doc.querySelector('body > main > div > div.da-form');
+  if (!formBlock) return false;
+
+  const rows = Array.from(formBlock.children)
+    .filter((row) => row.children.length >= 2);
+  if (rows.length === 0) return false;
+
+  const keys = rows
+    .map((row) => row.children[0]?.textContent?.trim().toLowerCase())
+    .filter(Boolean);
+
+  const hasTitle = keys.includes('title');
+  const hasSchemaName = keys.includes('x-schema-name');
+  return hasTitle && hasSchemaName;
+}
+
 /**
  * Build annotated field tree from dereferenced schema and data.
  * @param {string} key - Property key

--- a/nx/blocks/form/utils/utils.js
+++ b/nx/blocks/form/utils/utils.js
@@ -188,6 +188,7 @@ function hasMeaningfulContent(el) {
  * @returns {boolean}
  */
 export function isEmptyDocumentHtml(htmlString) {
+  console.log('htmlString', htmlString);
   if (typeof htmlString !== 'string') return false;
 
   const doc = new DOMParser().parseFromString(htmlString, 'text/html');

--- a/nx/blocks/form/utils/utils.js
+++ b/nx/blocks/form/utils/utils.js
@@ -175,8 +175,8 @@ export async function loadHtml(details) {
 
 /**
  * Check whether fetched document HTML only contains the default empty shell.
- * Empty means exactly: <body><header></header><main><div></div></main><footer></footer></body>
- * (ignoring whitespace-only text nodes).
+ * Empty means main content is exactly <main><div></div></main>.
+ * Header/footer presence or content is intentionally ignored.
  * @param {string} htmlString - Raw HTML string from source.
  * @returns {boolean}
  */
@@ -184,24 +184,9 @@ export function isEmptyDocumentHtml(htmlString) {
   if (typeof htmlString !== 'string') return false;
 
   const doc = new DOMParser().parseFromString(htmlString, 'text/html');
-  const body = doc.querySelector('body');
-  if (!body) return false;
+  const mainContainer = doc.querySelector('body > main > div');
+  if (!mainContainer) return false;
 
-  const bodyChildren = Array.from(body.children);
-  if (bodyChildren.length !== 3) return false;
-
-  const [header, main, footer] = bodyChildren;
-  if (header.tagName !== 'HEADER' || main.tagName !== 'MAIN' || footer.tagName !== 'FOOTER') {
-    return false;
-  }
-
-  if (header.childElementCount !== 0 || footer.childElementCount !== 0) return false;
-  if (header.textContent.trim().length > 0 || footer.textContent.trim().length > 0) return false;
-
-  const mainChildren = Array.from(main.children);
-  if (mainChildren.length !== 1) return false;
-
-  const [mainContainer] = mainChildren;
   if (mainContainer.tagName !== 'DIV') return false;
   if (mainContainer.childElementCount !== 0) return false;
   if (mainContainer.textContent.trim().length > 0) return false;

--- a/nx/blocks/form/utils/utils.js
+++ b/nx/blocks/form/utils/utils.js
@@ -173,17 +173,10 @@ export async function loadHtml(details) {
   return { html: (await resp.text()) };
 }
 
-function hasMeaningfulContent(el) {
-  if (!el) return false;
-  return Array.from(el.childNodes).some((node) => {
-    if (node.nodeType === 1) return true;
-    if (node.nodeType === 3) return node.textContent.trim().length > 0;
-    return false;
-  });
-}
-
 /**
  * Check whether fetched document HTML only contains the default empty shell.
+ * Empty means exactly: <body><header></header><main><div></div></main><footer></footer></body>
+ * (ignoring whitespace-only text nodes).
  * @param {string} htmlString - Raw HTML string from source.
  * @returns {boolean}
  */
@@ -191,18 +184,29 @@ export function isEmptyDocumentHtml(htmlString) {
   if (typeof htmlString !== 'string') return false;
 
   const doc = new DOMParser().parseFromString(htmlString, 'text/html');
-  const header = doc.querySelector('body > header');
-  const footer = doc.querySelector('body > footer');
-  const mainContainer = doc.querySelector('body > main > div');
+  const body = doc.querySelector('body');
+  if (!body) return false;
 
-  // If structure differs from the expected shell, treat as non-empty.
-  if (!mainContainer) return false;
+  const bodyChildren = Array.from(body.children);
+  if (bodyChildren.length !== 3) return false;
 
-  const hasHeaderContent = hasMeaningfulContent(header);
-  const hasFooterContent = hasMeaningfulContent(footer);
-  const hasMainContent = hasMeaningfulContent(mainContainer);
+  const [header, main, footer] = bodyChildren;
+  if (header.tagName !== 'HEADER' || main.tagName !== 'MAIN' || footer.tagName !== 'FOOTER') {
+    return false;
+  }
 
-  return !hasHeaderContent && !hasMainContent && !hasFooterContent;
+  if (header.childElementCount !== 0 || footer.childElementCount !== 0) return false;
+  if (header.textContent.trim().length > 0 || footer.textContent.trim().length > 0) return false;
+
+  const mainChildren = Array.from(main.children);
+  if (mainChildren.length !== 1) return false;
+
+  const [mainContainer] = mainChildren;
+  if (mainContainer.tagName !== 'DIV') return false;
+  if (mainContainer.childElementCount !== 0) return false;
+  if (mainContainer.textContent.trim().length > 0) return false;
+
+  return true;
 }
 
 /**

--- a/nx/blocks/form/utils/utils.js
+++ b/nx/blocks/form/utils/utils.js
@@ -188,7 +188,6 @@ function hasMeaningfulContent(el) {
  * @returns {boolean}
  */
 export function isEmptyDocumentHtml(htmlString) {
-  console.log('htmlString', htmlString);
   if (typeof htmlString !== 'string') return false;
 
   const doc = new DOMParser().parseFromString(htmlString, 'text/html');


### PR DESCRIPTION
Adds the following fixes:

* Loads the structured content editor when:
    * the loaded document is empty → displays the Schema Selector
    * the document is an existing structured content document
* Displays a warning message when:
    * no document exists at the given path (e.g., folder)
    * the path points to a non-empty, non-structured content document
    * the document exists but the could not be found
* Adds a link to the Schema Editor within the Schema Selector dialog.

Test URLs:
- https://da.live/form?nx=form/empty-document#/kozmaadrian/si/test/empty-document

<img width="1347" height="675" alt="Screenshot 2026-04-30 at 10 37 00 am" src="https://github.com/user-attachments/assets/b54281ed-f14d-4823-9b7d-596187c9f2a9" />


- https://da.live/form?nx=form/empty-document#/kozmaadrian/si/test/non-empty-document

<img width="1339" height="672" alt="Screenshot 2026-04-30 at 10 36 52 am" src="https://github.com/user-attachments/assets/6c689a85-8e36-4f6b-aff2-6ac228b266da" />


- https://da.live/form?nx=form/empty-document#/kozmaadrian/si/test/folder

<img width="1245" height="701" alt="Screenshot 2026-04-30 at 10 39 36 am" src="https://github.com/user-attachments/assets/c4be4c8a-e958-42eb-9cbf-960e13ba7b9c" />

- https://da.live/form?nx=form/empty-document#/kozmaadrian/si/test/missing-schema

<img width="1168" height="814" alt="Screenshot 2026-04-30 at 10 58 31 am" src="https://github.com/user-attachments/assets/881f7677-0b71-4ea5-adda-50d296a76a3c" />



