### PR TITLE
style(nx2): app-frame panel resize handle UX

### DIFF
--- a/nx2/styles/styles.css
+++ b/nx2/styles/styles.css
@@ -509,12 +509,11 @@ html:has(meta[content="edge-delivery"]) {
           .panel-resize-handle {
             display: none;
             position: absolute;
-            top: 50%;
-            translate: 0 -50%;
+            top: 4px;
+            bottom: 4px;
             z-index: 2;
             box-sizing: border-box;
             width: 12px;
-            height: 56px;
             padding: 0;
             margin: 0;
             border: none;
@@ -528,17 +527,26 @@ html:has(meta[content="edge-delivery"]) {
             content: '';
             position: absolute;
             left: 50%;
-            top: 50%;
-            translate: -50% -50%;
-            width: 4px;
-            height: 48px;
-            border-radius: 999px;
-            background-color: var(--s2-gray-600);
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            translate: -50% 0;
+            border-radius: 1px;
+            background-color: var(--s2-gray-400);
+            opacity: 0;
+            transition: opacity 0.12s ease 0s;
+            pointer-events: none;
           }
 
           .panel-resize-handle:hover::before,
           .panel-resize-handle:focus-visible::before {
-            background-color: var(--s2-gray-900);
+            opacity: 1;
+            transition: opacity 0.12s ease 0.2s;
+          }
+
+          .panel-resize-handle:active::before {
+            opacity: 1;
+            transition: opacity 0.12s ease 0s;
           }
 
           .panel-resize-handle:focus-visible {


### PR DESCRIPTION
Full-height inset grip with 2px --s2-gray-400 rail, opacity reveal after 0.2s on hover/focus, immediate on active for drag.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/
