### PR TITLE
feat: Wrap the form keys in headings.

### DIFF
--- a/nx/blocks/form/utils/json2html.js
+++ b/nx/blocks/form/utils/json2html.js
@@ -18,9 +18,9 @@ function createRow(key, valCol) {
   const row = document.createElement('div');
 
   const keyCol = document.createElement('div');
-  const keyPara = document.createElement('p');
-  keyPara.textContent = key;
-  keyCol.append(keyPara);
+  const keyHeading = document.createElement('h3');
+  keyHeading.textContent = key;
+  keyCol.append(keyHeading);
 
   row.append(keyCol, valCol);
   return row;

--- a/test/form/utils/json2html.test.js
+++ b/test/form/utils/json2html.test.js
@@ -232,7 +232,7 @@ describe('JSON to HTML Conversion', () => {
 
     // Verify @items key exists in array block
     const firstArrayBlock = arrayBlocks[0];
-    const itemsKey = Array.from(firstArrayBlock.querySelectorAll('p')).find((p) => p.textContent === '@items');
+    const itemsKey = Array.from(firstArrayBlock.querySelectorAll('h3')).find((h) => h.textContent === '@items');
     expect(itemsKey, '@items key should exist in array block').to.exist;
 
     // Verify the nested array contains the primitive values
@@ -272,7 +272,7 @@ describe('JSON to HTML Conversion', () => {
     expect(arrayBlocks.length).to.be.at.least(2);
 
     // Verify @items key exists in array blocks
-    const itemsKeys = Array.from(doc.querySelectorAll('p')).filter((p) => p.textContent === '@items');
+    const itemsKeys = Array.from(doc.querySelectorAll('h3')).filter((h) => h.textContent === '@items');
     expect(itemsKeys.length).to.be.at.least(2, '@items keys should exist for each array block');
 
     // Verify object blocks were created for the items

--- a/test/form/utils/mocks/invalidForm.html
+++ b/test/form/utils/mocks/invalidForm.html
@@ -5,7 +5,7 @@
       <div class="da-form">
         <div>
           <div>
-            <p>x-schema-name</p>
+            <h3>x-schema-name</h3>
           </div>
           <div>
             <p>schema</p>
@@ -13,7 +13,7 @@
         </div>
         <div>
           <div>
-            <p>title</p>
+            <h3>title</h3>
           </div>
           <div>
             <p>invalid-form</p>
@@ -23,7 +23,7 @@
       <div class="schema">
         <div>
           <div>
-            <p>emptyStringValue</p>
+            <h3>emptyStringValue</h3>
           </div>
           <div>
             <p></p>
@@ -31,7 +31,7 @@
         </div>
         <div>
           <div>
-            <p>ctas</p>
+            <h3>ctas</h3>
           </div>
           <div>
             <ul>

--- a/test/form/utils/mocks/nestedArrays.html
+++ b/test/form/utils/mocks/nestedArrays.html
@@ -5,7 +5,7 @@
       <div class="da-form">
         <div>
           <div>
-            <p>x-schema-name</p>
+            <h3>x-schema-name</h3>
           </div>
           <div>
             <p>array-tests-schema</p>
@@ -13,7 +13,7 @@
         </div>
         <div>
           <div>
-            <p>title</p>
+            <h3>title</h3>
           </div>
           <div>
             <p>array tests</p>
@@ -23,7 +23,7 @@
       <div class="array-tests-schema">
         <div>
           <div>
-            <p>emergencyContacts</p>
+            <h3>emergencyContacts</h3>
           </div>
           <div>
             <ul>
@@ -34,7 +34,7 @@
         </div>
         <div>
           <div>
-            <p>workHistory</p>
+            <h3>workHistory</h3>
           </div>
           <div>
             <ul>
@@ -45,7 +45,7 @@
         </div>
         <div>
           <div>
-            <p>skillCategories</p>
+            <h3>skillCategories</h3>
           </div>
           <div>
             <ul>
@@ -57,7 +57,7 @@
         </div>
         <div>
           <div>
-            <p>projectGroups</p>
+            <h3>projectGroups</h3>
           </div>
           <div>
             <ul>
@@ -70,7 +70,7 @@
       <div class="emergencycontacts emergencycontacts-rfx2f9">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>Sarah Johnson</p>
@@ -78,7 +78,7 @@
         </div>
         <div>
           <div>
-            <p>phone</p>
+            <h3>phone</h3>
           </div>
           <div>
             <p>+1-555-0123</p>
@@ -86,7 +86,7 @@
         </div>
         <div>
           <div>
-            <p>relationship</p>
+            <h3>relationship</h3>
           </div>
           <div>
             <p>Family</p>
@@ -96,7 +96,7 @@
       <div class="emergencycontacts emergencycontacts-i3mm2y">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>Mike Chen</p>
@@ -104,7 +104,7 @@
         </div>
         <div>
           <div>
-            <p>phone</p>
+            <h3>phone</h3>
           </div>
           <div>
             <p>+1-555-0456</p>
@@ -112,7 +112,7 @@
         </div>
         <div>
           <div>
-            <p>relationship</p>
+            <h3>relationship</h3>
           </div>
           <div>
             <p>Friend</p>
@@ -122,7 +122,7 @@
       <div class="workhistory workhistory-f6vxk9">
         <div>
           <div>
-            <p>company</p>
+            <h3>company</h3>
           </div>
           <div>
             <p>Tech Innovations Inc</p>
@@ -130,7 +130,7 @@
         </div>
         <div>
           <div>
-            <p>position</p>
+            <h3>position</h3>
           </div>
           <div>
             <p>Senior Developer</p>
@@ -138,7 +138,7 @@
         </div>
         <div>
           <div>
-            <p>startDate</p>
+            <h3>startDate</h3>
           </div>
           <div>
             <p>2020-03-15</p>
@@ -146,7 +146,7 @@
         </div>
         <div>
           <div>
-            <p>endDate</p>
+            <h3>endDate</h3>
           </div>
           <div>
             <p>2023-06-30</p>
@@ -154,7 +154,7 @@
         </div>
         <div>
           <div>
-            <p>responsibilities</p>
+            <h3>responsibilities</h3>
           </div>
           <div>
             <ul>
@@ -168,7 +168,7 @@
       <div class="workhistory workhistory-5sglgq">
         <div>
           <div>
-            <p>company</p>
+            <h3>company</h3>
           </div>
           <div>
             <p>Digital Solutions Ltd</p>
@@ -176,7 +176,7 @@
         </div>
         <div>
           <div>
-            <p>position</p>
+            <h3>position</h3>
           </div>
           <div>
             <p>Software Engineer</p>
@@ -184,7 +184,7 @@
         </div>
         <div>
           <div>
-            <p>startDate</p>
+            <h3>startDate</h3>
           </div>
           <div>
             <p>2018-01-10</p>
@@ -192,7 +192,7 @@
         </div>
         <div>
           <div>
-            <p>endDate</p>
+            <h3>endDate</h3>
           </div>
           <div>
             <p>2020-02-28</p>
@@ -200,7 +200,7 @@
         </div>
         <div>
           <div>
-            <p>responsibilities</p>
+            <h3>responsibilities</h3>
           </div>
           <div>
             <ul>
@@ -214,7 +214,7 @@
       <div class="skillcategories skillcategories-xbjqvk">
         <div>
           <div>
-            <p>@items</p>
+            <h3>@items</h3>
           </div>
           <div>
             <ul>
@@ -228,7 +228,7 @@
       <div class="skillcategories skillcategories-1pqfky">
         <div>
           <div>
-            <p>@items</p>
+            <h3>@items</h3>
           </div>
           <div>
             <ul>
@@ -242,7 +242,7 @@
       <div class="skillcategories skillcategories-24u1wd">
         <div>
           <div>
-            <p>@items</p>
+            <h3>@items</h3>
           </div>
           <div>
             <ul>
@@ -256,7 +256,7 @@
       <div class="projectgroups projectgroups-7v8ajv">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>E-commerce Platform</p>
@@ -264,7 +264,7 @@
         </div>
         <div>
           <div>
-            <p>description</p>
+            <h3>description</h3>
           </div>
           <div>
             <p>Built a scalable online shopping platform with payment integration</p>
@@ -272,7 +272,7 @@
         </div>
         <div>
           <div>
-            <p>status</p>
+            <h3>status</h3>
           </div>
           <div>
             <p>Completed</p>
@@ -280,7 +280,7 @@
         </div>
         <div>
           <div>
-            <p>priority</p>
+            <h3>priority</h3>
           </div>
           <div>
             <p>5</p>
@@ -290,7 +290,7 @@
       <div class="projectgroups projectgroups-l0cg2p">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>Mobile App Development</p>
@@ -298,7 +298,7 @@
         </div>
         <div>
           <div>
-            <p>description</p>
+            <h3>description</h3>
           </div>
           <div>
             <p>Created cross-platform mobile application for iOS and Android</p>
@@ -306,7 +306,7 @@
         </div>
         <div>
           <div>
-            <p>status</p>
+            <h3>status</h3>
           </div>
           <div>
             <p>Active</p>
@@ -314,7 +314,7 @@
         </div>
         <div>
           <div>
-            <p>priority</p>
+            <h3>priority</h3>
           </div>
           <div>
             <p>4</p>
@@ -324,7 +324,7 @@
       <div class="projectgroups projectgroups-1zr93v">
         <div>
           <div>
-            <p>@items</p>
+            <h3>@items</h3>
           </div>
           <div>
             <ul>
@@ -337,7 +337,7 @@
       <div class="projectgroups projectgroups-wibmsz">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>Data Analytics Dashboard</p>
@@ -345,7 +345,7 @@
         </div>
         <div>
           <div>
-            <p>description</p>
+            <h3>description</h3>
           </div>
           <div>
             <p>Real-time analytics dashboard for business intelligence</p>
@@ -353,7 +353,7 @@
         </div>
         <div>
           <div>
-            <p>status</p>
+            <h3>status</h3>
           </div>
           <div>
             <p>Planning</p>
@@ -361,7 +361,7 @@
         </div>
         <div>
           <div>
-            <p>priority</p>
+            <h3>priority</h3>
           </div>
           <div>
             <p>3</p>
@@ -371,7 +371,7 @@
       <div class="projectgroups projectgroups-j34nj3">
         <div>
           <div>
-            <p>name</p>
+            <h3>name</h3>
           </div>
           <div>
             <p>API Gateway Migration</p>
@@ -379,7 +379,7 @@
         </div>
         <div>
           <div>
-            <p>description</p>
+            <h3>description</h3>
           </div>
           <div>
             <p>Migrating legacy APIs to new cloud-based gateway</p>
@@ -387,7 +387,7 @@
         </div>
         <div>
           <div>
-            <p>status</p>
+            <h3>status</h3>
           </div>
           <div>
             <p>On Hold</p>
@@ -395,7 +395,7 @@
         </div>
         <div>
           <div>
-            <p>priority</p>
+            <h3>priority</h3>
           </div>
           <div>
             <p>2</p>
@@ -405,7 +405,7 @@
       <div class="projectgroups projectgroups-y8emdn">
         <div>
           <div>
-            <p>@items</p>
+            <h3>@items</h3>
           </div>
           <div>
             <ul>

--- a/test/form/utils/mocks/nestedForm.html
+++ b/test/form/utils/mocks/nestedForm.html
@@ -5,7 +5,7 @@
       <div class="da-form">
         <div>
           <div>
-            <p>x-schema-name</p>
+            <h3>x-schema-name</h3>
           </div>
           <div>
             <p>coffee-promotion</p>
@@ -13,7 +13,7 @@
         </div>
         <div>
           <div>
-            <p>title</p>
+            <h3>title</h3>
           </div>
           <div>
             <p>coffee</p>
@@ -23,7 +23,7 @@
       <div class="coffee-promotion">
         <div>
           <div>
-            <p>headline</p>
+            <h3>headline</h3>
           </div>
           <div>
             <p>Coffee Promotion</p>
@@ -31,7 +31,7 @@
         </div>
         <div>
           <div>
-            <p>detail</p>
+            <h3>detail</h3>
           </div>
           <div>
             <p>Some Test Promotion</p>
@@ -39,7 +39,7 @@
         </div>
         <div>
           <div>
-            <p>list</p>
+            <h3>list</h3>
           </div>
           <div>
             <ul>
@@ -50,7 +50,7 @@
         </div>
         <div>
           <div>
-            <p>ctas</p>
+            <h3>ctas</h3>
           </div>
           <div>
             <ul>
@@ -63,7 +63,7 @@
       <div class="ctas ctas-qr7hx4">
         <div>
           <div>
-            <p>ctaLabel</p>
+            <h3>ctaLabel</h3>
           </div>
           <div>
             <p>Click Here 1</p>
@@ -71,7 +71,7 @@
         </div>
         <div>
           <div>
-            <p>ctaUrl</p>
+            <h3>ctaUrl</h3>
           </div>
           <div>
             <p>https://www.adobe.com</p>
@@ -81,7 +81,7 @@
       <div class="ctas ctas-qr7hx3">
         <div>
           <div>
-            <p>ctaLabel</p>
+            <h3>ctaLabel</h3>
           </div>
           <div>
             <p>Click Here 2</p>
@@ -89,7 +89,7 @@
         </div>
         <div>
           <div>
-            <p>ctaUrl</p>
+            <h3>ctaUrl</h3>
           </div>
           <div>
             <p>https://www.adobe.com</p>

--- a/test/form/utils/mocks/rootArray.html
+++ b/test/form/utils/mocks/rootArray.html
@@ -4,17 +4,17 @@
     <div>
       <div class="da-form">
         <div>
-          <div><p>x-schema-name</p></div>
+          <div><h3>x-schema-name</h3></div>
           <div><p>color-families</p></div>
         </div>
         <div>
-          <div><p>title</p></div>
+          <div><h3>title</h3></div>
           <div><p>Color Families</p></div>
         </div>
       </div>
       <div class="color-families">
         <div>
-          <div><p>@items</p></div>
+          <div><h3>@items</h3></div>
           <div>
             <ul>
               <li>self://#color-families-abcdef</li>
@@ -25,7 +25,7 @@
       </div>
       <div class="groups groups-mnopqr">
         <div>
-          <div><p>@items</p></div>
+          <div><h3>@items</h3></div>
           <div>
             <ul>
               <li>brown, tan, beige</li>
@@ -36,7 +36,7 @@
       </div>
       <div class="groups groups-stuvwx">
         <div>
-          <div><p>@items</p></div>
+          <div><h3>@items</h3></div>
           <div>
             <ul>
               <li>rust, terracotta</li>
@@ -46,11 +46,11 @@
       </div>
       <div class="color-families color-families-abcdef">
         <div>
-          <div><p>name</p></div>
+          <div><h3>name</h3></div>
           <div><p>Earth Tones</p></div>
         </div>
         <div>
-          <div><p>groups</p></div>
+          <div><h3>groups</h3></div>
           <div>
             <ul>
               <li>self://#groups-mnopqr</li>
@@ -61,7 +61,7 @@
       </div>
       <div class="groups groups-yz1234">
         <div>
-          <div><p>@items</p></div>
+          <div><h3>@items</h3></div>
           <div>
             <ul>
               <li>navy, sky, aqua</li>
@@ -71,11 +71,11 @@
       </div>
       <div class="color-families color-families-ghijkl">
         <div>
-          <div><p>name</p></div>
+          <div><h3>name</h3></div>
           <div><p>Ocean Blues</p></div>
         </div>
         <div>
-          <div><p>groups</p></div>
+          <div><h3>groups</h3></div>
           <div>
             <ul>
               <li>self://#groups-yz1234</li>

--- a/test/form/utils/mocks/simpleArray.html
+++ b/test/form/utils/mocks/simpleArray.html
@@ -1,5 +1,5 @@
 <body>
   <header></header>
-  <main><div><div class="da-form"><div><div><p>x-schema-name</p></div><div><p>undefined</p></div></div><div><div><p>title</p></div><div><p>test-array-v-7</p></div></div></div><div class="undefined"><div><div><p>name</p></div><div><p>test</p></div></div><div><div><p>projectGroups</p></div><div><ul><li>self://#projectgroups-fkrn08</li></ul></div></div></div><div class="projectgroups projectgroups-4n80im"><div><div><p>name</p></div><div><p>project 4</p></div></div></div><div class="projectgroups projectgroups-fkrn08"><div><div><p>@items</p></div><div><ul><li>self://#projectgroups-4n80im</li></ul></div></div></div></div></main>
+  <main><div><div class="da-form"><div><div><h3>x-schema-name</h3></div><div><p>undefined</p></div></div><div><div><h3>title</h3></div><div><p>test-array-v-7</p></div></div></div><div class="undefined"><div><div><h3>name</h3></div><div><p>test</p></div></div><div><div><h3>projectGroups</h3></div><div><ul><li>self://#projectgroups-fkrn08</li></ul></div></div></div><div class="projectgroups projectgroups-4n80im"><div><div><h3>name</h3></div><div><p>project 4</p></div></div></div><div class="projectgroups projectgroups-fkrn08"><div><div><h3>@items</h3></div><div><ul><li>self://#projectgroups-4n80im</li></ul></div></div></div></div></main>
   <footer></footer>
 </body>

--- a/test/form/utils/mocks/simpleForm.html
+++ b/test/form/utils/mocks/simpleForm.html
@@ -5,7 +5,7 @@
       <div class="da-form">
         <div>
           <div>
-            <p>x-schema-name</p>
+            <h3>x-schema-name</h3>
           </div>
           <div>
             <p>coffee-promotion</p>
@@ -13,7 +13,7 @@
         </div>
         <div>
           <div>
-            <p>title</p>
+            <h3>title</h3>
           </div>
           <div>
             <p>coffee</p>
@@ -23,7 +23,7 @@
       <div class="coffee-promotion">
         <div>
           <div>
-            <p>headline</p>
+            <h3>headline</h3>
           </div>
           <div>
             <p>Coffee Promotion</p>
@@ -31,7 +31,7 @@
         </div>
         <div>
           <div>
-            <p>detail</p>
+            <h3>detail</h3>
           </div>
           <div>
             <p>Some Test Promotion</p>
@@ -39,7 +39,7 @@
         </div>
         <div>
           <div>
-            <p>empty</p>
+            <h3>empty</h3>
           </div>
           <div>
             <p></p>
@@ -47,7 +47,7 @@
         </div>
         <div>
           <div>
-            <p>list</p>
+            <h3>list</h3>
           </div>
           <div>
             <ul>
@@ -58,7 +58,7 @@
         </div>
         <div>
           <div>
-            <p>number0</p>
+            <h3>number0</h3>
           </div>
           <div>
             <p>0</p>
@@ -66,7 +66,7 @@
         </div>
         <div>
           <div>
-            <p>number1</p>
+            <h3>number1</h3>
           </div>
           <div>
             <p>123</p>
@@ -74,7 +74,7 @@
         </div>
         <div>
           <div>
-            <p>number2</p>
+            <h3>number2</h3>
           </div>
           <div>
             <p>456.789</p>
@@ -82,7 +82,7 @@
         </div>
         <div>
           <div>
-            <p>number3</p>
+            <h3>number3</h3>
           </div>
           <div>
             <p>-123</p>
@@ -90,7 +90,7 @@
         </div>
         <div>
           <div>
-            <p>boolean1</p>
+            <h3>boolean1</h3>
           </div>
           <div>
             <p>true</p>
@@ -98,7 +98,7 @@
         </div>
         <div>
           <div>
-            <p>boolean2</p>
+            <h3>boolean2</h3>
           </div>
           <div>
             <p>false</p>
@@ -106,7 +106,7 @@
         </div>
         <div>
           <div>
-            <p>ctas</p>
+            <h3>ctas</h3>
           </div>
           <div>
             <ul>
@@ -119,7 +119,7 @@
       <div class="ctas ctas-clmvfy">
         <div>
           <div>
-            <p>ctaLabel</p>
+            <h3>ctaLabel</h3>
           </div>
           <div>
             <p>Click Here 1</p>
@@ -127,7 +127,7 @@
         </div>
         <div>
           <div>
-            <p>ctaUrl</p>
+            <h3>ctaUrl</h3>
           </div>
           <div>
             <p>https://www.adobe.com</p>
@@ -137,7 +137,7 @@
       <div class="ctas ctas-azsrxg">
         <div>
           <div>
-            <p>ctaLabel</p>
+            <h3>ctaLabel</h3>
           </div>
           <div>
             <p>Click Here 2</p>
@@ -145,7 +145,7 @@
         </div>
         <div>
           <div>
-            <p>ctaUrl</p>
+            <h3>ctaUrl</h3>
           </div>
           <div>
             <p>https://www.adobe.com</p>


### PR DESCRIPTION
This change ensures that SC properties can be reliably indexed into a query index, regardless of their order in the underlying document table. Previously, indexing depended on the sequence of properties, which made it fragile and inconsistent.

By persisting property names as headings in the document, we ensure each property has a consistent identifier, an ID automatically generated by EDS from the heading text.

Note: The delivery worker already supports this change, so no additional updates are needed on the worker side.

Test URLs:
- https://main--da-sc--kozmaadrian.aem.page/forms/behr/h3-test
- https://da-sc.adobeaem.workers.dev/preview/kozmaadrian/da-sc/forms/behr/h3-test
