### PR TITLE
feat: configurable scriptsUrl and loadPage fn name for quick-edit

### DIFF
--- a/nx/public/plugins/quick-edit/quick-edit.js
+++ b/nx/public/plugins/quick-edit/quick-edit.js
@@ -60,13 +60,14 @@ function setupParentControllerListener() {
     parentControllerPort = port;
 
     let loadPageFn = null;
-    const scriptsUrl = `${window.location.origin}/scripts/scripts.js`;
+    const scriptsUrl = e.data.init?.scriptsUrl ?? `${window.location.origin}/scripts/scripts.js`;
+    const loadPageFnName = e.data.init?.loadPageFnName ?? 'loadPage';
 
     const loadPage = async () => {
       if (loadPageFn === null) {
         try {
           const mod = await import(/* webpackIgnore: true */ scriptsUrl);
-          loadPageFn = typeof mod?.loadPage === 'function' ? mod.loadPage : () => { };
+          loadPageFn = typeof mod?.[loadPageFnName] === 'function' ? mod[loadPageFnName] : () => { };
         } catch {
           loadPageFn = () => { };
         }

--- a/nx2/blocks/canvas/canvas.js
+++ b/nx2/blocks/canvas/canvas.js
@@ -87,7 +87,13 @@ function ensureNxEditorWysiwyg(mountRoot) {
 }
 
 function editorCtxFromHashState(state, fullPath) {
-  return { org: state.org, repo: state.site, path: fullPath };
+  return {
+    org: state.org,
+    repo: state.site,
+    path: fullPath,
+    ...(state.scriptsUrl && { scriptsUrl: state.scriptsUrl }),
+    ...(state.loadPageFnName && { loadPageFnName: state.loadPageFnName }),
+  };
 }
 
 function syncCanvasEditorsToHash({ mountRoot, header, state }) {

--- a/nx2/blocks/canvas/nx-editor-wysiwyg/nx-editor-wysiwyg.js
+++ b/nx2/blocks/canvas/nx-editor-wysiwyg/nx-editor-wysiwyg.js
@@ -11,12 +11,14 @@ const QUICK_EDIT_INIT_MAX_ATTEMPTS = 25;
 
 const WYSIWYG_PORT_READY_ATTR = 'data-nx-wysiwyg-port-ready';
 
-function buildQuickEditInitPayload({ org, repo, path }) {
+function buildQuickEditInitPayload({ org, repo, path, scriptsUrl, loadPageFnName }) {
   const pathWithoutOrgRepo = path.split('/').slice(2).join('/');
   const pathname = pathWithoutOrgRepo ? `/${pathWithoutOrgRepo}` : '/';
   return {
     config: {
       mountpoint: `${getPreviewOrigin(org, repo)}/${org}/${repo}`,
+      ...(scriptsUrl && { scriptsUrl }),
+      ...(loadPageFnName && { loadPageFnName }),
     },
     location: { pathname },
   };
@@ -177,14 +179,16 @@ export class NxEditorWysiwyg extends LitElement {
 
   _onIframeLoad(e) {
     const iframe = e?.target;
-    const { org, repo, path } = this.ctx ?? {};
+    const { org, repo, path, scriptsUrl, loadPageFnName } = this.ctx ?? {};
     if (!iframe?.contentWindow || !org || !repo || !path) return;
 
     this.removeAttribute(WYSIWYG_PORT_READY_ATTR);
     this._clearQuickEditRetry();
     this._syncCanvasVisibility();
 
-    const { config, location } = buildQuickEditInitPayload({ org, repo, path });
+    const { config, location } = buildQuickEditInitPayload({
+      org, repo, path, scriptsUrl, loadPageFnName,
+    });
     const send = () => this._postQuickEditInitToIframe({
       iframe,
       config,

--- a/nx2/blocks/canvas/nx-editor-wysiwyg/nx-editor-wysiwyg.js
+++ b/nx2/blocks/canvas/nx-editor-wysiwyg/nx-editor-wysiwyg.js
@@ -3,6 +3,7 @@ import { loadStyle } from '../../../utils/utils.js';
 import { getPreviewOrigin, fetchWysiwygCookie } from '../editor-utils/preview.js';
 import { loadIms } from '../../../utils/ims.js';
 import { hideSelectionToolbar } from '../editor-utils/selection-toolbar.js';
+import { fetchDaConfigs, getFirstSheet } from '../../../utils/daConfig.js';
 
 const style = await loadStyle(import.meta.url);
 
@@ -22,6 +23,22 @@ function buildQuickEditInitPayload({ org, repo, path, scriptsUrl, loadPageFnName
     },
     location: { pathname },
   };
+}
+
+async function fetchScriptsConfig({ org, site }) {
+  try {
+    const configs = fetchDaConfigs({ org, site });
+    const siteConfig = await configs[configs.length - 1];
+    if (!siteConfig || siteConfig.error) return {};
+    const rows = getFirstSheet(siteConfig) || [];
+    const get = (key) => rows.find((r) => r.key === key)?.value || undefined;
+    return {
+      scriptsUrl: get('quick-edit.scriptsUrl'),
+      loadPageFnName: get('quick-edit.loadPageFnName'),
+    };
+  } catch {
+    return {};
+  }
 }
 
 async function tryLoadWysiwygPreviewCookies({ org, repo, path, getCurrentCtx }) {
@@ -111,6 +128,9 @@ export class NxEditorWysiwyg extends LitElement {
   _resetCookieStateForCtxChange() {
     this._clearQuickEditRetry();
     this._cookieReady = false;
+    this._daConfigOverrides = null;
+    this._lastIframeLoaded = null;
+    this._ctxGen = (this._ctxGen ?? 0) + 1;
   }
 
   updated(changed) {
@@ -122,6 +142,8 @@ export class NxEditorWysiwyg extends LitElement {
     const { org, repo, path } = this.ctx ?? {};
     if (!org || !repo || !path) return;
 
+    const gen = this._ctxGen;
+
     tryLoadWysiwygPreviewCookies({
       org,
       repo,
@@ -131,6 +153,12 @@ export class NxEditorWysiwyg extends LitElement {
       if (!ok) return;
       this._cookieReady = true;
       this.requestUpdate();
+    });
+
+    fetchScriptsConfig({ org, site: repo }).then((overrides) => {
+      if (gen !== this._ctxGen) return;
+      this._daConfigOverrides = overrides;
+      this._lastIframeLoaded?.();
     });
   }
 
@@ -186,16 +214,23 @@ export class NxEditorWysiwyg extends LitElement {
     this._clearQuickEditRetry();
     this._syncCanvasVisibility();
 
-    const { config, location } = buildQuickEditInitPayload({
-      org, repo, path, scriptsUrl, loadPageFnName,
-    });
-    const send = () => this._postQuickEditInitToIframe({
-      iframe,
-      config,
-      location,
-      onReady: (port) => this._dispatchWysiwygPortReady(port),
-    });
+    const send = () => {
+      const { config, location } = buildQuickEditInitPayload({
+        org,
+        repo,
+        path,
+        scriptsUrl: scriptsUrl ?? this._daConfigOverrides?.scriptsUrl,
+        loadPageFnName: loadPageFnName ?? this._daConfigOverrides?.loadPageFnName,
+      });
+      this._postQuickEditInitToIframe({
+        iframe,
+        config,
+        location,
+        onReady: (port) => this._dispatchWysiwygPortReady(port),
+      });
+    };
 
+    this._lastIframeLoaded = send;
     send();
     this._scheduleQuickEditInitRetries(send);
   }


### PR DESCRIPTION
## Summary

- `editorCtxFromHashState` in `canvas.js` spreads optional `scriptsUrl` and `loadPageFnName` from site config into `ctx`
- `buildQuickEditInitPayload` in `nx-editor-wysiwyg.js` forwards those fields into the `config` object sent to the iframe; `_onIframeLoad` passes them through
- `setupParentControllerListener` in `quick-edit.js` reads both fields from `e.data.init` with fallbacks to the current hardcoded defaults (`/scripts/scripts.js` and `'loadPage'`)

No behaviour change for sites that don't supply either field.

## Test plan

- [ ] Verify quick-edit still works on a standard site (no config supplied — fallback path)
- [ ] Verify quick-edit works on a site with a custom `scriptsUrl` passed through `ctx`
- [ ] Verify quick-edit works on a site with a custom `loadPageFnName` passed through `ctx`
- [ ] Confirm neither field appears in the iframe message when absent from `ctx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)