### PR TITLE
fix: ignore non-path hashes (IMS OAuth access_token) in parseWindowPath

### DIFF
--- a/nx/utils/utils.js
+++ b/nx/utils/utils.js
@@ -86,7 +86,7 @@ const parseWindowPath = () => {
   }
 
   const fullpath = location.hash.slice(1);
-  if (!fullpath) return null;
+  if (!fullpath || !fullpath.startsWith('/')) return null;
 
   const [org, site, ...parts] = fullpath.slice(1).split('/');
   if (!org || (parts.length && !site)) return null;

--- a/nx/utils/utils.js
+++ b/nx/utils/utils.js
@@ -76,6 +76,17 @@ export const ALLOWED_TOKEN = [
   HLX_ADMIN,
 ];
 
+const IMS_HASH_KEYS = ['access_token', 'old_hash', 'ld_hash'];
+
+const stripImsHash = (hash) => {
+  const parts = hash.split('#');
+  const filtered = parts.filter((part, i) => {
+    if (i === 0) return true;
+    return !IMS_HASH_KEYS.some((key) => part.startsWith(`${key}=`));
+  });
+  return filtered.join('#');
+};
+
 const parseWindowPath = () => {
   const pathView = window.location.pathname.slice(1);
   const view = pathView === '' ? 'browse' : pathView;
@@ -85,7 +96,12 @@ const parseWindowPath = () => {
     history.replaceState(null, '', clean);
   }
 
-  const fullpath = location.hash.slice(1);
+  const cleanHash = stripImsHash(location.hash);
+  if (cleanHash !== location.hash) {
+    history.replaceState(null, '', `${location.pathname}${location.search}${cleanHash}`);
+  }
+
+  const fullpath = cleanHash.slice(1);
   if (!fullpath || !fullpath.startsWith('/')) return null;
 
   const [org, site, ...parts] = fullpath.slice(1).split('/');

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -78,6 +78,17 @@ export const ALLOWED_TOKEN = [
   HLX_ADMIN,
 ];
 
+const IMS_HASH_KEYS = ['access_token', 'old_hash', 'ld_hash'];
+
+const stripImsHash = (hash) => {
+  const parts = hash.split('#');
+  const filtered = parts.filter((part, i) => {
+    if (i === 0) return true;
+    return !IMS_HASH_KEYS.some((key) => part.startsWith(`${key}=`));
+  });
+  return filtered.join('#');
+};
+
 const parseWindowPath = () => {
   const pathView = window.location.pathname.slice(1);
   const view = pathView === '' ? 'browse' : pathView;
@@ -87,7 +98,12 @@ const parseWindowPath = () => {
     history.replaceState(null, '', clean);
   }
 
-  const fullpath = location.hash.slice(1);
+  const cleanHash = stripImsHash(location.hash);
+  if (cleanHash !== location.hash) {
+    history.replaceState(null, '', `${location.pathname}${location.search}${cleanHash}`);
+  }
+
+  const fullpath = cleanHash.slice(1);
   if (!fullpath || !fullpath.startsWith('/')) return null;
 
   const [org, site, ...parts] = fullpath.slice(1).split('/');

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -88,7 +88,7 @@ const parseWindowPath = () => {
   }
 
   const fullpath = location.hash.slice(1);
-  if (!fullpath) return null;
+  if (!fullpath || !fullpath.startsWith('/')) return null;
 
   const [org, site, ...parts] = fullpath.slice(1).split('/');
   if (!org || (parts.length && !site)) return null;

--- a/test/utils/hashChange.test.js
+++ b/test/utils/hashChange.test.js
@@ -51,6 +51,50 @@ describe('hashChange', () => {
       expect(received.site).to.equal('myrepo');
     });
 
+    it('returns pathDetails for a valid org/repo hash and removes IMS access_token hash', () => {
+      let received;
+      withHash('#/myorg/myrepo#access_token=eyJhbGciOiJSUzI1NiIsIng1dSI6Imltc19uYTEta2V5In0', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+    });
+
+    it('returns pathDetails for a valid org/repo hash and removes IMS old_hash hash', () => {
+      let received;
+      withHash('#/myorg/myrepo#old_hash=eyJhbGciOiJSUzI1NiIsIng1dSI6Imltc19uYTEta2V5In0', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+    });
+
+    it('returns pathDetails for a valid org/repo hash and removes IMS ld_hash hash', () => {
+      let received;
+      withHash('#/myorg/myrepo#ld_hash=eyJhbGciOiJSUzI1NiIsIng1dSI6Imltc19uYTEta2V5In0', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+    });
+
+    it('returns pathDetails for a valid org/repo hash and removes multiple IMS hashes', () => {
+      let received;
+      withHash('#/myorg/myrepo#access_token=eyJhbGciOiJSUzI1NiIsIng1dSI6Imltc19uYTEta2V5In0#old_hash=iuweyrwre', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+    });
+
     it('returns pathDetails for a valid org/repo/path hash', () => {
       let received;
       withHash('#/myorg/myrepo/some/deep/path', () => {

--- a/test/utils/hashChange.test.js
+++ b/test/utils/hashChange.test.js
@@ -1,0 +1,75 @@
+import { expect } from '@esm-bundle/chai';
+import { hashChange } from '../../nx/utils/utils.js';
+
+function withHash(hash, fn) {
+  const original = window.location.hash;
+  window.location.hash = hash;
+  try {
+    return fn();
+  } finally {
+    window.location.hash = original;
+  }
+}
+
+describe('hashChange', () => {
+  describe('subscribe immediate call', () => {
+    it('returns null for IMS OAuth access_token hash', () => {
+      let received;
+      withHash('#access_token=eyJhbGciOiJSUzI1NiIsIng1dSI6Imltc19uYTEta2V5In0', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.be.null;
+    });
+
+    it('returns null for old_hash IMS fragment', () => {
+      let received;
+      withHash('#old_hash=%23%2Forg%2Frepo', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.be.null;
+    });
+
+    it('returns null for empty hash', () => {
+      let received;
+      withHash('', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.be.null;
+    });
+
+    it('returns pathDetails for a valid org/repo hash', () => {
+      let received;
+      withHash('#/myorg/myrepo', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+    });
+
+    it('returns pathDetails for a valid org/repo/path hash', () => {
+      let received;
+      withHash('#/myorg/myrepo/some/deep/path', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.not.be.null;
+      expect(received.org).to.equal('myorg');
+      expect(received.site).to.equal('myrepo');
+      expect(received.path).to.equal('some/deep/path');
+    });
+
+    it('returns null for hash without leading slash', () => {
+      let received;
+      withHash('#noslash', () => {
+        const unsub = hashChange.subscribe((details) => { received = details; });
+        unsub();
+      });
+      expect(received).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- IMS OAuth login redirects back to `da.live/#access_token=eyJ...` — a hash with no leading `/`
- `parseWindowPath()` only checked `!fullpath`, so the token string was parsed as a valid org name, returning a truthy `pathDetails` object
- This caused `da-browse` to mount with the access token as `fullpath`, rendering it in breadcrumbs and hitting the admin API with it (→ "Not permitted")
- Fix: add `!fullpath.startsWith('/')` guard — valid DA paths always start with `/`

Applied to both `nx/utils/utils.js` and `nx2/utils/utils.js`.

## Test plan

- [ ] New unit tests in `test/utils/hashChange.test.js` cover: `access_token` hash → null, `old_hash` fragment → null, empty hash → null, valid `#/org/repo` → pathDetails, hash without leading slash → null
- [ ] Full test suite passes (`679 passed, 0 failed`)
- [ ] Reproduce: visit `da.live/#access_token=fake` — should show `da-sites` (recent sites) instead of `da-browse` with the token as content

🤖 Generated with [Claude Code](https://claude.com/claude-code)