### PR TITLE
#431: loc, add 'cache-control: no-cache' header to fetch document to …

### DIFF
--- a/nx/blocks/loc/views/translate/index.js
+++ b/nx/blocks/loc/views/translate/index.js
@@ -48,7 +48,11 @@ export async function getUrls(
 
     // Fetch the content and add DNT
     const fetchUrl = async (url) => {
-      const resp = await daFetch(`${DA_ORIGIN}/source/${org}/${site}${url.daDestPath}`);
+      const resp = await daFetch(`${DA_ORIGIN}/source/${org}/${site}${url.daDestPath}`, {
+        headers: {
+          'Cache-Control': 'no-cache',
+        },
+      });
       if (!resp.ok) {
         url.error = `Error fetching content from ${url.daDestPath} - ${resp.status}`;
         return;


### PR DESCRIPTION
Fix #431

When sending the document to the translation provider it is read from the browser cache. Depending on authoring updates and the current browser session this causes a stale document to be sent to the TMS not including latest changes.

Tested with browser dev tool overwrite

