### PR TITLE
feat: expand api.js with Helix 6 endpoint coverage

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -69,6 +69,23 @@ Decided to wrap nav and sidenav in semantic HTML elements:
 - Added to JS conventions section. Core idea: push validation to the boundary where data enters, return `null` or a well-formed result — no ambiguous middle ground. Downstream code trusts the shape without re-checking.
 - Codifies the distinct meaning of `null` (absent), `undefined` (not yet loaded), and `''` (explicitly cleared).
 - `parseWindowPath` is the canonical example: returns a clean `{ view, org, site, path }` or `null`.
+## 2026-05-07
+
+### nx2/utils/api.js — namespaced helpers + Helix 6 endpoint coverage
+- Replaced flat exports (`getSource`, `putSource`, etc.) with namespaced objects: `source`, `versions`, `config`, `org`, `status`, `aem` (combined preview + live), `log`, `snapshot`, `jobs`. Low-level primitives (`daFetch`, `isHlx6`, `signout`, `hlx6ToDaList`) stay top-level.
+- Two private URL builders: `getDaApiPath` for DA ↔ AEM endpoints (source/list/config/versions), `getAemApiPath` for AEM-only endpoints. AEM-only legacy fallback hits `HLX_ADMIN` with hardcoded `ref=main`.
+- Bulk endpoints inlined: `status.get`, `aem.preview`/`unPreview`/`publish`/`unPublish`, `snapshot.addPath`/`removePath` accept `daPath` as string or array. Array of length ≥ 2 dispatches to `/*` with JSON body `{ paths, delete? }`.
+- hlx6-only methods (`source.copy`/`move`, `versions.get`, `org.listSites`, `config.getAggregated`, `jobs.test`) return `{ error, status: 501 }` on legacy.
+- IMS import refactored from doubly-dynamic IIFE to relative `import { loadIms, handleSignIn } from './ims.js';` — same production behavior, no top-level await, lets the wtr importmap mock cleanly.
+- Snapshots: new API uses plural `/snapshots/{path}`, legacy uses singular `/snapshot/{org}/{site}/main{path}` — handled in `getAemApiPath`. Same singular/plural switch for `jobs`/`job`.
+- Migrated `nx/blocks/importer/index.js` from `putSource` to `source.put`.
+- New tests at `test/nx2/utils/api.test.js` (68 tests) covering daFetch, isHlx6, every namespace method, bulk dispatcher, hlx6-only short-circuits, hlx6ToDaList, signout. Added `/nx2/utils/ims.js` → `/nx2/test/mocks/ims.js` to the top-level `web-test-runner.config.mjs` importmap.
+
+### Out of scope
+- `code`, `cache`, `index`, `sitemap`, `media`, `discover` namespaces — explicitly skipped.
+- Login/logout/profile, config sub-namespaces (users/secrets/apikeys/tokens), nested config, profile config, org profiles — DA uses IMS, none of these are needed in the DA flow.
+- `versions.get` legacy — DA's versionsource get-by-id pattern isn't documented and existing repo usage only has POST-to-create. Marked hlx6-only with 501 on legacy.
+
 ## 2026-04-04
 
 ### Panel-aware default-content max-width

--- a/nx/blocks/importer/index.js
+++ b/nx/blocks/importer/index.js
@@ -1,5 +1,5 @@
 import { replaceHtml } from '../../utils/daFetch.js';
-import { isHlx6, putSource } from '../../../nx2/utils/api.js';
+import { isHlx6, source } from '../../../nx2/utils/api.js';
 import { mdToDocDom, docDomToAemHtml } from '../../utils/converters.js';
 import { Queue } from '../../public/utils/tree.js';
 
@@ -101,7 +101,7 @@ async function saveAllToDa(url, blob) {
   const body = blob;
 
   try {
-    const resp = await putSource({ org: toOrg, site: toRepo, daPath: formattedPath, body });
+    const resp = await source.put({ org: toOrg, site: toRepo, path: formattedPath, body });
     return resp.status;
   } catch {
     // eslint-disable-next-line no-console

--- a/nx2/public/utils/tree.js
+++ b/nx2/public/utils/tree.js
@@ -58,7 +58,7 @@ async function getChildren(path) {
     const opts = continuationToken
       ? { headers: { 'da-continuation-token': continuationToken } }
       : {};
-    const resp = await daFetch(`${DA_ORIGIN}/list${path}`, opts);
+    const resp = await daFetch({ url: `${DA_ORIGIN}/list${path}`, opts });
     if (!resp.ok) break;
 
     const json = await resp.json();

--- a/nx2/test/mocks/scripts-utils.js
+++ b/nx2/test/mocks/scripts-utils.js
@@ -1,0 +1,3 @@
+export function getNx() {
+  return '/nx2';
+}

--- a/nx2/utils/api.d.ts
+++ b/nx2/utils/api.d.ts
@@ -1,0 +1,310 @@
+/**
+ * Type declarations for nx2/utils/api.js
+ *
+ * Every namespace method accepts either an object form
+ * `{ org, site, path, ...extras }` or a path-string form
+ * `'/org/site/file/path'` (with extras passed as the second arg).
+ */
+
+/** A `Response` augmented with parsed permission hints from x-da-(child-)actions. */
+export interface ApiResponse extends Response {
+  permissions: string[];
+}
+
+// ─── low-level ──────────────────────────────────────────────────────────────
+
+export function daFetch(args: {
+  url: string;
+  opts?: RequestInit;
+  redirect?: boolean;
+}): Promise<ApiResponse>;
+
+export function isHlx6(org: string, site: string): Promise<boolean>;
+
+export function signout(): void;
+
+export function hlx6ToDaList(parentPath: string, items: any[]): any[];
+
+/** Split `/org/site/file/path` into `{ org, site, path }`. */
+export function fromPath(fullPath: string): { org: string; site: string; path: string };
+
+// ─── source ─────────────────────────────────────────────────────────────────
+
+export const source: {
+  get(arg: { org: string; site: string; path?: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  get(fullPath: string): Promise<ApiResponse>;
+
+  /**
+   * List a folder. Pass `{ org }` (no site) to list sites at the org level —
+   * this falls back to DA-legacy `/list/{org}` (no hlx6 equivalent).
+   */
+  list(arg: { org: string; site?: string; path?: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/folder` string (omit trailing file for root). */
+  list(fullPath: string): Promise<ApiResponse>;
+
+  put(arg: {
+    org: string;
+    site: string;
+    path: string;
+    /** File contents to upload. */
+    body: BodyInit;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  put(
+    fullPath: string,
+    extras: {
+      /** File contents to upload. */
+      body: BodyInit;
+    },
+  ): Promise<ApiResponse>;
+
+  getMetadata(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  getMetadata(fullPath: string): Promise<ApiResponse>;
+
+  delete(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  delete(fullPath: string): Promise<ApiResponse>;
+
+  copy(arg: {
+    org: string;
+    site: string;
+    /** Source file path (leading-slash). */
+    path: string;
+    /** Destination file path (leading-slash). */
+    destination: string;
+    /** Conflict policy when destination exists. e.g. `'overwrite'`. */
+    collision?: 'overwrite' | string;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is the source `/org/site/file/path` string. */
+  copy(
+    fullPath: string,
+    extras: {
+      /** Destination file path (leading-slash). */
+      destination: string;
+      /** Conflict policy when destination exists. e.g. `'overwrite'`. */
+      collision?: string;
+    },
+  ): Promise<ApiResponse>;
+
+  move(arg: {
+    org: string;
+    site: string;
+    /** Source file path (leading-slash). */
+    path: string;
+    /** Destination file path (leading-slash). */
+    destination: string;
+    /** Conflict policy when destination exists. e.g. `'overwrite'`. */
+    collision?: 'overwrite' | string;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is the source `/org/site/file/path` string. */
+  move(
+    fullPath: string,
+    extras: {
+      /** Destination file path (leading-slash). */
+      destination: string;
+      /** Conflict policy when destination exists. e.g. `'overwrite'`. */
+      collision?: string;
+    },
+  ): Promise<ApiResponse>;
+
+  createFolder(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/folder` string. */
+  createFolder(fullPath: string): Promise<ApiResponse>;
+
+  deleteFolder(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/folder` string. */
+  deleteFolder(fullPath: string): Promise<ApiResponse>;
+};
+
+// ─── versions ───────────────────────────────────────────────────────────────
+
+export const versions: {
+  list(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  list(fullPath: string): Promise<ApiResponse>;
+
+  get(arg: {
+    org: string;
+    site: string;
+    path: string;
+    /** ULID on hlx6; `{versionGuid}/{fileGuid}.{ext}` segment on legacy DA. */
+    versionId: string;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  get(
+    fullPath: string,
+    extras: {
+      /** ULID on hlx6; `{versionGuid}/{fileGuid}.{ext}` segment on legacy DA. */
+      versionId: string;
+    },
+  ): Promise<ApiResponse>;
+
+  create(arg: {
+    org: string;
+    site: string;
+    path: string;
+    /** Operation that triggered the version (e.g. `'preview'`). */
+    operation?: string;
+    /** Optional human-readable label/comment for the version. */
+    comment?: string;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  create(
+    fullPath: string,
+    extras?: {
+      /** Operation that triggered the version (e.g. `'preview'`). */
+      operation?: string;
+      /** Optional human-readable label/comment for the version. */
+      comment?: string;
+    },
+  ): Promise<ApiResponse>;
+};
+
+// ─── config ─────────────────────────────────────────────────────────────────
+
+export const config: {
+  get(arg: { org: string; site?: string }): Promise<ApiResponse>;
+  put(arg: {
+    org: string;
+    site?: string;
+    /** Config payload (typically a JSON Blob or string). */
+    body: BodyInit;
+  }): Promise<ApiResponse>;
+  delete(arg: { org: string; site?: string }): Promise<ApiResponse>;
+  /** hlx6 only; returns `{ error, status: 501 }` on legacy. */
+  getAggregated(arg: { org: string; site: string }): Promise<ApiResponse | { error: string; status: 501 }>;
+};
+
+// ─── org ────────────────────────────────────────────────────────────────────
+
+export const org: {
+  listSites(arg: { org: string }): Promise<ApiResponse>;
+};
+
+// ─── status ────────────────────────────────────────────────────────────────
+
+export const status: {
+  /** Single-path only. H6 has no bulk status endpoint. */
+  get(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  get(fullPath: string): Promise<ApiResponse>;
+};
+
+// ─── aem (preview + live) ───────────────────────────────────────────────────
+
+export const aem: {
+  /** GET preview status (single only). */
+  getPreview(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  getPreview(fullPath: string): Promise<ApiResponse>;
+
+  /** GET publish status (single only). */
+  getPublish(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string. */
+  getPublish(fullPath: string): Promise<ApiResponse>;
+
+  /** Update preview. `path` array of 2+ → bulk. `forceUpdate`/`forceSync` are bulk-only. */
+  preview(arg: {
+    org: string;
+    site: string;
+    path: string | string[];
+    /** Bulk only: force update even if source is unchanged. */
+    forceUpdate?: boolean;
+    /** Bulk only: run synchronously and wait for the operation to complete. */
+    forceSync?: boolean;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string (single only). */
+  preview(fullPath: string): Promise<ApiResponse>;
+
+  /** Remove from preview. `path` array of 2+ → bulk with `{ delete: true }`. */
+  unPreview(arg: { org: string; site: string; path: string | string[] }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string (single only). */
+  unPreview(fullPath: string): Promise<ApiResponse>;
+
+  /** Publish. `path` array of 2+ → bulk. `forceUpdate`/`forceSync` are bulk-only. */
+  publish(arg: {
+    org: string;
+    site: string;
+    path: string | string[];
+    /** Bulk only: force update even if source is unchanged. */
+    forceUpdate?: boolean;
+    /** Bulk only: run synchronously and wait for the operation to complete. */
+    forceSync?: boolean;
+  }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string (single only). */
+  publish(fullPath: string): Promise<ApiResponse>;
+
+  /** Unpublish. `path` array of 2+ → bulk with `{ delete: true }`. */
+  unPublish(arg: { org: string; site: string; path: string | string[] }): Promise<ApiResponse>;
+  /** `fullPath` is a `/org/site/file/path` string (single only). */
+  unPublish(fullPath: string): Promise<ApiResponse>;
+};
+
+// ─── snapshot ───────────────────────────────────────────────────────────────
+
+export const snapshot: {
+  list(arg: { org: string; site: string }): Promise<ApiResponse>;
+  get(arg: { org: string; site: string; snapshotId: string }): Promise<ApiResponse>;
+  update(arg: {
+    org: string;
+    site: string;
+    snapshotId: string;
+    /** Manifest payload to write to the snapshot. */
+    body?: any;
+  }): Promise<ApiResponse>;
+  delete(arg: { org: string; site: string; snapshotId: string }): Promise<ApiResponse>;
+  /** Add path(s). `path` array of 2+ → bulk. */
+  addPath(arg: {
+    org: string;
+    site: string;
+    snapshotId: string;
+    path: string | string[];
+  }): Promise<ApiResponse>;
+  /** Remove path(s). `path` array of 2+ → bulk with `{ delete: true }`. */
+  removePath(arg: {
+    org: string;
+    site: string;
+    snapshotId: string;
+    path: string | string[];
+  }): Promise<ApiResponse>;
+  publish(arg: { org: string; site: string; snapshotId: string }): Promise<ApiResponse>;
+  review(arg: {
+    org: string;
+    site: string;
+    snapshotId: string;
+    /** Review state to transition to. */
+    action: 'request' | 'approve' | 'reject';
+  }): Promise<ApiResponse>;
+};
+
+// ─── jobs ───────────────────────────────────────────────────────────────────
+
+export const jobs: {
+  /** Omit `name` to list jobs for the topic. */
+  get(arg: {
+    org: string;
+    site: string;
+    /** Job topic (e.g. `'preview'`, `'publish'`). */
+    topic: string;
+    /** Job name/id; omit to list all jobs in the topic. */
+    name?: string;
+  }): Promise<ApiResponse>;
+  details(arg: {
+    org: string;
+    site: string;
+    /** Job topic (e.g. `'preview'`, `'publish'`). */
+    topic: string;
+    /** Job name/id. */
+    name: string;
+  }): Promise<ApiResponse>;
+  stop(arg: {
+    org: string;
+    site: string;
+    /** Job topic (e.g. `'preview'`, `'publish'`). */
+    topic: string;
+    /** Job name/id. */
+    name: string;
+  }): Promise<ApiResponse>;
+};

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -92,7 +92,7 @@ const getDaApiPath = async (api, org, site, path = '') => {
 
   if (api === VERSIONS) {
     if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}/.versions`;
-    return `${DA_ADMIN}/versionsource/${org}/${site}${path}`;
+    return `${DA_ADMIN}/versionsource/${org}/${site}/${path}`;
   }
 
   if (api === CONFIG) {
@@ -108,12 +108,12 @@ const getDaApiPath = async (api, org, site, path = '') => {
   // HLX6 has no list api, so source formatting is used (with trailing slash).
   if (api === LIST) {
     if (!site) return `${DA_ADMIN}/list/${org}`;
-    return `${DA_ADMIN}/list/${org}/${site}${path}`;
+    return `${DA_ADMIN}/list/${org}/${site}/${path}`;
   }
 
   // SOURCE
   if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}`;
-  return `${DA_ADMIN}/source/${org}/${site}${path}`;
+  return `${DA_ADMIN}/source/${org}/${site}/${path}`;
 };
 
 // AEM-only endpoints. New API origin or legacy admin.hlx.page with ref=main.
@@ -251,7 +251,7 @@ export const source = {
     const formData = new FormData();
     formData.append('destination', destination);
     return daFetch({
-      url: `${DA_ADMIN}/copy/${org}/${site}${path}`,
+      url: `${DA_ADMIN}/copy/${org}/${site}/${path}`,
       opts: { method: 'POST', body: formData },
     });
   }),
@@ -268,7 +268,7 @@ export const source = {
     const formData = new FormData();
     formData.append('destination', destination);
     return daFetch({
-      url: `${DA_ADMIN}/move/${org}/${site}${path}`,
+      url: `${DA_ADMIN}/move/${org}/${site}/${path}`,
       opts: { method: 'POST', body: formData },
     });
   }),
@@ -292,7 +292,7 @@ export const versions = {
       return daFetch({ url: `${AEM_API}/${org}/sites/${site}/source${path}/.versions` });
     }
     // Legacy DA uses a separate /versionlist endpoint for listing.
-    return daFetch({ url: `${DA_ADMIN}/versionlist/${org}/${site}${path}` });
+    return daFetch({ url: `${DA_ADMIN}/versionlist/${org}/${site}/${path}` });
   }),
 
   // versionId on hlx6 is the ULID returned by versions.list; on legacy it is

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -216,7 +216,7 @@ export const source = {
   put: withArgs(async ({ org, site, path, body }) => {
     const hlx6 = await isHlx6(org, site);
     const url = await getDaApiPath(SOURCE, org, site, path);
-    const opts = { method: 'PUT' };
+    const opts = { method: 'POST' };
     if (hlx6) {
       const textExt = Object.keys(TEXT_TYPES).find((e) => path.endsWith(e));
       if (textExt) {

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -1,9 +1,16 @@
 import { HLX_ADMIN, AEM_API, DA_ADMIN, ALLOWED_TOKEN } from './utils.js';
+import { loadIms, handleSignIn } from './ims.js';
 
-const { loadIms, handleSignIn } = await (async () => {
-  const { getNx } = await import(`${window.location.origin}/scripts/utils.js`);
-  return import(`${getNx()}/utils/ims.js`);
-})();
+const SOURCE = 'source';
+const LIST = 'list';
+const CONFIG = 'config';
+const VERSIONS = 'versions';
+const REF = 'main';
+
+const TEXT_TYPES = {
+  '.html': 'text/html',
+  '.json': 'application/json',
+};
 
 export const daFetch = async ({ url, opts = { method: 'GET' }, redirect = false }) => {
   const { accessToken } = await loadIms();
@@ -75,103 +82,394 @@ export const isHlx6 = (() => {
   };
 })();
 
-const getApiPath = async (org, site, api, daPath) => {
+// DA-owned endpoints proxied between DA_ADMIN and AEM_API.
+const getDaApiPath = async (api, org, site, path = '') => {
   const hlx6 = await isHlx6(org, site);
 
-  if (api === 'versionsource') {
-    if (hlx6) return `${AEM_API}/${org}/sites/${site}/${api}${daPath}/.versions`;
-    return `${DA_ADMIN}/versionsource/${org}/${site}${daPath}`;
+  if (api === VERSIONS) {
+    if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}/.versions`;
+    return `${DA_ADMIN}/versionsource/${org}/${site}${path}`;
   }
 
-  if (api === 'config') {
+  if (api === CONFIG) {
     if (hlx6) {
       if (!site) return `${AEM_API}/${org}/config.json`;
       return `${AEM_API}/${org}/sites/${site}/config.json`;
     }
-    if (!site) return `${DA_ADMIN}/${api}/${org}/`;
-    return `${DA_ADMIN}/${api}/${org}/${site}/`;
+    if (!site) return `${DA_ADMIN}/config/${org}/`;
+    return `${DA_ADMIN}/config/${org}/${site}/`;
   }
 
-  // HLX6 does not have a list api,
-  // it will use the source formatting.
-  if (api === 'list') {
-    return `${DA_ADMIN}/${api}/${org}/${site}${daPath}`;
+  // HLX6 has no list api, so source formatting is used (with trailing slash).
+  if (api === LIST) {
+    if (!site) return `${DA_ADMIN}/list/${org}`;
+    return `${DA_ADMIN}/list/${org}/${site}${path}`;
   }
 
-  // api === 'source'
-  if (hlx6) return `${AEM_API}/${org}/sites/${site}/${api}${daPath}`;
-  return `${DA_ADMIN}/${api}/${org}/${site}${daPath}`;
+  // SOURCE
+  if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}`;
+  return `${DA_ADMIN}/source/${org}/${site}${path}`;
+};
+
+// AEM-only endpoints. New API origin or legacy admin.hlx.page with ref=main.
+const getAemApiPath = async (api, org, site, path = '') => {
+  const hlx6 = await isHlx6(org, site);
+
+  if (hlx6) {
+    if (api === 'jobs') return `${AEM_API}/${org}/sites/${site}/jobs${path}`;
+    if (api === 'snapshots') return `${AEM_API}/${org}/sites/${site}/snapshots${path}`;
+    return `${AEM_API}/${org}/sites/${site}/${api}${path}`;
+  }
+
+  // Legacy: singular forms for jobs/snapshots, ref in path.
+  if (api === 'jobs') return `${HLX_ADMIN}/job/${org}/${site}/${REF}${path}`;
+  if (api === 'snapshots') return `${HLX_ADMIN}/snapshot/${org}/${site}/${REF}${path}`;
+  return `${HLX_ADMIN}/${api}/${org}/${site}/${REF}${path}`;
+};
+
+const HLX6_ONLY = { error: 'Requires Helix 6 upgrade', status: 501 };
+
+// Convert a `/org/site/file/path` string into `{ org, site, path }`.
+export const fromPath = (str) => {
+  const [, org, site, ...parts] = str.split('/');
+  return { org, site, path: parts.length ? `/${parts.join('/')}` : '' };
+};
+
+// HOF: wraps a method body so it receives resolved args. The first arg
+// can be either `{ org, site, path, ...extras }` or a `/org/site/file/path`
+// string; `extras` (second positional) merges in when arg is a string.
+// `org` is required; `site` is required by most methods but optional for a
+// few (e.g., `source.list({ org })` lists at the org level on legacy DA).
+// Bad input is logged but still passed through — the resulting fetch
+// fails naturally and callers handle non-ok responses as usual.
+const withArgs = (fn) => (arg = {}, extras = {}) => {
+  const args = typeof arg === 'string'
+    ? { ...fromPath(arg), ...extras }
+    : arg;
+  if (!args.org) {
+    // eslint-disable-next-line no-console
+    console.error('api: invalid args - pass /org/site/... string or { org, site, path }', arg);
+  }
+  return fn(args);
+};
+
+const jsonOpts = (method, payload) => ({
+  method,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+
+// Dispatcher for AEM ops that accept path as string or array.
+// Array of length >= 2 routes to the bulk /* endpoint with { paths, delete? }.
+// `forceUpdate`/`forceSync` are bulk-only (server ignores them on single-path).
+const callPath = async ({
+  api, org, site, path, method, includeDelete = false, forceUpdate, forceSync,
+}) => {
+  if (Array.isArray(path) && path.length >= 2) {
+    const url = await getAemApiPath(api, org, site, '/*');
+    const payload = { paths: path };
+    if (includeDelete) payload.delete = true;
+    if (forceUpdate) payload.forceUpdate = true;
+    if (forceSync) payload.forceSync = true;
+    return daFetch({ url, opts: jsonOpts('POST', payload) });
+  }
+  const single = Array.isArray(path) ? path[0] : path;
+  const url = await getAemApiPath(api, org, site, single);
+  return daFetch({ url, opts: { method } });
 };
 
 export const signout = () => {
-  daFetch(`${DA_ADMIN}/logout`);
+  daFetch({ url: `${DA_ADMIN}/logout` });
 };
 
-const TEXT_TYPES = {
-  '.html': 'text/html',
-  '.json': 'application/json',
-};
-
-export const putSource = async ({ org, site, daPath, body }) => {
-  const hlx6 = await isHlx6(org, site);
-  const url = await getApiPath(org, site, 'source', daPath);
-  const textExt = Object.keys(TEXT_TYPES).find((e) => daPath.endsWith(e));
-  const opts = { method: 'POST' };
-  if (hlx6) {
-    const hlx6Opts = { ...opts };
-    // Convert blobs to text for HLX6
-    if (textExt) {
-      hlx6Opts.body = body instanceof Blob ? await body.text() : body;
-      hlx6Opts.headers = { 'Content-Type': TEXT_TYPES[textExt] };
-    } else {
-      hlx6Opts.body = body;
-    }
-    return daFetch({ url, opts: hlx6Opts });
-  }
-  const formData = new FormData();
-  formData.append('data', body);
-  const daOpts = { ...opts, body: formData };
-  return daFetch({ url, opts: daOpts });
-};
-
-export const getSource = async ({ org, site, daPath }) => {
-  const url = await getApiPath(org, site, 'source', daPath);
-  return daFetch({ url });
-};
-
-export const listSource = async ({ org, site, daPath }) => {
-  const hlx6 = await isHlx6(org, site);
-  if (hlx6) {
-    const path = daPath ? `/${daPath}/` : '/';
-    const url = await getApiPath(org, site, 'source', path);
+// source: DA <-> AEM document operations. First arg is either
+// { org, site, path, ...extras } or a `/org/site/file/path` string.
+// `extras` (second arg) merges with parsed args when arg is a string.
+export const source = {
+  get: withArgs(async ({ org, site, path }) => {
+    const url = await getDaApiPath(SOURCE, org, site, path);
     return daFetch({ url });
-  }
-  const url = await getApiPath(org, site, 'list', daPath);
-  return daFetch({ url });
+  }),
+
+  list: withArgs(async ({ org, site, path }) => {
+    // Org-only list (no site) is DA-legacy only; hlx6 has no equivalent.
+    if (site) {
+      const hlx6 = await isHlx6(org, site);
+      if (hlx6) {
+        const slashed = path ? `${path}/` : '/';
+        const url = await getDaApiPath(SOURCE, org, site, slashed);
+        return daFetch({ url });
+      }
+    }
+    const url = await getDaApiPath(LIST, org, site, path);
+    return daFetch({ url });
+  }),
+
+  put: withArgs(async ({ org, site, path, body }) => {
+    const hlx6 = await isHlx6(org, site);
+    const url = await getDaApiPath(SOURCE, org, site, path);
+    const opts = { method: 'PUT' };
+    if (hlx6) {
+      const textExt = Object.keys(TEXT_TYPES).find((e) => path.endsWith(e));
+      if (textExt) {
+        opts.body = body instanceof Blob ? await body.text() : body;
+        opts.headers = { 'Content-Type': TEXT_TYPES[textExt] };
+      } else {
+        opts.body = body;
+      }
+      return daFetch({ url, opts });
+    }
+    const formData = new FormData();
+    formData.append('data', body);
+    opts.body = formData;
+    return daFetch({ url, opts });
+  }),
+
+  getMetadata: withArgs(async ({ org, site, path }) => {
+    const url = await getDaApiPath(SOURCE, org, site, path);
+    return daFetch({ url, opts: { method: 'HEAD' } });
+  }),
+
+  delete: withArgs(async ({ org, site, path }) => {
+    const url = await getDaApiPath(SOURCE, org, site, path);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  }),
+
+  copy: withArgs(async ({ org, site, path, destination, collision }) => {
+    const hlx6 = await isHlx6(org, site);
+    if (hlx6) {
+      const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
+      url.searchParams.set('source', path);
+      if (collision) url.searchParams.set('collision', collision);
+      return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+    }
+    const formData = new FormData();
+    formData.append('destination', destination);
+    return daFetch({
+      url: `${DA_ADMIN}/copy/${org}/${site}${path}`,
+      opts: { method: 'POST', body: formData },
+    });
+  }),
+
+  move: withArgs(async ({ org, site, path, destination, collision }) => {
+    const hlx6 = await isHlx6(org, site);
+    if (hlx6) {
+      const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
+      url.searchParams.set('source', path);
+      url.searchParams.set('move', 'true');
+      if (collision) url.searchParams.set('collision', collision);
+      return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+    }
+    const formData = new FormData();
+    formData.append('destination', destination);
+    return daFetch({
+      url: `${DA_ADMIN}/move/${org}/${site}${path}`,
+      opts: { method: 'POST', body: formData },
+    });
+  }),
+
+  createFolder: withArgs(async ({ org, site, path }) => {
+    const url = await getDaApiPath(SOURCE, org, site, `${path}/`);
+    return daFetch({ url, opts: { method: 'POST' } });
+  }),
+
+  deleteFolder: withArgs(async ({ org, site, path }) => {
+    const url = await getDaApiPath(SOURCE, org, site, `${path}/`);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  }),
 };
 
-export const putVersion = async ({ org, site, daPath, operation, comment }) => {
-  const url = new URL(await getApiPath(org, site, 'versionsource', daPath));
-  if (operation) url.searchParams.set('operation', operation);
-  if (comment) url.searchParams.set('comment', comment);
-  const opts = { method: 'POST' };
-  return daFetch({ url: url.toString(), opts });
+// versions: list/get/create document versions.
+export const versions = {
+  list: withArgs(async ({ org, site, path }) => {
+    const hlx6 = await isHlx6(org, site);
+    if (hlx6) {
+      return daFetch({ url: `${AEM_API}/${org}/sites/${site}/source${path}/.versions` });
+    }
+    // Legacy DA uses a separate /versionlist endpoint for listing.
+    return daFetch({ url: `${DA_ADMIN}/versionlist/${org}/${site}${path}` });
+  }),
+
+  // versionId on hlx6 is the ULID returned by versions.list; on legacy it is
+  // the trailing `{versionGuid}/{fileGuid}.{ext}` segment from the list response.
+  get: withArgs(async ({ org, site, path, versionId }) => {
+    const hlx6 = await isHlx6(org, site);
+    if (hlx6) {
+      const url = `${AEM_API}/${org}/sites/${site}/source${path}/.versions/${versionId}`;
+      return daFetch({ url });
+    }
+    return daFetch({ url: `${DA_ADMIN}/versionsource/${org}/${versionId}` });
+  }),
+
+  create: withArgs(async ({ org, site, path, operation, comment }) => {
+    const hlx6 = await isHlx6(org, site);
+    const url = await getDaApiPath(VERSIONS, org, site, path);
+    const opts = { method: 'POST' };
+    if (hlx6) {
+      // hlx6 accepts { operation, comment } JSON body.
+      const payload = {};
+      if (operation) payload.operation = operation;
+      if (comment) payload.comment = comment;
+      if (Object.keys(payload).length > 0) {
+        opts.headers = { 'Content-Type': 'application/json' };
+        opts.body = JSON.stringify(payload);
+      }
+    } else if (comment) {
+      // Legacy DA accepts { label } JSON body. Map comment -> label.
+      opts.body = JSON.stringify({ label: comment });
+    }
+    return daFetch({ url, opts });
+  }),
 };
 
-export const getConfig = async ({ org, site }) => {
-  const url = await getApiPath(org, site, 'config');
-  return daFetch({ url });
+// config: top-level org/site config.
+export const config = {
+  get: async ({ org, site }) => {
+    const url = await getDaApiPath(CONFIG, org, site);
+    return daFetch({ url });
+  },
+
+  put: async ({ org, site, body }) => {
+    const url = await getDaApiPath(CONFIG, org, site);
+    const formData = new FormData();
+    formData.append(CONFIG, body);
+    return daFetch({ url, opts: { method: 'POST', body: formData } });
+  },
+
+  delete: async ({ org, site }) => {
+    const url = await getDaApiPath(CONFIG, org, site);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  },
+
+  getAggregated: async ({ org, site }) => {
+    const hlx6 = await isHlx6(org, site);
+    if (!hlx6) return { ...HLX6_ONLY };
+    const url = `${AEM_API}/${org}/aggregated/${site}/config.json`;
+    return daFetch({ url });
+  },
 };
 
-export const putConfig = async ({ org, site, body }) => {
-  const url = await getApiPath(org, site, 'config');
+// org: organization-level operations. New-API only; no hlx6 detection
+// (no site to probe). The endpoint will 404 on non-migrated orgs.
+const orgNs = {
+  listSites: async ({ org }) => daFetch({ url: `${AEM_API}/${org}/sites` }),
+};
+export { orgNs as org };
 
-  const formData = new FormData();
-  formData.append('config', body);
+// status: single-path only. H6 has no bulk status endpoint.
+export const status = {
+  get: withArgs(async ({ org, site, path }) => {
+    const url = await getAemApiPath('status', org, site, path);
+    return daFetch({ url });
+  }),
+};
 
-  const opts = { method: 'POST', body: formData };
+// aem: combined preview + live operations.
+// preview/unPreview/publish/unPublish accept `path` as string or array (2+ -> bulk).
+// preview/publish also accept optional `forceUpdate`/`forceSync` flags.
+export const aem = {
+  getPreview: withArgs(({ org, site, path }) => callPath({
+    api: 'preview', org, site, path, method: 'GET',
+  })),
 
-  return daFetch({ url, opts });
+  getPublish: withArgs(({ org, site, path }) => callPath({
+    api: 'live', org, site, path, method: 'GET',
+  })),
+
+  preview: withArgs(({
+    org, site, path, forceUpdate, forceSync,
+  }) => callPath({
+    api: 'preview', org, site, path, method: 'POST', forceUpdate, forceSync,
+  })),
+
+  unPreview: withArgs(({ org, site, path }) => callPath({
+    api: 'preview', org, site, path, method: 'DELETE', includeDelete: true,
+  })),
+
+  publish: withArgs(({
+    org, site, path, forceUpdate, forceSync,
+  }) => callPath({
+    api: 'live', org, site, path, method: 'POST', forceUpdate, forceSync,
+  })),
+
+  unPublish: withArgs(({ org, site, path }) => callPath({
+    api: 'live', org, site, path, method: 'DELETE', includeDelete: true,
+  })),
+};
+
+// snapshot: snapshot CRUD and review/publish actions.
+export const snapshot = {
+  list: async ({ org, site }) => {
+    const url = await getAemApiPath('snapshots', org, site);
+    return daFetch({ url });
+  },
+
+  get: async ({ org, site, snapshotId }) => {
+    const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}`);
+    return daFetch({ url });
+  },
+
+  update: async ({ org, site, snapshotId, body }) => {
+    const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}`);
+    const opts = body ? jsonOpts('POST', body) : { method: 'POST' };
+    return daFetch({ url, opts });
+  },
+
+  delete: async ({ org, site, snapshotId }) => {
+    const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}`);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  },
+
+  addPath: async ({ org, site, snapshotId, path }) => {
+    if (Array.isArray(path) && path.length >= 2) {
+      const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}/*`);
+      return daFetch({ url, opts: jsonOpts('POST', { paths: path }) });
+    }
+    const single = Array.isArray(path) ? path[0] : path;
+    const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}${single}`);
+    return daFetch({ url, opts: { method: 'POST' } });
+  },
+
+  removePath: async ({ org, site, snapshotId, path }) => {
+    if (Array.isArray(path) && path.length >= 2) {
+      const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}/*`);
+      return daFetch({ url, opts: jsonOpts('POST', { paths: path, delete: true }) });
+    }
+    const single = Array.isArray(path) ? path[0] : path;
+    const url = await getAemApiPath('snapshots', org, site, `/${snapshotId}${single}`);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  },
+
+  publish: async ({ org, site, snapshotId }) => {
+    const url = new URL(await getAemApiPath('snapshots', org, site, `/${snapshotId}`));
+    url.searchParams.set('publish', 'true');
+    return daFetch({ url: url.toString(), opts: { method: 'POST' } });
+  },
+
+  review: async ({ org, site, snapshotId, action }) => {
+    const url = new URL(await getAemApiPath('snapshots', org, site, `/${snapshotId}`));
+    url.searchParams.set('review', action);
+    return daFetch({ url: url.toString(), opts: { method: 'POST' } });
+  },
+};
+
+// jobs: background job control.
+export const jobs = {
+  get: async ({ org, site, topic, name }) => {
+    const tail = name ? `/${topic}/${name}` : `/${topic}`;
+    const url = await getAemApiPath('jobs', org, site, tail);
+    return daFetch({ url });
+  },
+
+  details: async ({ org, site, topic, name }) => {
+    const url = await getAemApiPath('jobs', org, site, `/${topic}/${name}/details`);
+    return daFetch({ url });
+  },
+
+  stop: async ({ org, site, topic, name }) => {
+    const url = await getAemApiPath('jobs', org, site, `/${topic}/${name}`);
+    return daFetch({ url, opts: { method: 'DELETE' } });
+  },
 };
 
 export function hlx6ToDaList(parentPath, items) {

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -1,5 +1,9 @@
 import { HLX_ADMIN, AEM_API, DA_ADMIN, ALLOWED_TOKEN } from './utils.js';
-import { loadIms, handleSignIn } from './ims.js';
+
+const { loadIms, handleSignIn } = await (async () => {
+  const { getNx } = await import(`${window.location.origin}/scripts/utils.js`);
+  return import(`${getNx()}/utils/ims.js`);
+})();
 
 const SOURCE = 'source';
 const LIST = 'list';

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -137,7 +137,7 @@ const HLX6_ONLY = { error: 'Requires Helix 6 upgrade', status: 501 };
 // Convert a `/org/site/file/path` string into `{ org, site, path }`.
 export const fromPath = (str) => {
   const [, org, site, ...parts] = str.split('/');
-  return { org, site, path: parts.length ? `/${parts.join('/')}` : '' };
+  return { org, site, path: parts.length ? `${parts.join('/')}` : '' };
 };
 
 // HOF: wraps a method body so it receives resolved args. The first arg

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -92,7 +92,7 @@ const getDaApiPath = async (api, org, site, path = '') => {
 
   if (api === VERSIONS) {
     if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}/.versions`;
-    return `${DA_ADMIN}/versionsource/${org}/${site}/${path}`;
+    return `${DA_ADMIN}/versionsource/${org}/${site}${path}`;
   }
 
   if (api === CONFIG) {
@@ -108,12 +108,12 @@ const getDaApiPath = async (api, org, site, path = '') => {
   // HLX6 has no list api, so source formatting is used (with trailing slash).
   if (api === LIST) {
     if (!site) return `${DA_ADMIN}/list/${org}`;
-    return `${DA_ADMIN}/list/${org}/${site}/${path}`;
+    return `${DA_ADMIN}/list/${org}/${site}${path}`;
   }
 
   // SOURCE
   if (hlx6) return `${AEM_API}/${org}/sites/${site}/source${path}`;
-  return `${DA_ADMIN}/source/${org}/${site}/${path}`;
+  return `${DA_ADMIN}/source/${org}/${site}${path}`;
 };
 
 // AEM-only endpoints. New API origin or legacy admin.hlx.page with ref=main.
@@ -137,7 +137,7 @@ const HLX6_ONLY = { error: 'Requires Helix 6 upgrade', status: 501 };
 // Convert a `/org/site/file/path` string into `{ org, site, path }`.
 export const fromPath = (str) => {
   const [, org, site, ...parts] = str.split('/');
-  return { org, site, path: parts.length ? `${parts.join('/')}` : '' };
+  return { org, site, path: parts.length ? `/${parts.join('/')}` : '' };
 };
 
 // HOF: wraps a method body so it receives resolved args. The first arg
@@ -154,6 +154,9 @@ const withArgs = (fn) => (arg = {}, extras = {}) => {
   if (!args.org) {
     // eslint-disable-next-line no-console
     console.error('api: invalid args - pass /org/site/... string or { org, site, path }', arg);
+  }
+  if (!args.path.startsWith('/')) {
+    args.path = `/${args.path}`;
   }
   return fn(args);
 };
@@ -255,7 +258,7 @@ export const source = {
     formData.append('destination', destination);
     if (continuationToken) formData.append('continuation-token', continuationToken);
     return daFetch({
-      url: `${DA_ADMIN}/copy/${org}/${site}/${path}`,
+      url: `${DA_ADMIN}/copy/${org}/${site}${path}`,
       opts: { method: 'POST', body: formData },
     });
   }),
@@ -276,7 +279,7 @@ export const source = {
     formData.append('destination', destination);
     if (continuationToken) formData.append('continuation-token', continuationToken);
     return daFetch({
-      url: `${DA_ADMIN}/move/${org}/${site}/${path}`,
+      url: `${DA_ADMIN}/move/${org}/${site}${path}`,
       opts: { method: 'POST', body: formData },
     });
   }),
@@ -300,7 +303,7 @@ export const versions = {
       return daFetch({ url: `${AEM_API}/${org}/sites/${site}/source${path}/.versions` });
     }
     // Legacy DA uses a separate /versionlist endpoint for listing.
-    return daFetch({ url: `${DA_ADMIN}/versionlist/${org}/${site}/${path}` });
+    return daFetch({ url: `${DA_ADMIN}/versionlist/${org}/${site}${path}` });
   }),
 
   // versionId on hlx6 is the ULID returned by versions.list; on legacy it is

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -240,33 +240,41 @@ export const source = {
     return daFetch({ url, opts: { method: 'DELETE' } });
   }),
 
-  copy: withArgs(async ({ org, site, path, destination, collision }) => {
+  copy: withArgs(async ({
+    org, site, path, destination, collision, continuationToken,
+  }) => {
     const hlx6 = await isHlx6(org, site);
     if (hlx6) {
       const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
       url.searchParams.set('source', path);
       if (collision) url.searchParams.set('collision', collision);
+      if (continuationToken) url.searchParams.set('continuation-token', continuationToken);
       return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
     }
     const formData = new FormData();
     formData.append('destination', destination);
+    if (continuationToken) formData.append('continuation-token', continuationToken);
     return daFetch({
       url: `${DA_ADMIN}/copy/${org}/${site}/${path}`,
       opts: { method: 'POST', body: formData },
     });
   }),
 
-  move: withArgs(async ({ org, site, path, destination, collision }) => {
+  move: withArgs(async ({
+    org, site, path, destination, collision, continuationToken,
+  }) => {
     const hlx6 = await isHlx6(org, site);
     if (hlx6) {
       const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
       url.searchParams.set('source', path);
       url.searchParams.set('move', 'true');
       if (collision) url.searchParams.set('collision', collision);
+      if (continuationToken) url.searchParams.set('continuation-token', continuationToken);
       return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
     }
     const formData = new FormData();
     formData.append('destination', destination);
+    if (continuationToken) formData.append('continuation-token', continuationToken);
     return daFetch({
       url: `${DA_ADMIN}/move/${org}/${site}/${path}`,
       opts: { method: 'POST', body: formData },

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -96,10 +96,11 @@ const getDaApiPath = async (api, org, site, path = '') => {
   }
 
   if (api === CONFIG) {
-    if (hlx6) {
-      if (!site) return `${AEM_API}/${org}/config.json`;
-      return `${AEM_API}/${org}/sites/${site}/config.json`;
-    }
+    // TODO: For now config is only supported on DA_ADMIN
+    // if (hlx6) {
+    //   if (!site) return `${AEM_API}/${org}/config.json`;
+    //   return `${AEM_API}/${org}/sites/${site}/config.json`;
+    // }
     if (!site) return `${DA_ADMIN}/config/${org}/`;
     return `${DA_ADMIN}/config/${org}/${site}/`;
   }

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -155,7 +155,7 @@ const withArgs = (fn) => (arg = {}, extras = {}) => {
     // eslint-disable-next-line no-console
     console.error('api: invalid args - pass /org/site/... string or { org, site, path }', arg);
   }
-  if (!args.path.startsWith('/')) {
+  if (typeof args.path === 'string' && !args.path.startsWith('/')) {
     args.path = `/${args.path}`;
   }
   return fn(args);

--- a/nx2/utils/api.md
+++ b/nx2/utils/api.md
@@ -1,0 +1,455 @@
+# `nx2/utils/api.js` — DA / AEM Admin API
+
+A unified client for talking to **DA admin** (`admin.da.live`) and the **AEM admin API** in either its legacy form (`admin.hlx.page`, "helix5") or its new form (`api.aem.live`, "helix6"). Every method auto-routes by the per-site **hlx6** upgrade flag — once a site has been upgraded, calls flow to the new origin; otherwise they fall back to the legacy origin.
+
+The module ships its low-level primitive (`daFetch`), an upgrade detector (`isHlx6`), helpers (`fromPath`, `signout`, `hlx6ToDaList`), and **eight namespaced surfaces**: `source`, `versions`, `config`, `org`, `status`, `aem`, `snapshot`, `jobs`. Type definitions live in [`api.d.ts`](./api.d.ts) — VSCode picks them up automatically and surfaces overloads, field-level docs, and inline shapes.
+
+> **Routing model.** Some endpoints are owned by DA itself (`source`, `list`, `config`, `versions`) and DA proxies them to AEM when the site is upgraded. Others are AEM-only (`status`, `preview`, `live`, `snapshots`, `jobs`) and live on either `admin.hlx.page` (legacy) or `api.aem.live` (hlx6). The module hides this distinction; callers always pass `{ org, site, path }` and get a `Response` back.
+
+---
+
+## Imports
+
+```js
+import {
+  // Low-level
+  daFetch, isHlx6, signout, fromPath, hlx6ToDaList,
+  // Namespaces
+  source, versions, config, org, status, aem, snapshot, jobs,
+} from '/nx2/utils/api.js';
+```
+
+---
+
+## Argument shapes
+
+Most methods accept the first argument as **either** an object or a path string.
+
+**Object form** — pass parts explicitly:
+
+```js
+source.get({ org: 'adobe', site: 'aem-boilerplate', path: '/index.html' });
+```
+
+**Path-string form** — pass a `/org/site/file/path` string. The helper splits it for you. Method-specific extras go in a second positional argument:
+
+```js
+source.get('/adobe/aem-boilerplate/index.html');
+source.put('/adobe/aem-boilerplate/page.html', { body: '<main>…</main>' });
+versions.get('/adobe/aem-boilerplate/index.html', { versionId: 'abc' });
+```
+
+**Bad input** is logged via `console.error` and passed through; the resulting fetch fails naturally and callers handle the non-`ok` response.
+
+`fromPath('/org/site/path')` is exported if you need the conversion explicitly.
+
+---
+
+## Return values
+
+Every method returns the **`Response` object from `fetch`**, with two augmentations performed by `daFetch`:
+
+- `resp.permissions: string[]` — parsed from the `x-da-child-actions` header (preferred), `x-da-actions` (fallback), or defaulted to `['read', 'write']`.
+- For two methods (`config.getAggregated` is the current case) that are hlx6-only, calling them on a non-upgraded site returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` instead of a `Response`.
+
+Treat the return like any `fetch` result: `await resp.json()`, check `resp.ok`, etc.
+
+---
+
+## Authentication
+
+Auth is handled inside `daFetch`:
+
+1. `await loadIms()` — pulls the IMS access token. If none, `handleSignIn()` fires and the call returns `{}`.
+2. If the URL's origin is in `ALLOWED_TOKEN` (DA, HLX_ADMIN, AEM_API, plus collab/content/preview/etc.), an `Authorization: Bearer …` header is attached.
+3. For `HLX_ADMIN` and `AEM_API` specifically, an additional `x-content-source-authorization` header carries the same token.
+4. `401`/`403` responses with `redirect: true` redirect the page to `/not-found`.
+
+Callers don't usually need to think about this — using a namespace method handles it transparently.
+
+---
+
+## hlx6 (upgrade) detection
+
+```js
+const upgraded = await isHlx6('adobe', 'aem-boilerplate');
+```
+
+`isHlx6(org, site)` returns a `Promise<boolean>`. It memoizes per `(org, site)` in module memory and persists positive results in `localStorage` under the key `hlx6-upgrade`. Detection works by pinging `${HLX_ADMIN}/ping/{org}/{site}` and looking for the `x-api-upgrade-available` header.
+
+Returns `false` immediately when `site` is missing.
+
+Most callers don't call `isHlx6` directly — they let the namespace methods do the routing.
+
+---
+
+## Namespace: `source`
+
+Document CRUD on `source` paths. Bridges DA's `/source` and AEM's `/sites/{site}/source` (hlx6).
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get` | `({ org, site, path })` or `(fullPath)` | GET |
+| `list` | `({ org, site, path? })` or `(fullPath)` | List a folder. Pass `{ org }` (no site) to list at org level — DA-legacy only. |
+| `put` | `({ org, site, path, body })` or `(fullPath, { body })` | Upload. PUT for both branches. **DA**: wraps body in `multipart/form-data` field `data`. **hlx6**: sends body raw with `Content-Type` sniffed from path extension. |
+| `getMetadata` | `({ org, site, path })` or `(fullPath)` | HEAD — returns headers only (`doc-id`, `last-modified`, etc.) |
+| `delete` | `({ org, site, path })` or `(fullPath)` | DELETE |
+| `copy` | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | `path` = source, `destination` = target. **hlx6**: PUT to dest URL with `?source=…&collision=…` query. **DA**: POST `/copy/{org}/{site}{path}` with `multipart/form-data` field `destination`. |
+| `move` | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | Same shape as `copy` but adds `?move=true` (hlx6) or POSTs to `/move/{org}/{site}{path}` (DA). |
+| `createFolder` | `({ org, site, path })` or `(fullPath)` | POST on `${path}/` (trailing slash). |
+| `deleteFolder` | `({ org, site, path })` or `(fullPath)` | DELETE on `${path}/`. |
+
+### URL shapes
+
+| Method | hlx6 | legacy DA |
+|---|---|---|
+| get / list / put / head / delete | `${AEM_API}/{org}/sites/{site}/source{path}` | `${DA_ADMIN}/source/{org}/{site}{path}` |
+| list (org-only) | n/a | `${DA_ADMIN}/list/{org}` |
+| list (with site, legacy) | n/a | `${DA_ADMIN}/list/{org}/{site}{path}` |
+| copy / move | PUT to dest URL with `?source=&collision=&move=` | POST to `${DA_ADMIN}/copy/{org}/{site}{path}` (or `/move`) with `destination` form field |
+
+### Examples
+
+```js
+// Read
+const resp = await source.get('/adobe/aem-boilerplate/index.html');
+const html = await resp.text();
+
+// Write (path string + body extra)
+await source.put('/adobe/aem-boilerplate/page.html', { body: '<main>…</main>' });
+
+// List a folder
+const list = await source.list('/adobe/aem-boilerplate/folder');
+const items = await list.json();
+
+// Copy
+await source.copy({
+  org: 'adobe',
+  site: 'aem-boilerplate',
+  path: '/old.html',          // source
+  destination: '/new.html',   // dest
+  collision: 'overwrite',
+});
+```
+
+---
+
+## Namespace: `versions`
+
+Document version history. Versions are document-scoped, so all methods take a `path`.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `list` | `({ org, site, path })` or `(fullPath)` | List versions. **hlx6**: `…/source{path}/.versions`. **DA**: `${DA_ADMIN}/versionlist/{org}/{site}{path}`. |
+| `get` | `({ org, site, path, versionId })` or `(fullPath, { versionId })` | Retrieve specific version content. **hlx6**: `versionId` is the ULID returned by `list`. **DA**: `versionId` is the trailing `{versionGuid}/{fileGuid}.{ext}` segment from the list response. |
+| `create` | `({ org, site, path, operation?, comment? })` or `(fullPath, { operation?, comment? })` | Create a version snapshot. **hlx6**: POSTs `{ operation, comment }` JSON body. **DA**: POSTs `{ label }` JSON body, with `comment` mapped to `label`. |
+
+### Example
+
+```js
+// Snapshot a version with a label
+await versions.create({
+  org, site, path: '/index.html', comment: 'Pre-launch checkpoint',
+});
+
+// List all versions
+const list = await versions.list({ org, site, path: '/index.html' });
+const versions = await list.json();
+```
+
+---
+
+## Namespace: `config`
+
+Org or site-level configuration JSON. The `site` argument is **optional** — omit it for org-level config.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get` | `({ org, site? })` | Read |
+| `put` | `({ org, site?, body })` | Update. Sent as `multipart/form-data` with field `config`. **NOTE:** This wire shape currently doesn't match what the H5/H6 admin endpoints expect (JSON body) and may need realignment — see [Known issues](#known-issues). |
+| `delete` | `({ org, site? })` | DELETE |
+| `getAggregated` | `({ org, site })` | hlx6-only. Returns `{ error, status: 501 }` on legacy. Hits `${AEM_API}/{org}/aggregated/{site}/config.json`. |
+
+### URL shapes
+
+| | hlx6 | legacy DA |
+|---|---|---|
+| org-level | `${AEM_API}/{org}/config.json` | `${DA_ADMIN}/config/{org}/` |
+| site-level | `${AEM_API}/{org}/sites/{site}/config.json` | `${DA_ADMIN}/config/{org}/{site}/` |
+
+### Example
+
+```js
+// Read site config
+const resp = await config.get({ org, site });
+const json = await resp.json();
+
+// Read aggregated (resolved) config — hlx6 only
+const agg = await config.getAggregated({ org, site });
+if (agg.status === 501) {
+  // Site not on hlx6; fall back to plain config.get
+}
+```
+
+---
+
+## Namespace: `org`
+
+Organization-level operations. hlx6-only (no DA-legacy fallback exists at org level).
+
+| Method | Signature | Notes |
+|---|---|---|
+| `listSites` | `({ org })` | GETs `${AEM_API}/{org}/sites`. Returns 404 on non-migrated orgs. |
+
+---
+
+## Namespace: `status`
+
+Resource status (preview + live combined view). **Single-path only** — H6 has no bulk status endpoint.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get` | `({ org, site, path })` or `(fullPath)` | GET `/status/{path}` |
+
+### URL shapes
+
+| hlx6 | legacy |
+|---|---|
+| `${AEM_API}/{org}/sites/{site}/status{path}` | `${HLX_ADMIN}/status/{org}/{site}/main{path}` |
+
+### Example
+
+```js
+const resp = await status.get('/adobe/aem-boilerplate/index.html');
+const { preview, live, edit } = await resp.json();
+```
+
+---
+
+## Namespace: `aem`
+
+Combined preview + live (publish) operations. The `path` argument can be a **string** (single op) or an **array of length ≥ 2** (bulk op). Single string or one-item array hits the single-path endpoint.
+
+`forceUpdate` and `forceSync` are **bulk-only** — server ignores them on single-path calls.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `getPreview` | `({ org, site, path })` or `(fullPath)` | GET preview status (single only) |
+| `getPublish` | `({ org, site, path })` or `(fullPath)` | GET publish status (single only) |
+| `preview` | `({ org, site, path, forceUpdate?, forceSync? })` | string → POST `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, forceUpdate?, forceSync? }`. |
+| `unPreview` | `({ org, site, path })` | string → DELETE `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, delete: true }`. |
+| `publish` | `({ org, site, path, forceUpdate?, forceSync? })` | string → POST `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, forceUpdate?, forceSync? }`. |
+| `unPublish` | `({ org, site, path })` | string → DELETE `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, delete: true }`. |
+
+### URL shapes
+
+| | hlx6 | legacy |
+|---|---|---|
+| preview / unPreview | `${AEM_API}/{org}/sites/{site}/preview{path}` (or `/*`) | `${HLX_ADMIN}/preview/{org}/{site}/main{path}` (or `/*`) |
+| publish / unPublish | `${AEM_API}/{org}/sites/{site}/live{path}` (or `/*`) | `${HLX_ADMIN}/live/{org}/{site}/main{path}` (or `/*`) |
+
+### Examples
+
+```js
+// Single preview
+await aem.preview('/adobe/aem-boilerplate/index.html');
+
+// Bulk publish with extras
+await aem.publish({
+  org, site,
+  path: ['/a.html', '/b.html', '/c.html'],
+  forceUpdate: true,
+});
+
+// Bulk unpublish — body becomes { paths, delete: true }
+await aem.unPublish({ org, site, path: ['/old.html', '/legacy.html'] });
+```
+
+---
+
+## Namespace: `snapshot`
+
+Snapshot CRUD plus review/publish actions. Snapshots are AEM-only. New API uses plural `snapshots` in the URL; legacy uses singular `snapshot`.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `list` | `({ org, site })` | List all snapshots |
+| `get` | `({ org, site, snapshotId })` | Retrieve manifest |
+| `update` | `({ org, site, snapshotId, body? })` | POST manifest |
+| `delete` | `({ org, site, snapshotId })` | DELETE |
+| `addPath` | `({ org, site, snapshotId, path })` | string → POST `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths }`. |
+| `removePath` | `({ org, site, snapshotId, path })` | string → DELETE `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths, delete: true }`. |
+| `publish` | `({ org, site, snapshotId })` | POST `?publish=true` |
+| `review` | `({ org, site, snapshotId, action })` | POST `?review=…`. `action`: `'request'` \| `'approve'` \| `'reject'` |
+
+### Example
+
+```js
+// Create + populate + publish a snapshot
+await snapshot.update({
+  org, site, snapshotId: 'snap-1', body: { title: 'Launch candidate' },
+});
+await snapshot.addPath({
+  org, site, snapshotId: 'snap-1',
+  path: ['/index.html', '/about.html', '/contact.html'],
+});
+await snapshot.publish({ org, site, snapshotId: 'snap-1' });
+```
+
+---
+
+## Namespace: `jobs`
+
+Background job control.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get` | `({ org, site, topic, name? })` | Omit `name` to list jobs in the topic. |
+| `details` | `({ org, site, topic, name })` | GET on `…/details` — progress data |
+| `stop` | `({ org, site, topic, name })` | DELETE — stop a running job |
+
+### URL shapes
+
+| | hlx6 | legacy |
+|---|---|---|
+| Single job | `${AEM_API}/{org}/sites/{site}/jobs/{topic}/{name}` | `${HLX_ADMIN}/job/{org}/{site}/main/{topic}/{name}` (singular `job`) |
+| Job list | `${AEM_API}/{org}/sites/{site}/jobs/{topic}` | `${HLX_ADMIN}/job/{org}/{site}/main/{topic}` |
+
+### Example
+
+```js
+// Poll a job until complete
+let resp = await jobs.details({ org, site, topic: 'preview', name: 'job-123' });
+let info = await resp.json();
+while (info.state !== 'complete') {
+  await new Promise((r) => setTimeout(r, 2000));
+  resp = await jobs.details({ org, site, topic: 'preview', name: 'job-123' });
+  info = await resp.json();
+}
+```
+
+---
+
+## Helpers
+
+### `fromPath(str)`
+
+Splits a `/org/site/file/path` string into `{ org, site, path }`. Used internally by every method when the first argument is a string; exported so callers can do their own splitting if convenient.
+
+```js
+fromPath('/adobe/aem-boilerplate/index.html');
+// → { org: 'adobe', site: 'aem-boilerplate', path: '/index.html' }
+```
+
+### `hlx6ToDaList(parentPath, items)`
+
+Normalizes a folder listing returned by hlx6's source bus into the shape DA's `/list` endpoint produces. Folders get their trailing slash stripped, file extensions get extracted into `ext`, `last-modified` becomes a unix timestamp at `lastModified`. Items without a `content-type` (i.e., DA's existing format) pass through unchanged.
+
+Useful when you want to render a folder listing without caring whether the site is hlx6 or legacy.
+
+### `signout()`
+
+Fire-and-forget GET to `${DA_ADMIN}/logout`. Returns nothing.
+
+### `daFetch({ url, opts?, redirect? })`
+
+The low-level fetch primitive. Most callers shouldn't use it directly — namespace methods handle URL construction, body shaping, and routing. Reach for `daFetch` only when you need to hit an endpoint not covered by a namespace.
+
+```js
+const resp = await daFetch({
+  url: 'https://admin.da.live/some-endpoint',
+  opts: { method: 'POST', body: formData },
+});
+```
+
+---
+
+## Error handling
+
+Every namespace method returns a `Response` (or a Response-shaped object — see hlx6-only methods below). No method throws on HTTP failure; callers should branch on `resp.ok` or `resp.status`.
+
+```js
+const resp = await source.get(path);
+if (!resp.ok) {
+  // 4xx/5xx — handle as appropriate
+  return;
+}
+const json = await resp.json();
+```
+
+**Special return shapes:**
+
+- `daFetch` returns `{}` (empty object) when no IMS access token is available.
+- `config.getAggregated` returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` when the site isn't hlx6.
+
+These are the **only** non-`Response` return values. All other methods always return a real `Response`.
+
+**`console.error` on bad args:** when an invalid first argument is passed (missing `org`), the module logs a console error but doesn't throw — the bad call still flows through and produces a malformed URL that the server will reject. The console message is the only signal from the client side; rely on the server's response status for handling.
+
+---
+
+## Path conventions
+
+- `path` always uses a leading slash: `/index.html`, `/folder/page.html`.
+- Empty path is allowed where the endpoint supports it (e.g., `source.list({ org, site })` lists root).
+- Path-string form expects the full `/org/site/file/path` shape. The first two segments after the leading slash are interpreted as org and site; everything after is the path.
+
+---
+
+## Module-internal architecture
+
+These are not exported, but understanding them helps when reading the source.
+
+- **`getDaApiPath(api, org, site, path)`** — URL builder for endpoints DA proxies (`source`, `list`, `config`, `versions`). Branches on `isHlx6` to choose `DA_ADMIN` or `AEM_API`.
+- **`getAemApiPath(api, org, site, path)`** — URL builder for AEM-only endpoints (`status`, `preview`, `live`, `snapshots`, `jobs`). Branches on `isHlx6` to choose `HLX_ADMIN` (with hardcoded `ref=main`) or `AEM_API`.
+- **`withArgs(fn)`** — HOF that resolves the first arg (object or path string) and forwards a normalized `{ org, site, path, ...extras }` object to `fn`. Handles the bad-arg `console.error` for missing org.
+- **`callPath({ api, org, site, path, method, … })`** — Dispatcher used by `aem.*` methods. Handles the string-vs-array branching for bulk preview/publish operations and folds `forceUpdate`/`forceSync` into the bulk JSON body.
+- **`jsonOpts(method, payload)`** — small helper that builds `{ method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }`.
+
+---
+
+## Constants
+
+Imported from `./utils.js`:
+
+| Constant | Value | Used for |
+|---|---|---|
+| `DA_ADMIN` | `https://admin.da.live` (env-aware) | DA admin origin |
+| `HLX_ADMIN` | `https://admin.hlx.page` | Legacy AEM admin |
+| `AEM_API` | `https://api.aem.live` | New AEM admin (hlx6) |
+| `ALLOWED_TOKEN` | array of origins | Auth header allowlist |
+
+Defined locally:
+
+| Constant | Value | Used for |
+|---|---|---|
+| `REF` | `'main'` | Hardcoded ref for legacy AEM URLs |
+| `STORAGE_KEY` | `'hlx6-upgrade'` | localStorage key for hlx6 cache |
+| `TEXT_TYPES` | `{ '.html': 'text/html', '.json': 'application/json' }` | Content-Type sniffing for `source.put` on hlx6 |
+
+---
+
+## Known issues
+
+These are tracked but not yet resolved. They don't block typical usage; flagged here for completeness.
+
+- **`config.put` wire shape**: currently sends `multipart/form-data` with field `config`. The H5/H6 admin endpoints actually expect raw JSON body. DA's exact requirement is undocumented; existing da-live tests assert PUT instead of POST. Needs verification against running servers.
+- **`forceSync` field name**: the H6 server source reads `forceAsync` (with inverse meaning), not `forceSync`. Currently sending `forceSync: true` is silently ignored by the server. This affects the `aem.preview`/`aem.publish` bulk paths and `start/index.js` in da-live.
+
+---
+
+## Testing
+
+Tests live in [`test/nx2/utils/api.test.js`](../../test/nx2/utils/api.test.js). Pattern: stub `window.fetch` with a recording fake, call the method, assert URL/method/body/headers.
+
+```js
+window.fetch = async (url, opts = {}) => {
+  // record [url, opts]
+  return new Response('{}', { status: 200 });
+};
+
+await source.get({ org: 'foo', site: 'bar', path: '/x.html' });
+expect(lastCall().url).to.equal('https://admin.da.live/source/foo/bar/x.html');
+```
+
+The IMS dependency is mocked via the importmap in `web-test-runner.config.mjs` (`/nx2/utils/ims.js` → `/nx2/test/mocks/ims.js`).

--- a/nx2/utils/ims.js
+++ b/nx2/utils/ims.js
@@ -94,7 +94,7 @@ const getTenantId = (profile) => {
   const found = profile.projectedProductContext?.find(
     (projected) => projected.prodCtx.serviceCode === 'dma_tartan',
   );
-  return found?.prodCtx.serviceCode;
+  return found?.prodCtx.tenant_id;
 };
 
 async function loadDetails(accessToken) {
@@ -105,11 +105,19 @@ async function loadDetails(accessToken) {
   return { ...profile, tenantId, accessToken, getIo, getOrgs };
 }
 
+function settleWithTimeout(resolve, reject) {
+  const timeout = setTimeout(() => reject(new Error('IMS timeout')), IMS_TIMEOUT);
+  return [resolve, reject].map((fn) => (v) => {
+    clearTimeout(timeout);
+    fn(v);
+  });
+}
+
 export const loadIms = (() => {
   let ims;
 
   const setup = () => new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('IMS timeout')), IMS_TIMEOUT);
+    const [done, fail] = settleWithTimeout(resolve, reject);
 
     window.adobeid = {
       client_id: imsClientId,
@@ -118,18 +126,17 @@ export const loadIms = (() => {
       autoValidateToken: true,
       environment: IMS_ENV[env],
       useLocalStorage: true,
-      onError: reject,
+      onError: fail,
       onReady: () => {
         const accessToken = window.adobeIMS.getAccessToken();
-        if (accessToken) {
-          loadDetails(accessToken).then((details) => resolve(details));
-        } else {
-          resolve({ anonymous: true });
+        if (!accessToken) {
+          done({ anonymous: true });
+          return;
         }
-        clearTimeout(timeout);
+        loadDetails(accessToken).then(done, fail);
       },
     };
-    loadScript(IMS_URL);
+    loadScript(IMS_URL).catch(fail);
   });
 
   return () => {

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -1,0 +1,718 @@
+import { expect } from '@esm-bundle/chai';
+import { setMockIms, resetMockIms } from '../../../nx2/test/mocks/ims.js';
+import { HLX_ADMIN, AEM_API, DA_ADMIN } from '../../../nx2/utils/utils.js';
+import {
+  daFetch,
+  isHlx6,
+  signout,
+  hlx6ToDaList,
+  fromPath,
+  source,
+  versions,
+  config,
+  org,
+  status,
+  aem,
+  snapshot,
+  jobs,
+} from '../../../nx2/utils/api.js';
+
+const STORAGE_KEY = 'hlx6-upgrade';
+
+let counter = 0;
+const uniq = (label) => {
+  counter += 1;
+  return `${label}-${counter}-${Math.floor(Math.random() * 1e6)}`;
+};
+
+const makeOrgSite = ({ hlx6 = false } = {}) => {
+  const o = uniq('org');
+  const s = uniq('site');
+  if (hlx6) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      ...(JSON.parse(localStorage.getItem(STORAGE_KEY)) ?? {}),
+      [`/${o}/${s}`]: true,
+    }));
+  }
+  return { org: o, site: s };
+};
+
+let calls;
+let origFetch;
+
+const installFetch = ({ pingHlx6 = false, headers = {}, status: httpStatus = 200, body = '{}' } = {}) => {
+  calls = [];
+  origFetch = window.fetch;
+  window.fetch = async (url, opts = {}) => {
+    const u = url.toString();
+    calls.push({ url: u, method: opts.method || 'GET', headers: opts.headers || {}, body: opts.body });
+    if (u.includes(`${HLX_ADMIN}/ping/`)) {
+      const respHeaders = pingHlx6 ? { 'x-api-upgrade-available': 'true' } : {};
+      return new Response('', { status: 200, headers: respHeaders });
+    }
+    return new Response(body, { status: httpStatus, headers });
+  };
+};
+
+const restoreFetch = () => {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+};
+
+const lastCall = () => calls[calls.length - 1];
+const callsTo = (origin) => calls.filter((c) => c.url.startsWith(origin));
+
+describe('api.js', () => {
+  beforeEach(() => {
+    resetMockIms();
+    localStorage.removeItem(STORAGE_KEY);
+    installFetch();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  describe('daFetch', () => {
+    it('attaches Authorization for ALLOWED_TOKEN origins', async () => {
+      await daFetch({ url: `${HLX_ADMIN}/ping/x/y` });
+      expect(lastCall().headers.Authorization).to.equal('Bearer test-token');
+    });
+
+    it('also attaches x-content-source-authorization for HLX_ADMIN and AEM_API', async () => {
+      await daFetch({ url: `${HLX_ADMIN}/ping/x/y` });
+      expect(lastCall().headers['x-content-source-authorization']).to.equal('Bearer test-token');
+
+      await daFetch({ url: `${AEM_API}/some/path` });
+      expect(lastCall().headers['x-content-source-authorization']).to.equal('Bearer test-token');
+    });
+
+    it('does not attach auth for unknown origins', async () => {
+      await daFetch({ url: 'https://example.com/foo' });
+      expect(lastCall().headers.Authorization).to.be.undefined;
+      expect(lastCall().headers['x-content-source-authorization']).to.be.undefined;
+    });
+
+    it('parses x-da-child-actions into permissions', async () => {
+      restoreFetch();
+      installFetch({ headers: { 'x-da-child-actions': 'role=read,write,delete' } });
+      const resp = await daFetch({ url: `${AEM_API}/some/path` });
+      expect(resp.permissions).to.deep.equal(['read', 'write', 'delete']);
+    });
+
+    it('falls back to x-da-actions when child actions missing', async () => {
+      restoreFetch();
+      installFetch({ headers: { 'x-da-actions': 'role=read,write' } });
+      const resp = await daFetch({ url: `${AEM_API}/some/path` });
+      expect(resp.permissions).to.deep.equal(['read', 'write']);
+    });
+
+    it('falls back to [read, write] when no permission headers', async () => {
+      const resp = await daFetch({ url: `${AEM_API}/some/path` });
+      expect(resp.permissions).to.deep.equal(['read', 'write']);
+    });
+
+    it('returns {} and signs in when no access token', async () => {
+      setMockIms({ token: null });
+      const resp = await daFetch({ url: `${HLX_ADMIN}/ping/a/b` });
+      expect(resp).to.deep.equal({});
+    });
+  });
+
+  describe('isHlx6', () => {
+    it('returns false when site is missing', async () => {
+      const result = await isHlx6('myorg', null);
+      expect(result).to.equal(false);
+    });
+
+    it('returns true when ping responds with x-api-upgrade-available', async () => {
+      restoreFetch();
+      installFetch({ pingHlx6: true });
+      const o = uniq('org');
+      const s = uniq('site');
+      const result = await isHlx6(o, s);
+      expect(result).to.equal(true);
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+      expect(stored[`/${o}/${s}`]).to.equal(true);
+    });
+
+    it('uses localStorage cache without fetching', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await isHlx6(o, s);
+      expect(result).to.equal(true);
+      // No ping call made (in-memory call may or may not occur but no /ping/ url)
+      const pingCalls = calls.filter((c) => c.url.includes(`${HLX_ADMIN}/ping/`));
+      expect(pingCalls).to.have.lengthOf(0);
+    });
+  });
+
+  describe('source', () => {
+    it('source.get hits DA on legacy', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      // Trigger a ping fetch by querying — it returns no upgrade header → legacy
+      await source.get({ org: o, site: s, path: '/index.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${DA_ADMIN}/source/${o}/${s}/index.html`);
+      expect(last.method).to.equal('GET');
+    });
+
+    it('source.get hits AEM_API on hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.get({ org: o, site: s, path: '/index.html' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/index.html`);
+    });
+
+    it('source.list uses /list on legacy', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await source.list({ org: o, site: s, path: '/folder' });
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/list/${o}/${s}/folder`);
+    });
+
+    it('source.list uses source URL with trailing slash on hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.list({ org: o, site: s, path: '/folder' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/folder/`);
+    });
+
+    it('source.list root path hlx6 uses /', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.list({ org: o, site: s });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/`);
+    });
+
+    it('source.list org-only hits DA legacy /list/{org}', async () => {
+      const o = uniq('org');
+      await source.list({ org: o });
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/list/${o}`);
+    });
+
+    it('source.put DA wraps body in FormData', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      const body = new Blob(['<html></html>'], { type: 'text/html' });
+      await source.put({ org: o, site: s, path: '/page.html', body });
+      const last = lastCall();
+      expect(last.method).to.equal('PUT');
+      expect(last.body).to.be.instanceof(FormData);
+      const stored = last.body.get('data');
+      expect(stored).to.be.instanceof(Blob);
+      expect(stored.size).to.equal(body.size);
+    });
+
+    it('source.put hlx6 sets Content-Type for known text exts', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.put({ org: o, site: s, path: '/page.html', body: '<main></main>' });
+      const last = lastCall();
+      expect(last.method).to.equal('PUT');
+      expect(last.headers['Content-Type']).to.equal('text/html');
+      expect(last.body).to.equal('<main></main>');
+    });
+
+    it('source.put hlx6 passes body as-is for non-text exts', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const blob = new Blob(['binary'], { type: 'image/png' });
+      await source.put({ org: o, site: s, path: '/img.png', body: blob });
+      const last = lastCall();
+      expect(last.headers['Content-Type']).to.be.undefined;
+      expect(last.body).to.equal(blob);
+    });
+
+    it('source.getMetadata sends HEAD', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.getMetadata({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().method).to.equal('HEAD');
+    });
+
+    it('source.delete sends DELETE', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.delete({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().method).to.equal('DELETE');
+    });
+
+    it('source.copy hlx6 PUTs with source/collision query params', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.copy({ org: o, site: s, path: '/src.html', destination: '/dest.html', collision: 'overwrite' });
+      const last = lastCall();
+      expect(last.method).to.equal('PUT');
+      const u = new URL(last.url);
+      expect(u.pathname).to.equal(`/${o}/sites/${s}/source/dest.html`);
+      expect(u.searchParams.get('source')).to.equal('/src.html');
+      expect(u.searchParams.get('collision')).to.equal('overwrite');
+      expect(u.searchParams.get('move')).to.be.null;
+    });
+
+    it('source.copy legacy POSTs to /copy/{org}/{site}{path} with destination form field', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await source.copy({ org: o, site: s, path: '/src.html', destination: '/dest.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${DA_ADMIN}/copy/${o}/${s}/src.html`);
+      expect(last.method).to.equal('POST');
+      expect(last.body).to.be.instanceof(FormData);
+      expect(last.body.get('destination')).to.equal('/dest.html');
+    });
+
+    it('source.move hlx6 adds move=true', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.move({ org: o, site: s, path: '/src.html', destination: '/dest.html' });
+      const u = new URL(lastCall().url);
+      expect(u.pathname).to.equal(`/${o}/sites/${s}/source/dest.html`);
+      expect(u.searchParams.get('move')).to.equal('true');
+      expect(u.searchParams.get('source')).to.equal('/src.html');
+    });
+
+    it('source.move legacy POSTs to /move/{org}/{site}{path} with destination form field', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await source.move({ org: o, site: s, path: '/src.html', destination: '/dest.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${DA_ADMIN}/move/${o}/${s}/src.html`);
+      expect(last.method).to.equal('POST');
+      expect(last.body.get('destination')).to.equal('/dest.html');
+    });
+
+    it('source.get accepts a full /org/site/path string', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.get(`/${o}/${s}/index.html`);
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/index.html`);
+    });
+
+    it('source.put accepts a path string with extras', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.put(`/${o}/${s}/page.html`, { body: '<main></main>' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/source/page.html`);
+      expect(last.body).to.equal('<main></main>');
+    });
+
+    it('source.copy accepts a path string with extras', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.copy(`/${o}/${s}/src.html`, {
+        destination: '/dest.html',
+        collision: 'overwrite',
+      });
+      const u = new URL(lastCall().url);
+      expect(u.pathname).to.equal(`/${o}/sites/${s}/source/dest.html`);
+      expect(u.searchParams.get('source')).to.equal('/src.html');
+      expect(u.searchParams.get('collision')).to.equal('overwrite');
+    });
+
+    it('source.get logs an error when org is missing', async () => {
+      const origErr = console.error;
+      let errored = false;
+      console.error = () => { errored = true; };
+      try {
+        await source.get('');
+      } finally {
+        console.error = origErr;
+      }
+      expect(errored).to.equal(true);
+    });
+
+    it('source.createFolder POSTs with trailing slash', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.createFolder({ org: o, site: s, path: '/folder' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/source/folder/`);
+      expect(last.method).to.equal('POST');
+    });
+
+    it('source.deleteFolder DELETEs with trailing slash', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.deleteFolder({ org: o, site: s, path: '/folder' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/source/folder/`);
+      expect(last.method).to.equal('DELETE');
+    });
+  });
+
+  describe('versions', () => {
+    it('versions.list legacy hits /versionlist', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await versions.list({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/versionlist/${o}/${s}/x.html`);
+    });
+
+    it('versions.list hlx6 hits .versions sub-resource', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await versions.list({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/x.html/.versions`);
+    });
+
+    it('versions.list accepts a path string', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await versions.list(`/${o}/${s}/x.html`);
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/x.html/.versions`);
+    });
+
+    it('versions.get accepts a path string with versionId in extras', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await versions.get(`/${o}/${s}/x.html`, { versionId: 'abc' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/x.html/.versions/abc`);
+    });
+
+    it('versions.get hlx6 hits source/.versions/{id}', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await versions.get({ org: o, site: s, path: '/x.html', versionId: 'abc' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/x.html/.versions/abc`);
+    });
+
+    it('versions.get legacy hits /versionsource/{org}/{versionId}', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await versions.get({ org: o, site: s, path: '/x.html', versionId: 'guid1/guid2.html' });
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/versionsource/${o}/guid1/guid2.html`);
+    });
+
+    it('versions.create hlx6 POSTs operation/comment as JSON body', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await versions.create({ org: o, site: s, path: '/x.html', operation: 'preview', comment: 'note' });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(last.headers['Content-Type']).to.equal('application/json');
+      expect(JSON.parse(last.body)).to.deep.equal({ operation: 'preview', comment: 'note' });
+    });
+
+    it('versions.create legacy POSTs comment as { label } JSON body', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await versions.create({ org: o, site: s, path: '/x.html', comment: 'My Label' });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(last.body).to.equal('{"label":"My Label"}');
+    });
+
+    it('versions.create with no comment sends no body', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await versions.create({ org: o, site: s, path: '/x.html' });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(last.body).to.be.undefined;
+    });
+  });
+
+  describe('config', () => {
+    it('config.get site-level hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await config.get({ org: o, site: s });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/config.json`);
+    });
+
+    it('config.get org-only legacy', async () => {
+      const o = uniq('org');
+      await config.get({ org: o });
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/config/${o}/`);
+    });
+
+    it('config.put uses FormData with config field', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await config.put({ org: o, site: s, body: '{"foo":"bar"}' });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(last.body).to.be.instanceof(FormData);
+      expect(last.body.get('config')).to.equal('{"foo":"bar"}');
+    });
+
+    it('config.delete sends DELETE', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await config.delete({ org: o, site: s });
+      expect(lastCall().method).to.equal('DELETE');
+    });
+
+    it('config.getAggregated is hlx6-only', async () => {
+      const legacy = makeOrgSite();
+      const r = await config.getAggregated({ org: legacy.org, site: legacy.site });
+      expect(r.status).to.equal(501);
+
+      const up = makeOrgSite({ hlx6: true });
+      await config.getAggregated({ org: up.org, site: up.site });
+      expect(lastCall().url).to.equal(`${AEM_API}/${up.org}/aggregated/${up.site}/config.json`);
+    });
+  });
+
+  describe('org', () => {
+    it('org.listSites hits AEM_API', async () => {
+      const o = uniq('org');
+      await org.listSites({ org: o });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites`);
+    });
+  });
+
+  describe('status', () => {
+    it('GETs single path on hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await status.get({ org: o, site: s, path: '/page.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/status/page.html`);
+      expect(last.method).to.equal('GET');
+    });
+
+    it('accepts a full /org/site/path string', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await status.get(`/${o}/${s}/page.html`);
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/status/page.html`);
+    });
+
+    it('legacy uses HLX_ADMIN with main ref', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await status.get({ org: o, site: s, path: '/page.html' });
+      expect(lastCall().url).to.equal(`${HLX_ADMIN}/status/${o}/${s}/main/page.html`);
+    });
+  });
+
+  describe('aem (preview/live combined)', () => {
+    it('aem.preview single POSTs', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.preview({ org: o, site: s, path: '/x.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/preview/x.html`);
+      expect(last.method).to.equal('POST');
+    });
+
+    it('aem.preview accepts a path string', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.preview(`/${o}/${s}/x.html`);
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/preview/x.html`);
+      expect(last.method).to.equal('POST');
+    });
+
+    it('aem.preview bulk uses /* and { paths }', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.preview({ org: o, site: s, path: ['/a', '/b'] });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/preview/*`);
+      expect(JSON.parse(last.body)).to.deep.equal({ paths: ['/a', '/b'] });
+    });
+
+    it('aem.unPreview single DELETEs', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.unPreview({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().method).to.equal('DELETE');
+    });
+
+    it('aem.unPreview bulk includes delete:true', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.unPreview({ org: o, site: s, path: ['/a', '/b'] });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(JSON.parse(last.body)).to.deep.equal({ paths: ['/a', '/b'], delete: true });
+    });
+
+    it('aem.publish hits /live', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.publish({ org: o, site: s, path: '/x.html' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/live/x.html`);
+    });
+
+    it('aem.unPublish bulk includes delete:true', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.unPublish({ org: o, site: s, path: ['/a', '/b'] });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/live/*`);
+      expect(JSON.parse(last.body)).to.deep.equal({ paths: ['/a', '/b'], delete: true });
+    });
+
+    it('aem.preview single ignores forceUpdate/forceSync (bulk-only flags)', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.preview({
+        org: o, site: s, path: '/x.html', forceUpdate: true, forceSync: true,
+      });
+      const last = lastCall();
+      // Single-path URL has no query params for these flags.
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/preview/x.html`);
+      expect(last.body).to.be.undefined;
+    });
+
+    it('aem.preview bulk folds forceUpdate/forceSync into JSON body', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.preview({
+        org: o, site: s, path: ['/a', '/b'], forceUpdate: true, forceSync: true,
+      });
+      const last = lastCall();
+      expect(JSON.parse(last.body)).to.deep.equal({
+        paths: ['/a', '/b'], forceUpdate: true, forceSync: true,
+      });
+    });
+
+    it('aem.getPreview GETs', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.getPreview({ org: o, site: s, path: '/x' });
+      expect(lastCall().method).to.equal('GET');
+    });
+
+    it('aem.getPublish GETs /live', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await aem.getPublish({ org: o, site: s, path: '/x' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/live/x`);
+      expect(lastCall().method).to.equal('GET');
+    });
+  });
+
+  describe('snapshot', () => {
+    it('snapshot.list hits /snapshots on hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.list({ org: o, site: s });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/snapshots`);
+    });
+
+    it('snapshot.list hits singular /snapshot on legacy', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await snapshot.list({ org: o, site: s });
+      expect(lastCall().url).to.equal(`${HLX_ADMIN}/snapshot/${o}/${s}/main`);
+    });
+
+    it('snapshot.get retrieves manifest', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.get({ org: o, site: s, snapshotId: 'snap1' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/snapshots/snap1`);
+    });
+
+    it('snapshot.update POSTs body', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.update({ org: o, site: s, snapshotId: 'snap1', body: { title: 'hi' } });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(JSON.parse(last.body)).to.deep.equal({ title: 'hi' });
+    });
+
+    it('snapshot.delete DELETEs', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.delete({ org: o, site: s, snapshotId: 'snap1' });
+      expect(lastCall().method).to.equal('DELETE');
+    });
+
+    it('snapshot.addPath single POSTs to snapshotId/{path}', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.addPath({ org: o, site: s, snapshotId: 'snap1', path: '/x.html' });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/snapshots/snap1/x.html`);
+      expect(last.method).to.equal('POST');
+    });
+
+    it('snapshot.addPath bulk POSTs to /* with paths', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.addPath({ org: o, site: s, snapshotId: 'snap1', path: ['/a', '/b'] });
+      const last = lastCall();
+      expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/snapshots/snap1/*`);
+      expect(JSON.parse(last.body)).to.deep.equal({ paths: ['/a', '/b'] });
+    });
+
+    it('snapshot.removePath bulk includes delete:true', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.removePath({ org: o, site: s, snapshotId: 'snap1', path: ['/a', '/b'] });
+      const last = lastCall();
+      expect(last.method).to.equal('POST');
+      expect(JSON.parse(last.body)).to.deep.equal({ paths: ['/a', '/b'], delete: true });
+    });
+
+    it('snapshot.publish adds publish=true', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.publish({ org: o, site: s, snapshotId: 'snap1' });
+      const u = new URL(lastCall().url);
+      expect(u.searchParams.get('publish')).to.equal('true');
+    });
+
+    it('snapshot.review adds review=action', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await snapshot.review({ org: o, site: s, snapshotId: 'snap1', action: 'approve' });
+      const u = new URL(lastCall().url);
+      expect(u.searchParams.get('review')).to.equal('approve');
+    });
+  });
+
+  describe('jobs', () => {
+    it('jobs.get with name on hlx6', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await jobs.get({ org: o, site: s, topic: 'preview', name: 'job-123' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/jobs/preview/job-123`);
+    });
+
+    it('jobs.get without name lists topic', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await jobs.get({ org: o, site: s, topic: 'preview' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/jobs/preview`);
+    });
+
+    it('jobs.get legacy uses singular /job', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await jobs.get({ org: o, site: s, topic: 'preview', name: 'job-123' });
+      expect(lastCall().url).to.equal(`${HLX_ADMIN}/job/${o}/${s}/main/preview/job-123`);
+    });
+
+    it('jobs.details GETs /details', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await jobs.details({ org: o, site: s, topic: 'preview', name: 'j1' });
+      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/jobs/preview/j1/details`);
+    });
+
+    it('jobs.stop DELETEs', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await jobs.stop({ org: o, site: s, topic: 'preview', name: 'j1' });
+      expect(lastCall().method).to.equal('DELETE');
+    });
+  });
+
+  describe('fromPath', () => {
+    it('splits /org/site/file/path into { org, site, path }', () => {
+      expect(fromPath('/adobe/aem-boilerplate/index.html')).to.deep.equal({
+        org: 'adobe',
+        site: 'aem-boilerplate',
+        path: '/index.html',
+      });
+    });
+
+    it('handles deep paths', () => {
+      expect(fromPath('/adobe/site/folder/sub/page.html')).to.deep.equal({
+        org: 'adobe',
+        site: 'site',
+        path: '/folder/sub/page.html',
+      });
+    });
+
+    it('returns empty path when only org/site present', () => {
+      expect(fromPath('/adobe/site')).to.deep.equal({
+        org: 'adobe',
+        site: 'site',
+        path: '',
+      });
+    });
+  });
+
+  describe('hlx6ToDaList', () => {
+    it('passes through items without content-type unchanged', () => {
+      const items = [{ name: 'foo', path: '/foo' }];
+      expect(hlx6ToDaList('/parent', items)).to.deep.equal(items);
+    });
+
+    it('strips trailing slash for folders', () => {
+      const result = hlx6ToDaList('/parent', [
+        { name: 'subfolder/', 'content-type': 'application/folder' },
+      ]);
+      expect(result[0].name).to.equal('subfolder');
+      expect(result[0].path).to.equal('/parent/subfolder');
+    });
+
+    it('extracts ext and strips it from display name', () => {
+      const result = hlx6ToDaList('/parent', [
+        { name: 'page.html', 'content-type': 'text/html' },
+      ]);
+      expect(result[0].name).to.equal('page');
+      expect(result[0].ext).to.equal('html');
+      expect(result[0].path).to.equal('/parent/page.html');
+    });
+
+    it('converts last-modified to unix timestamp', () => {
+      const result = hlx6ToDaList('/parent', [
+        { name: 'x.html', 'content-type': 'text/html', 'last-modified': '2025-01-01T00:00:00.000Z' },
+      ]);
+      expect(result[0].lastModified).to.equal(new Date('2025-01-01T00:00:00.000Z').getTime());
+    });
+  });
+
+  describe('signout', () => {
+    it('hits DA_ADMIN/logout', async () => {
+      signout();
+      // signout is fire-and-forget; await microtask
+      await Promise.resolve();
+      await Promise.resolve();
+      const logoutCalls = callsTo(DA_ADMIN).filter((c) => c.url.endsWith('/logout'));
+      expect(logoutCalls.length).to.be.greaterThan(0);
+    });
+  });
+});

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
-import { setMockIms, resetMockIms } from '../../../nx2/test/mocks/ims.js';
 import { HLX_ADMIN, AEM_API, DA_ADMIN } from '../../../nx2/utils/utils.js';
+
 import {
   daFetch,
   isHlx6,
@@ -16,6 +16,13 @@ import {
   snapshot,
   jobs,
 } from '../../../nx2/utils/api.js';
+
+// Dynamic-expression import (not a literal string) so @web/dev-server-import-maps
+// does not rewrite this to ...?wds-import-map=0. The same mock URL is reached at
+// runtime via the inline importmap when api.js's dynamic IIFE imports ims.js, so
+// both this test and api.js receive the *same* mock module instance.
+const imsPath = '../../../nx2/utils/ims.js';
+const { setMockIms, resetMockIms } = await import(imsPath);
 
 const STORAGE_KEY = 'hlx6-upgrade';
 
@@ -191,7 +198,7 @@ describe('api.js', () => {
       const body = new Blob(['<html></html>'], { type: 'text/html' });
       await source.put({ org: o, site: s, path: '/page.html', body });
       const last = lastCall();
-      expect(last.method).to.equal('PUT');
+      expect(last.method).to.equal('POST');
       expect(last.body).to.be.instanceof(FormData);
       const stored = last.body.get('data');
       expect(stored).to.be.instanceof(Blob);
@@ -202,7 +209,7 @@ describe('api.js', () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
       await source.put({ org: o, site: s, path: '/page.html', body: '<main></main>' });
       const last = lastCall();
-      expect(last.method).to.equal('PUT');
+      expect(last.method).to.equal('POST');
       expect(last.headers['Content-Type']).to.equal('text/html');
       expect(last.body).to.equal('<main></main>');
     });
@@ -387,10 +394,10 @@ describe('api.js', () => {
   });
 
   describe('config', () => {
-    it('config.get site-level hlx6', async () => {
+    it('config.get site-level uses DA regardless of hlx6 status', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
       await config.get({ org: o, site: s });
-      expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/config.json`);
+      expect(lastCall().url).to.equal(`${DA_ADMIN}/config/${o}/${s}/`);
     });
 
     it('config.get org-only legacy', async () => {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -49,7 +49,8 @@ export default {
           {
             "imports": {
               "da-lit": "/deps/lit/dist/index.js",
-              "/nx/public/sl/components.js": "/test/mocks/sl-components.js"
+              "/nx/public/sl/components.js": "/test/mocks/sl-components.js",
+              "/nx2/utils/ims.js": "/nx2/test/mocks/ims.js"
             }
           }
         </script>

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -50,7 +50,8 @@ export default {
             "imports": {
               "da-lit": "/deps/lit/dist/index.js",
               "/nx/public/sl/components.js": "/test/mocks/sl-components.js",
-              "/nx2/utils/ims.js": "/nx2/test/mocks/ims.js"
+              "/nx2/utils/ims.js": "/nx2/test/mocks/ims.js",
+              "/scripts/utils.js": "/nx2/test/mocks/scripts-utils.js"
             }
           }
         </script>


### PR DESCRIPTION
Group endpoint helpers into namespaces: `source` `versions` `config` `status` `aem` `snapshot` `jobs`. Calls are routed each call to AEM_API or the legacy origin via the per-site hlx6 flag. Add unit tests for every namespace.

[API Documentation](https://github.com/adobe/da-nx/blob/5f8a2410675868ddada50271d5f35535689372e7/nx2/utils/api.md)