### PR TITLE
feat(nx2): inject Omega Adobe Launch lazily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ helix-importer-ui
 *.bak
 .idea
 .claude/settings.local.json
+PR-throwaways/

--- a/docs/chat-ui-component.md
+++ b/docs/chat-ui-component.md
@@ -25,23 +25,35 @@ The component manages its own controller internally. No external wiring needed.
 **Message shape:**
 
 ```js
-{ role: 'user', content: string }
+{ role: 'user', content: string, selectionContext?: [...], attachmentsMeta?: [...] }
 { role: 'assistant', content: string }
 { role: 'tool', ... }  // filtered from display automatically
 ```
 
-**Request body:** The controller POSTs `{ messages, pageContext, imsToken, room }` to the agent. Selection context is embedded on individual user messages (see [Selection context](#selection-context)) rather than as a top-level request field.
+`attachmentsMeta` items: `{ id, fileName, mediaType, sizeBytes? }` — base64 data is stripped before storing.
+
+**Request body:** The controller POSTs `{ messages, pageContext, imsToken, room, attachments? }` to the agent. Selection context is embedded on individual user messages (see [Selection context](#selection-context)) rather than as a top-level request field.
+
+`attachments` items: `{ id, fileName, mediaType, dataBase64?, contentUrl?, sizeBytes? }`. Exactly one of `dataBase64` or `contentUrl` must be present. On the first POST `dataBase64` is sent; after a successful `content_upload` the controller replaces it with `contentUrl` (the DA storage URL from the tool result) on continuation POSTs. Present when the user attached files to the message; omitted on turns with no attachments.
+
+> **Contract:** `attachments` is consumed by da-agent to make file content available to the model. The agent stores attachments in a per-request map keyed by `id`; the model calls `content_upload(attachmentRef)` to persist a file to DA storage.
 
 ## Methods
 
 | Method | Description |
 |---|---|
-| `chat.addAttachment({ id, label, ...rest })` | Adds a pill above the textarea. `id` is required — duplicate ids are silently ignored. `label` is the display text. Any additional fields are forwarded to the agent as context alongside the next message. |
+| `chat.addAttachment({ id, label, ...rest })` | Adds a pill above the textarea. `id` is required — duplicate ids are silently ignored. `label` is the display text. Any additional fields are forwarded to the agent as selection context alongside the next message. |
 | `chat.clear()` | Clears conversation history and resets IndexedDB for the current room. |
 
-**Current scope:** `addAttachment` supports simple content references — e.g. a block or element from the document editor. Binary file attachments (images, uploads) are not yet supported and will extend this same API when introduced.
-
 **Pills display:** All attached pills are currently shown with vertical scroll capped at two rows. Collapsing overflow into a "+N more" control is pending UX mocks.
+
+## File attachments
+
+Users can attach files via the **+** menu ("Files or images") or by **drag-and-dropping** onto the chat form. Up to 20 files per message. Accepted types: images (`image/*`), markdown (`.md`), and PDF (`.pdf`). The same restriction applies to drag-and-drop.
+
+File items are read as base64 and sent to da-agent as `attachments` (see [Request body](#request-body)). They are stored on the sent user message as `attachmentsMeta` (no base64) for display in the conversation log.
+
+> **Note:** `addAttachment` is for selection context (blocks, file paths). Binary file attachments go through the internal file picker / drag-and-drop path and are not exposed via `addAttachment`.
 
 ## Events in
 

--- a/nx2/blocks/canvas/nx-editor-doc/nx-editor-doc.js
+++ b/nx2/blocks/canvas/nx-editor-doc/nx-editor-doc.js
@@ -208,7 +208,9 @@ export class NxEditorDoc extends LitElement {
               const blockIndex = getActiveBlockIndex(pmView);
               if (blockIndex === this._lastDocBlockIndex) return;
               this._lastDocBlockIndex = blockIndex;
-              const explicit = pmView.state.selection instanceof NodeSelection;
+              const sel = pmView.state.selection;
+              const isTopLevel = sel instanceof NodeSelection && sel.$from.depth === 0;
+              const explicit = isTopLevel;
               editorSelectChange.emit({ blockIndex, source: 'doc', explicit });
             },
           ),

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -154,16 +154,45 @@ export default class ChatController {
       if (state === TOOL_STATE.DONE) {
         // Add a virtual message so the tool renders in the conversation at the right
         // position and persists across refreshes, without being sent back to the agent.
-        this._messages = [
-          ...this._messages,
-          {
-            role: ROLE.ASSISTANT,
-            virtual: true,
-            content: [{
-              type: AGENT_EVENT.TOOL_CALL, toolCallId, toolName: prior.toolName, input: prior.input,
-            }],
-          },
-        ];
+        // Skip if a real message already exists for this toolCallId (approval flow adds one).
+        const hasApprovalMessage = this._messages.some(
+          (m) => !m.virtual && Array.isArray(m.content) && m.content.some(
+            (p) => p.type === AGENT_EVENT.TOOL_CALL && p.toolCallId === toolCallId,
+          ),
+        );
+        if (!hasApprovalMessage) {
+          this._messages = [
+            ...this._messages,
+            {
+              role: ROLE.ASSISTANT,
+              virtual: true,
+              content: [{
+                type: AGENT_EVENT.TOOL_CALL,
+                toolCallId,
+                toolName: prior.toolName,
+                input: prior.input,
+              }],
+            },
+          ];
+        }
+
+        // Once content_upload succeeds, replace dataBase64 with contentUrl on the pending
+        // attachment so continuation POSTs don't retransmit bytes already in storage.
+        const contentUrl = output?.source?.contentUrl;
+
+        if (prior.toolName === 'content_upload' && prior.input?.attachmentRef && contentUrl) {
+          this._pendingAttachments = (this._pendingAttachments ?? []).map((a) => (
+            a.id === prior.input.attachmentRef
+              ? {
+                id: a.id,
+                fileName: a.fileName,
+                mediaType: a.mediaType,
+                contentUrl,
+                ...(typeof a.sizeBytes === 'number' ? { sizeBytes: a.sizeBytes } : {}),
+              }
+              : a
+          ));
+        }
         this._onToolDone?.();
       }
     }
@@ -225,6 +254,7 @@ export default class ChatController {
         imsToken: accessToken?.token ?? null,
         room,
         ...(this._requestedSkills?.length ? { requestedSkills: this._requestedSkills } : {}),
+        ...(this._pendingAttachments?.length ? { attachments: this._pendingAttachments } : {}),
       }),
       signal: this._abortController.signal,
     });
@@ -245,7 +275,7 @@ export default class ChatController {
     });
   }
 
-  async sendMessage(message, context = [], { requestedSkills = [] } = {}) {
+  async sendMessage(message, context = [], { requestedSkills = [], attachments = [] } = {}) {
     if (this._thinking || !this._connected) return;
 
     this._requestedSkills = requestedSkills;
@@ -257,11 +287,21 @@ export default class ChatController {
         ...(innerText && { innerText }),
       }));
 
+    const attachmentsMeta = attachments.map(({ id, fileName, mediaType, sizeBytes }) => ({
+      id,
+      fileName,
+      mediaType,
+      ...(typeof sizeBytes === 'number' ? { sizeBytes } : {}),
+    }));
+
     const userMessage = {
       role: ROLE.USER,
       content: message,
       ...(selectionContext.length && { selectionContext }),
+      ...(attachmentsMeta.length && { attachmentsMeta }),
     };
+
+    this._pendingAttachments = attachments;
 
     this._messages = [...(this._messages ?? []), userMessage];
     this._thinking = true;

--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -346,6 +346,35 @@
     var(--s2-spacing-100);
   gap: var(--s2-spacing-75);
   margin: 0 auto;
+  position: relative;
+}
+
+.chat-drop-zone {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s2-spacing-75);
+  background: color-mix(in srgb, var(--s2-gray-25) 85%, transparent);
+  border: 2px solid var(--s2-blue-900);
+  border-radius: var(--s2-corner-radius-400);
+  text-align: center;
+  padding: var(--s2-spacing-200);
+  box-sizing: border-box;
+
+  .chat-drop-title {
+    font-size: var(--s2-body-size-s);
+    font-weight: var(--s2-component-m-bold-font-weight);
+    color: var(--s2-gray-900);
+  }
+
+  .chat-drop-hint {
+    font-size: var(--s2-body-size-xs);
+    color: var(--s2-gray-600);
+  }
 }
 
 .chat-actions {
@@ -409,7 +438,8 @@
   font-size: var(--s2-body-size-s);
   background: inherit;
 
-  &:not(:placeholder-shown) + .chat-actions .chat-send {
+  &:not(:placeholder-shown) + .chat-actions .chat-send,
+  & + .chat-actions[data-has-items] .chat-send {
     display: flex;
   }
 
@@ -458,6 +488,7 @@
   flex-direction: column;
   gap: var(--s2-spacing-100);
   padding: var(--s2-spacing-100);
+  z-index: 1;
 
   .approval-tool-name {
     font-weight: bold;

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -1,12 +1,13 @@
 import { LitElement, html, nothing } from 'da-lit';
 import ChatController from './chat-controller.js';
+import { SlashMenuController } from './slash-menu.js';
 import { renderMessage, renderApprovalCard } from './renderers.js';
 import './welcome/welcome.js';
 import './prompts/prompts.js';
 import './pills/pills.js';
 import '../shared/menu/menu.js';
 import { loadStyle, hashChange } from '../../utils/utils.js';
-import { loadChatIcons } from './utils.js';
+import { loadChatIcons, readFileAsBase64 } from './utils.js';
 import { loadSiteConfig } from './api.js';
 import { ADD_MENU_ITEMS, CHAT_ICONS, MENU_OPTIONS, ROLE, TOOL_STATE } from './constants.js';
 
@@ -24,6 +25,7 @@ class NxChat extends LitElement {
     toolCards: { type: Object },
     _prompts: { state: true },
     _items: { state: true },
+    _dragging: { state: true },
   };
 
   set context(value) {
@@ -32,6 +34,8 @@ class NxChat extends LitElement {
   }
 
   _keyedItemIds = new Map();
+
+  _slashMenu = new SlashMenuController();
 
   _onAddToChat = ({ detail }) => {
     const { key, ...item } = detail;
@@ -82,68 +86,12 @@ class NxChat extends LitElement {
     this._configKey = key;
     const { prompts, skills } = await loadSiteConfig(org, site);
     this._prompts = prompts ?? [];
-    this._skills = skills ?? [];
-    if (this._slashCtx) this._syncSlashMenu(this._slashCtx);
-  }
-
-  _getSlashItems(filter) {
-    if (!this._skills) return [];
-    const skills = this._skills.map((id) => ({ id, label: id }));
-    const filtered = filter
-      ? skills.filter((item) => item.id.toLowerCase().includes(filter))
-      : skills;
-    if (!filtered.length) return [];
-    return [{ section: 'Skills' }, ...filtered];
+    this._slashMenu.setSkills(skills ?? []);
+    this._slashMenu.refresh(this.shadowRoot?.querySelector('.chat-form'));
   }
 
   firstUpdated() {
-    this._slashMenuEl = this.shadowRoot.querySelector('.slash-menu');
-  }
-
-  _getSlashContext(input) {
-    const pos = input.selectionStart;
-    const before = input.value.slice(0, pos);
-    const wordStart = Math.max(before.lastIndexOf(' '), before.lastIndexOf('\n')) + 1;
-    const word = before.slice(wordStart);
-    if (!word.startsWith('/')) return null;
-    return { filter: word.slice(1).toLowerCase(), wordStart };
-  }
-
-  _syncSlashMenu(ctx) {
-    if (!this._slashMenuEl) return;
-    if (!ctx) {
-      this._slashMenuEl.close();
-      return;
-    }
-    const items = this._getSlashItems(ctx.filter);
-    if (!items.length) {
-      this._slashMenuEl.close();
-      return;
-    }
-    this._slashMenuEl.items = items;
-    if (!this._slashMenuEl.open) {
-      const form = this.shadowRoot.querySelector('.chat-form');
-      this._slashMenuEl.show({ anchor: form, placement: 'above' });
-    } else {
-      this._slashMenuEl.reposition();
-    }
-  }
-
-  _spliceInput(input, text, start, end = start) {
-    input.value = input.value.slice(0, start) + text + input.value.slice(end);
-    input.setSelectionRange(start + text.length, start + text.length);
-  }
-
-  _onSlashSelect(skillId) {
-    const input = this.shadowRoot?.querySelector('.chat-input');
-    const { wordStart } = this._slashCtx ?? {};
-    const before = input?.value.slice(0, wordStart ?? 0).trimEnd();
-    const after = input?.value.slice(input.selectionStart).trimStart();
-    const message = [before, `/${skillId}`, after].filter(Boolean).join(' ');
-    this._slashCtx = null;
-    this._slashMenuEl?.close();
-    if (input) input.value = '';
-    this._controller.sendMessage(message, [], { requestedSkills: [skillId] });
+    this._slashMenu.connect(this.shadowRoot.querySelector('.slash-menu'));
   }
 
   async connectedCallback() {
@@ -177,6 +125,9 @@ class NxChat extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    (this._items ?? []).forEach((item) => {
+      if (item.thumbnail) URL.revokeObjectURL(item.thumbnail);
+    });
     this._unsubscribeHash?.();
     this._controller?.destroy();
     document.removeEventListener('keydown', this._onApprovalKeydown);
@@ -246,26 +197,18 @@ class NxChat extends LitElement {
   }
 
   _handleInput(e) {
-    this._slashCtx = this._getSlashContext(e.target);
-    this._syncSlashMenu(this._slashCtx);
+    const form = this.shadowRoot.querySelector('.chat-form');
+    this._slashMenu.handleInput(e.target, form);
   }
 
   _handleBlur() {
-    // Defer past any click event on a menu item that triggered the blur
-    setTimeout(() => {
-      this._slashMenuEl?.close();
-      this._slashCtx = null;
-    }, 0);
+    this._slashMenu.handleBlur();
   }
 
   _handleKeydown(e) {
-    if (this._slashMenuEl?.open) {
-      const keys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape'];
-      if (keys.includes(e.key)) {
-        e.preventDefault();
-        this._slashMenuEl.handleKey(e.key);
-        return;
-      }
+    if (this._slashMenu.handleKey(e.key)) {
+      e.preventDefault();
+      return;
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -280,11 +223,19 @@ class NxChat extends LitElement {
       return;
     }
     const input = this.shadowRoot.querySelector('.chat-input');
-    const message = input.value.trim();
-    if (!message && !this._items?.length) return;
-    const context = this._items ?? [];
-    this._slashMenuEl?.close();
-    this._controller.sendMessage(message, context);
+    const text = input.value.trim();
+    if (!text && !this._items?.length) return;
+
+    const fileItems = (this._items ?? []).filter((i) => i.dataBase64);
+    const contextItems = (this._items ?? []).filter((i) => !i.dataBase64);
+    const message = text || (fileItems.length > 1 ? 'Attached files' : 'Attached file');
+    const attachments = fileItems.map(({ id, fileName, mediaType, sizeBytes, dataBase64 }) => ({
+      id, fileName, mediaType, dataBase64, ...(typeof sizeBytes === 'number' ? { sizeBytes } : {}),
+    }));
+    fileItems.forEach((i) => { if (i.thumbnail) URL.revokeObjectURL(i.thumbnail); });
+
+    this._slashMenu.close();
+    this._controller.sendMessage(message, contextItems, { attachments });
     input.value = '';
     this._items = [];
   }
@@ -298,23 +249,87 @@ class NxChat extends LitElement {
     input.focus();
   }
 
-  _handleMenuSelect({ detail: { id } }) {
-    if (id === MENU_OPTIONS.PROMPT) this._openPrompts();
-    if (id === MENU_OPTIONS.COMMAND) this._insertSlash();
+  async _onFilesSelected(fileList) {
+    const MAX_FILES = 20;
+    const fileCount = (this._items ?? []).filter((i) => i.dataBase64).length;
+    const available = Math.max(0, MAX_FILES - fileCount);
+    const files = Array.from(fileList).slice(0, available);
+    if (!files.length) return;
+
+    const results = await Promise.all(files.map(async (file) => {
+      try {
+        const dataBase64 = await readFileAsBase64(file);
+        if (!dataBase64) return null;
+        const isImage = file.type?.startsWith('image/');
+        return {
+          id: crypto.randomUUID(),
+          label: file.name,
+          type: isImage ? 'image' : 'file',
+          fileName: file.name,
+          mediaType: file.type,
+          sizeBytes: file.size,
+          dataBase64,
+          ...(isImage ? { thumbnail: URL.createObjectURL(file) } : {}),
+        };
+      } catch { return null; }
+    }));
+
+    results.filter(Boolean).forEach((item) => this.addAttachment(item));
   }
 
-  _insertSlash() {
+  _openFilePicker() {
+    this.shadowRoot.querySelector('.chat-file-input')?.click();
+  }
+
+  async _onFileInputChange(e) {
+    const { target } = e;
+    await this._onFilesSelected(target.files);
+    target.value = '';
+  }
+
+  _handleMenuSelect({ detail: { id } }) {
+    if (id === MENU_OPTIONS.PROMPT) this._openPrompts();
+    if (id === MENU_OPTIONS.COMMAND) this._slashMenu.insertSlash(this.shadowRoot.querySelector('.chat-input'));
+    if (id === MENU_OPTIONS.FILES) this._openFilePicker();
+  }
+
+  _onDragEnter(e) {
+    e.preventDefault();
+    this._dragging = true;
+  }
+
+  _onDragLeave(e) {
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+    this._dragging = false;
+  }
+
+  _onDragOver(e) {
+    e.preventDefault();
+  }
+
+  async _onDrop(e) {
+    e.preventDefault();
+    this._dragging = false;
+    const { files } = e.dataTransfer ?? {};
+    if (!files?.length) return;
+    const accepted = Array.from(files).filter((f) => {
+      if (f.type?.startsWith('image/')) return true;
+      if (f.type === 'text/markdown' || f.type === 'application/pdf') return true;
+      return f.name?.endsWith('.md') || f.name?.endsWith('.pdf');
+    });
+    if (accepted.length) await this._onFilesSelected(accepted);
+  }
+
+  _onSkillSelect({ detail }) {
     const input = this.shadowRoot.querySelector('.chat-input');
-    if (!input) return;
-    const { value, selectionStart: pos } = input;
-    const before = value.slice(0, pos);
-    const slash = (before && !before.endsWith(' ')) ? ' /' : '/';
-    this._spliceInput(input, slash, pos);
-    input.focus();
-    input.dispatchEvent(new Event('input'));
+    this._slashMenu.select(detail.id, input, (msg, skill) => {
+      this._controller.sendMessage(msg, [], { requestedSkills: [skill] });
+    });
   }
 
   _handlePillRemove({ detail: { id } }) {
+    const removed = (this._items ?? []).find((i) => i.id === id);
+    if (removed?.thumbnail) URL.revokeObjectURL(removed.thumbnail);
     this._items = (this._items ?? []).filter((item) => item.id !== id);
   }
 
@@ -327,7 +342,7 @@ class NxChat extends LitElement {
       <nx-popover class="prompts-popover">
         <nx-prompts
           .prompts=${prompts}
-          .onSend=${(p) => this._sendPrompt(p)}
+          @nx-select-prompt=${({ detail }) => this._sendPrompt(detail.prompt)}
         ></nx-prompts>
       </nx-popover>
       <div class="chat-header">
@@ -350,7 +365,7 @@ class NxChat extends LitElement {
           ${!this.messages?.length && !this.thinking
         ? html`<nx-chat-welcome
               .prompts=${prompts}
-              .onSend=${(p) => this._sendPrompt(p)}
+              @nx-select-prompt=${({ detail }) => this._sendPrompt(detail.prompt)}
               @nx-show-prompts=${this._openPrompts}
             ></nx-chat-welcome>`
         : nothing}
@@ -363,11 +378,29 @@ class NxChat extends LitElement {
           class="slash-menu"
           .ignoreFocus=${true}
           .scoped=${true}
-          @select=${({ detail }) => this._onSlashSelect(detail.id)}
           @mousedown=${(e) => e.preventDefault()}
+          @select=${this._onSkillSelect}
         ></nx-menu>
         ${renderApprovalCard(this._pendingApproval(), this._controller.approveToolCall)}
-        <form class="chat-form" autocomplete="off" @submit=${this._submit}>
+        <form class="chat-form" autocomplete="off" @submit=${this._submit}
+          @dragenter=${this._onDragEnter}
+          @dragleave=${this._onDragLeave}
+          @dragover=${this._onDragOver}
+          @drop=${this._onDrop}
+        >
+        <input
+          class="chat-file-input"
+          type="file"
+          accept="image/*,text/markdown,.md,application/pdf,.pdf"
+          multiple
+          hidden
+          @change=${this._onFileInputChange}
+        />
+        ${this._dragging ? html`
+          <div class="chat-drop-zone" aria-hidden="true">
+            <span class="chat-drop-title">Drop a file to add context</span>
+            <span class="chat-drop-hint">Supports PDF, images, and documents</span>
+          </div>` : nothing}
         ${this._items?.length ? html`
           <nx-chat-pills
             .items=${this._items}
@@ -382,7 +415,7 @@ class NxChat extends LitElement {
           @keydown=${this._handleKeydown}
           @blur=${this._handleBlur}
         ></textarea>
-        <div class="chat-actions" ?data-thinking=${this.thinking}>
+        <div class="chat-actions" ?data-thinking=${this.thinking} ?data-has-items=${!!this._items?.length}>
           <nx-menu .items=${ADD_MENU_ITEMS} placement="above" @select=${this._handleMenuSelect}>
             <button slot="trigger" class="chat-add" type="button" aria-label="Add" @click=${this._onAddClick}>
               <span class="icon-add">${icon('add')}</span>

--- a/nx2/blocks/chat/constants.js
+++ b/nx2/blocks/chat/constants.js
@@ -1,6 +1,7 @@
 const MENU_OPTIONS = {
   PROMPT: 'prompt',
   COMMAND: 'command',
+  FILES: 'files',
 };
 
 const ADD_MENU_ITEMS = [

--- a/nx2/blocks/chat/pills/pills.css
+++ b/nx2/blocks/chat/pills/pills.css
@@ -49,6 +49,32 @@
     mask-image: url("/nx2/img/icons/S2_Icon_Close_20_N.svg");
   }
 
+  .pill-thumbnail {
+    width: 16px;
+    height: 16px;
+    object-fit: cover;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .pill-type-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    background-color: var(--s2-blue-1000);
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-position: center;
+
+    &.icon-image {
+      mask-image: url("/nx2/img/icons/S2_Icon_Image_20_N.svg");
+    }
+
+    &.icon-file {
+      mask-image: url("/nx2/img/icons/S2_Icon_FileText_20_N.svg");
+    }
+  }
+
   .pill-label {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/nx2/blocks/chat/pills/pills.js
+++ b/nx2/blocks/chat/pills/pills.js
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle } from '../../../utils/utils.js';
+import { iconClassFromName } from '../../shared/utils/icons.js';
 
 const styles = await loadStyle(import.meta.url);
 
@@ -17,7 +18,12 @@ class NxChatPills extends LitElement {
     this.dispatchEvent(new CustomEvent('nx-pill-remove', { detail: { id } }));
   }
 
-  _renderPill({ id, label }) {
+  _pillTypeIcon(label, thumbnail) {
+    if (thumbnail) return html`<img class="pill-thumbnail" src=${thumbnail} alt="" aria-hidden="true">`;
+    return html`<span class="pill-type-icon ${iconClassFromName(label)}" aria-hidden="true"></span>`;
+  }
+
+  _renderPill({ id, label, thumbnail }) {
     return html`
       <li class="pill">
         <button
@@ -26,6 +32,7 @@ class NxChatPills extends LitElement {
           aria-label="Remove ${label}"
           @click=${() => this._remove(id)}
         ></button>
+        ${this._pillTypeIcon(label, thumbnail)}
         <span class="pill-label" title=${label}>${label}</span>
       </li>
     `;

--- a/nx2/blocks/chat/prompts/prompts.js
+++ b/nx2/blocks/chat/prompts/prompts.js
@@ -45,6 +45,10 @@ class NxPrompts extends LitElement {
     });
   }
 
+  _onSelectPrompt(prompt) {
+    this.dispatchEvent(new CustomEvent('nx-select-prompt', { detail: { prompt }, bubbles: true, composed: true }));
+  }
+
   _onListKeydown(e) {
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     const items = [...this.shadowRoot.querySelectorAll('.prompt-item')];
@@ -105,7 +109,7 @@ class NxPrompts extends LitElement {
       <ul class="prompts-list" @keydown=${this._onListKeydown}>
         ${filtered.map((p) => html`
           <li>
-            <button class="prompt-item" type="button" @click=${() => this.onSend?.(p.prompt)}>
+            <button class="prompt-item" type="button" @click=${() => this._onSelectPrompt(p.prompt)}>
               <div class="prompt-item-header">
                 <span class="prompt-item-title">${p.title}</span>
                 ${p.category ? html`<span class="prompt-item-category">${p.category}</span>` : nothing}

--- a/nx2/blocks/chat/renderers.js
+++ b/nx2/blocks/chat/renderers.js
@@ -1,6 +1,7 @@
 import { html, nothing } from 'da-lit';
 import { AGENT_EVENT, ROLE, TOOL_INPUT, TOOL_STATE } from './constants.js';
 import { unified, remarkParse } from '../../deps/mdast/dist/index.js';
+import { iconClassFromName } from '../shared/utils/icons.js';
 
 function renderNode(node) {
   switch (node.type) {
@@ -90,14 +91,7 @@ function renderApprovalCard(pending, onApprove) {
   `;
 }
 
-// Mirrors entryTypeFromExtension in browse/utils.js — switch to common utils once migrated.
-function selectionIconClass(blockName) {
-  const ext = (blockName ?? '').includes('.') ? blockName.split('.').pop().toLowerCase() : '';
-  if (!ext) return 'icon-block';
-  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'mp4', 'webm', 'mov'].includes(ext)) return 'icon-image';
-  if (['json', 'xlsx', 'xls', 'csv'].includes(ext)) return 'icon-table';
-  return 'icon-file';
-}
+const toContextItem = (name, fallback = 'icon-file') => ({ name, iconClass: iconClassFromName(name, fallback) });
 
 function renderMessage(msg, icons, toolCards) {
   if (msg.role === ROLE.TOOL) return nothing;
@@ -115,25 +109,31 @@ function renderMessage(msg, icons, toolCards) {
       </button>`
     : nothing;
 
-  const selectionItem = ({ blockName }) => html`
+  const contextItem = ({ name, iconClass }) => html`
     <li class="selection-context-item">
-      <span class="selection-icon ${selectionIconClass(blockName)}"></span>
-      <span>${blockName}</span>
+      <span class="selection-icon ${iconClass}"></span>
+      <span>${name}</span>
     </li>`;
 
-  let selectionPills = nothing;
-  if (!isAssistant && msg.selectionContext?.length) {
-    selectionPills = msg.selectionContext.length === 1
-      ? html`<ul class="selection-context-list" aria-label="Attached context">${selectionItem(msg.selectionContext[0])}</ul>`
-      : html`<details class="selection-context">
-          <summary><span class="selection-context-count">${msg.selectionContext.length} items added</span></summary>
-          <ul class="selection-context-list">${msg.selectionContext.map(selectionItem)}</ul>
+  let contextPills = nothing;
+  if (!isAssistant) {
+    const items = [
+      ...(msg.selectionContext ?? []).map(({ blockName }) => toContextItem(blockName, 'icon-block')),
+      ...(msg.attachmentsMeta ?? []).map(({ fileName }) => toContextItem(fileName)),
+    ];
+    if (items.length === 1) {
+      contextPills = html`<ul class="selection-context-list" aria-label="Attached context">${contextItem(items[0])}</ul>`;
+    } else if (items.length > 1) {
+      contextPills = html`<details class="selection-context">
+          <summary><span class="selection-context-count">${items.length} items added</span></summary>
+          <ul class="selection-context-list">${items.map(contextItem)}</ul>
         </details>`;
+    }
   }
 
   return html`
     <div class="message message-${msg.role}">
-      ${selectionPills}
+      ${contextPills}
       <div class="message-content">${isAssistant ? renderMessageContent(msg.content) : msg.content}</div>
       ${copy}
     </div>

--- a/nx2/blocks/chat/slash-menu.js
+++ b/nx2/blocks/chat/slash-menu.js
@@ -1,0 +1,104 @@
+function spliceInput(input, text, start, end = start) {
+  input.value = input.value.slice(0, start) + text + input.value.slice(end);
+  input.setSelectionRange(start + text.length, start + text.length);
+}
+
+export class SlashMenuController {
+  _ctx = null;
+
+  _menuEl = null;
+
+  _skills = [];
+
+  connect(menuEl) {
+    this._menuEl = menuEl;
+  }
+
+  setSkills(skills) {
+    this._skills = skills ?? [];
+  }
+
+  _getItems(filter) {
+    const skills = this._skills.map((id) => ({ id, label: id }));
+    const filtered = filter
+      ? skills.filter((item) => item.id.toLowerCase().includes(filter))
+      : skills;
+    if (!filtered.length) return [];
+    return [{ section: 'Skills' }, ...filtered];
+  }
+
+  _getContext(input) {
+    const pos = input.selectionStart;
+    const before = input.value.slice(0, pos);
+    const wordStart = Math.max(before.lastIndexOf(' '), before.lastIndexOf('\n')) + 1;
+    const word = before.slice(wordStart);
+    if (!word.startsWith('/')) return null;
+    return { filter: word.slice(1).toLowerCase(), wordStart };
+  }
+
+  _sync(ctx, anchor) {
+    if (!this._menuEl) return;
+    if (!ctx) {
+      this._menuEl.close();
+      return;
+    }
+    const items = this._getItems(ctx.filter);
+    if (!items.length) {
+      this._menuEl.close();
+      return;
+    }
+    this._menuEl.items = items;
+    if (!this._menuEl.open) this._menuEl.show({ anchor, placement: 'above' });
+  }
+
+  handleInput(input, anchor) {
+    this._ctx = this._getContext(input);
+    this._sync(this._ctx, anchor);
+  }
+
+  handleBlur() {
+    setTimeout(() => {
+      this._menuEl?.close();
+      this._ctx = null;
+    }, 0);
+  }
+
+  // Returns true if the key was consumed by the menu.
+  handleKey(key) {
+    if (!this._menuEl?.open) return false;
+    const keys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape'];
+    if (!keys.includes(key)) return false;
+    this._menuEl.handleKey(key);
+    return true;
+  }
+
+  refresh(anchor) {
+    if (this._ctx) this._sync(this._ctx, anchor);
+  }
+
+  select(skillId, input, onSend) {
+    const { wordStart } = this._ctx ?? {};
+    const before = input?.value.slice(0, wordStart ?? 0).trimEnd();
+    const after = input?.value.slice(input.selectionStart).trimStart();
+    const message = [before, `/${skillId}`, after].filter(Boolean).join(' ');
+    this._ctx = null;
+    this._menuEl?.close();
+    if (input) input.value = '';
+    onSend(message, skillId);
+  }
+
+  insertSlash(input) {
+    if (!input) return;
+    const { value, selectionStart: pos } = input;
+    const before = value.slice(0, pos);
+    const slash = (before && !before.endsWith(' ')) ? ' /' : '/';
+    spliceInput(input, slash, pos);
+    input.focus();
+    input.dispatchEvent(new Event('input'));
+  }
+
+  close() {
+    this._menuEl?.close();
+    this._ctx = null;
+  }
+}

--- a/nx2/blocks/chat/utils.js
+++ b/nx2/blocks/chat/utils.js
@@ -60,6 +60,18 @@ function processEvent(event, streaming, callbacks) {
   return { streaming, done: false };
 }
 
+export function readFileAsBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || '');
+      resolve(result.includes(',') ? result.split(',')[1] : '');
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
 export async function readStream(body, callbacks) {
   const decoder = new TextDecoder();
   let buffer = '';

--- a/nx2/blocks/chat/welcome/welcome.js
+++ b/nx2/blocks/chat/welcome/welcome.js
@@ -18,6 +18,10 @@ class NxChatWelcome extends LitElement {
     });
   }
 
+  _onSelectPrompt(prompt) {
+    this.dispatchEvent(new CustomEvent('nx-select-prompt', { detail: { prompt }, bubbles: true, composed: true }));
+  }
+
   _showMore() {
     this.dispatchEvent(new CustomEvent('nx-show-prompts', { bubbles: true, composed: true }));
   }
@@ -34,7 +38,7 @@ class NxChatWelcome extends LitElement {
       ${prompts.length ? html`
         <div class="prompt-cards">
           ${prompts.slice(0, 3).map((card) => html`
-            <button class="prompt-card" @click=${() => this.onSend?.(card.prompt)}>
+            <button class="prompt-card" @click=${() => this._onSelectPrompt(card.prompt)}>
               <span class="prompt-card-description">${card.description}</span>
             </button>
           `)}

--- a/nx2/blocks/shared/utils/icons.js
+++ b/nx2/blocks/shared/utils/icons.js
@@ -1,0 +1,10 @@
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'mp4', 'webm', 'mov']);
+const TABLE_EXTS = new Set(['json', 'xlsx', 'xls', 'csv']);
+
+export function iconClassFromName(name, fallback = 'icon-file') {
+  if (!String(name ?? '').includes('.')) return fallback;
+  const ext = String(name).split('.').pop().toLowerCase();
+  if (IMAGE_EXTS.has(ext)) return 'icon-image';
+  if (TABLE_EXTS.has(ext)) return 'icon-table';
+  return fallback;
+}

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -301,6 +301,11 @@ export async function loadArea({ area } = { area: document }) {
     const { restorePanels } = await import('../utils/panel.js');
     await restorePanels();
   }
+
+  if (isDoc) {
+    const { initOmegaTracking } = await import('../utils/omega-tracking.js');
+    initOmegaTracking();
+  }
 }
 
 export function getColorScheme() {

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -303,8 +303,10 @@ export async function loadArea({ area } = { area: document }) {
   }
 
   if (isDoc) {
-    const lazy = () => import('../utils/omega-tracking.js')
-      .then(({ initOmegaTracking }) => initOmegaTracking());
+    const lazy = () => Promise.all([
+      import('../utils/user-settings.js').then(({ loadUserSettings }) => loadUserSettings()),
+      import('../utils/omega-tracking.js').then(({ initOmegaTracking }) => initOmegaTracking()),
+    ]);
     if ('requestIdleCallback' in window) {
       requestIdleCallback(lazy);
     } else {

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -303,8 +303,13 @@ export async function loadArea({ area } = { area: document }) {
   }
 
   if (isDoc) {
-    const { initOmegaTracking } = await import('../utils/omega-tracking.js');
-    initOmegaTracking();
+    const lazy = () => import('../utils/omega-tracking.js')
+      .then(({ initOmegaTracking }) => initOmegaTracking());
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(lazy);
+    } else {
+      setTimeout(lazy, 0);
+    }
   }
 }
 

--- a/nx2/scripts/scripts.js
+++ b/nx2/scripts/scripts.js
@@ -11,7 +11,6 @@
  */
 
 import { loadArea, setConfig } from './nx.js';
-import { initOmegaTracking } from '../utils/omega-tracking.js';
 
 const hostnames = ['nx.live'];
 
@@ -55,4 +54,3 @@ export async function loadPage() {
   await loadArea();
 }
 await loadPage();
-initOmegaTracking();

--- a/nx2/scripts/scripts.js
+++ b/nx2/scripts/scripts.js
@@ -11,6 +11,7 @@
  */
 
 import { loadArea, setConfig } from './nx.js';
+import { initOmegaTracking } from '../utils/omega-tracking.js';
 
 const hostnames = ['nx.live'];
 
@@ -54,3 +55,4 @@ export async function loadPage() {
   await loadArea();
 }
 await loadPage();
+initOmegaTracking();

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { env, getMetadata } from '../scripts/nx.js';
+
+/** Adobe Experience Platform Launch (development) — Omega / unified content stage. */
+const ADOBE_LAUNCH_SRC = 'https://exc-unifiedcontent.experience-stage.adobe.net/static/launch/d4d114c60e50/1bdb1b16530b/launch-3e9e0f669557-development.min.js';
+
+const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/;
+
+function trackingEnabled() {
+  if (env !== 'prod') return true;
+  return getMetadata('omega-tracking') === 'on';
+}
+
+function appendExternalScript(src) {
+  if (document.querySelector(`script[src="${src}"]`)) return;
+  const el = document.createElement('script');
+  el.src = src;
+  el.async = true;
+  document.body.append(el);
+}
+
+function loadGoogleTagManager() {
+  const id = (getMetadata('gtm-id') || '').trim();
+  if (!id || !GTM_ID_PATTERN.test(id)) return;
+
+  const gtmSrc = `https://www.googletagmanager.com/gtm.js?id=${encodeURIComponent(id)}`;
+  if (document.querySelector(`script[src="${gtmSrc}"]`)) return;
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ 'gtm.start': Date.now(), event: 'gtm.js' });
+
+  const g = document.createElement('script');
+  g.async = true;
+  g.src = gtmSrc;
+  document.body.append(g);
+
+  const noscript = document.createElement('noscript');
+  const iframe = document.createElement('iframe');
+  iframe.src = `https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(id)}`;
+  iframe.height = '0';
+  iframe.width = '0';
+  iframe.style.display = 'none';
+  iframe.style.visibility = 'hidden';
+  iframe.setAttribute('aria-hidden', 'true');
+  noscript.append(iframe);
+  document.body.append(noscript);
+}
+
+/**
+ * Loads optional GTM (when meta gtm-id is set) and Adobe Launch at the end of
+ * {@link document.body} for Omega tracking validation. Gated off production unless
+ * meta name="omega-tracking" content="on" is present in the document head.
+ */
+export function initOmegaTracking() {
+  if (!trackingEnabled()) return;
+  loadGoogleTagManager();
+  appendExternalScript(ADOBE_LAUNCH_SRC);
+}

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -12,12 +12,15 @@
 
 import { env, getMetadata } from '../scripts/nx.js';
 
-/** Adobe Experience Platform Launch (development) — Omega / unified content stage. */
-const ADOBE_LAUNCH_SRC = 'https://exc-unifiedcontent.experience-stage.adobe.net/static/launch/d4d114c60e50/1bdb1b16530b/launch-3e9e0f669557-development.min.js';
+// Adobe Experience Platform Launch (dev) — Omega / unified content stage
+const LAUNCH_HOST = 'https://exc-unifiedcontent.experience-stage.adobe.net';
+const LAUNCH_PATH = '/static/launch/d4d114c60e50/1bdb1b16530b'
+  + '/launch-3e9e0f669557-development.min.js';
+const ADOBE_LAUNCH_SRC = `${LAUNCH_HOST}${LAUNCH_PATH}`;
 
 const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/;
 
-/** Prod {@code nx} values that enable Omega without meta: {@code ew}, or any {@code ew-omega-…} branch. */
+// nx=ew or nx=ew-omega-* enables Omega on prod without meta
 const OMEGA_NX_PREFIX = 'ew-omega-';
 
 function isOmegaNxBranchInQuery() {

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -17,8 +17,23 @@ const ADOBE_LAUNCH_SRC = 'https://exc-unifiedcontent.experience-stage.adobe.net/
 
 const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/;
 
+/** Prod {@code nx} values that enable Omega without meta: {@code ew}, or any {@code ew-omega-…} branch. */
+const OMEGA_NX_PREFIX = 'ew-omega-';
+
+function isOmegaNxBranchInQuery() {
+  try {
+    const nx = new URLSearchParams(window.location.search).get('nx');
+    if (nx == null) return false;
+    if (nx === 'ew') return true;
+    return nx.startsWith(OMEGA_NX_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
 function trackingEnabled() {
   if (env !== 'prod') return true;
+  if (isOmegaNxBranchInQuery()) return true;
   return getMetadata('omega-tracking') === 'on';
 }
 
@@ -58,9 +73,12 @@ function loadGoogleTagManager() {
 }
 
 /**
- * Loads optional GTM (when meta gtm-id is set) and Adobe Launch at the end of
- * {@link document.body} for Omega tracking validation. Gated off production unless
- * meta name="omega-tracking" content="on" is present in the document head.
+ * Injects GTM (when head meta {@code gtm-id} is a valid {@code GTM-…} id) and Adobe
+ * Launch by appending scripts to the **end of {@link document.body}**, not
+ * {@link document.head}, so Omega can verify behaviour vs a typical head snippet.
+ * On production hosts: enabled when the URL query has {@code nx=ew}, or {@code nx}
+ * starting with {@code ew-omega-} (e.g. {@code nx=ew-omega-launch}), or when meta
+ * {@code omega-tracking} is {@code on}.
  */
 export function initOmegaTracking() {
   if (!trackingEnabled()) return;

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { env, getMetadata } from '../scripts/nx.js';
+import { getMetadata } from '../scripts/nx.js';
 
 // Adobe Experience Platform Launch (dev) — Omega / unified content stage
 const LAUNCH_HOST = 'https://exc-unifiedcontent.experience-stage.adobe.net';
@@ -20,8 +20,15 @@ const ADOBE_LAUNCH_SRC = `${LAUNCH_HOST}${LAUNCH_PATH}`;
 
 const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/;
 
-// nx=ew or nx=ew-omega-* enables Omega on prod without meta
 const OMEGA_NX_PREFIX = 'ew-omega-';
+const DA_AUTHORING_PATHS = ['/canvas', '/browse'];
+
+function isDaAuthoringPage() {
+  const { hostname, pathname } = window.location;
+  const isDaHost = hostname === 'da.live' || hostname === 'localhost';
+  if (!isDaHost) return false;
+  return DA_AUTHORING_PATHS.some((p) => pathname.startsWith(p));
+}
 
 function isOmegaNxBranchInQuery() {
   try {
@@ -35,7 +42,7 @@ function isOmegaNxBranchInQuery() {
 }
 
 function trackingEnabled() {
-  if (env !== 'prod') return true;
+  if (!isDaAuthoringPage()) return false;
   if (isOmegaNxBranchInQuery()) return true;
   return getMetadata('omega-tracking') === 'on';
 }
@@ -79,9 +86,9 @@ function loadGoogleTagManager() {
  * Injects GTM (when head meta {@code gtm-id} is a valid {@code GTM-…} id) and Adobe
  * Launch by appending scripts to the **end of {@link document.body}**, not
  * {@link document.head}, so Omega can verify behaviour vs a typical head snippet.
- * On production hosts: enabled when the URL query has {@code nx=ew}, or {@code nx}
- * starting with {@code ew-omega-} (e.g. {@code nx=ew-omega-launch}), or when meta
- * {@code omega-tracking} is {@code on}.
+ * Only fires on DA authoring pages ({@code da.live/canvas}, {@code da.live/browse},
+ * or {@code localhost} for local dev) when the URL query has {@code nx=ew} or
+ * {@code nx} starting with {@code ew-omega-} (e.g. {@code nx=ew-omega-launch}).
  */
 export function initOmegaTracking() {
   if (!trackingEnabled()) return;

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -10,15 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import { getMetadata } from '../scripts/nx.js';
+import { getConfig } from '../scripts/nx.js';
 
-const LAUNCH_HOST = 'https://exc-unifiedcontent.experience-stage.adobe.net';
-const LAUNCH_PATH = '/static/launch/d4d114c60e50/1bdb1b16530b'
-  + '/launch-3e9e0f669557-development.min.js';
+const { imsClientId } = getConfig();
+
+const LAUNCH_HOST = 'https://assets.adobedtm.com';
+const LAUNCH_PATH = '/d4d114c60e50/02a795757a26/launch-55fd4f558136.min.js';
 const ADOBE_LAUNCH_SRC = `${LAUNCH_HOST}${LAUNCH_PATH}`;
 
-const OMEGA_NX_PREFIX = 'ew-omega-';
-const DA_AUTHORING_PATHS = ['/canvas', '/browse'];
+const DA_AUTHORING_PATHS = ['/canvas', '/edit'];
+
+const OMEGA_SUITE = 'aem';
 
 function isDaAuthoringPage() {
   const { hostname, pathname } = window.location;
@@ -27,21 +29,17 @@ function isDaAuthoringPage() {
   return DA_AUTHORING_PATHS.some((p) => pathname.startsWith(p));
 }
 
-function isOmegaNxBranchInQuery() {
-  try {
-    const nx = new URLSearchParams(window.location.search).get('nx');
-    if (nx == null) return false;
-    if (nx === 'ew') return true;
-    return nx.startsWith(OMEGA_NX_PREFIX);
-  } catch {
-    return false;
-  }
+function trackingEnabled() {
+  return isDaAuthoringPage();
 }
 
-function trackingEnabled() {
-  if (!isDaAuthoringPage()) return false;
-  if (isOmegaNxBranchInQuery()) return true;
-  return getMetadata('omega-tracking') === 'on';
+const CONSENT_PERMISSIONS = ['globalDataCollectionAndUsage', 'adobeUsageDataCollection'];
+
+function hasTrackingConsent(consents) {
+  if (!consents?.permissions) return false;
+  return CONSENT_PERMISSIONS.every(
+    (name) => consents.permissions.find((p) => p.name === name)?.enabled === true,
+  );
 }
 
 function appendLaunchScript() {
@@ -52,13 +50,128 @@ function appendLaunchScript() {
   document.body.append(el);
 }
 
+async function buildDigitalData(ims) {
+  const orgsData = await ims.getOrgs().catch(() => null);
+  const currentOrg = orgsData?.data?.find((org) => org.userId === ims.userId);
+  const language = document.documentElement.lang?.toLowerCase().replace('-', ':') || 'en:us';
+  const { pathname } = window.location;
+  return {
+    user: {
+      id: ims.userId,
+      corpId: currentOrg?.owningOrgId,
+      corpName: currentOrg?.description,
+      internal: ims.email?.endsWith('@adobe.com') ?? false,
+      authSystem: 'ims',
+      accountType: currentOrg?.role,
+      language,
+      auth: 'authenticated',
+      privileges: ['user'],
+    },
+    unifiedShell: {
+      config: {
+        user: {
+          accountType: ims?.account_type,
+        },
+        metricsConfig: {
+          user: { accountType: ims?.account_type },
+        },
+        appId: imsClientId,
+        gainsight: {},
+        imsinfo: {},
+      },
+    },
+    page: {
+      solution: { name: pathname.includes('canvas') ? 'Experience Workspace' : 'Darkalley' },
+    },
+  };
+}
+
+async function buildAdobeMetrics(ims) {
+  return {
+    metricsState: {
+      environment: 'prod',
+      user: {
+        auth_id: ims.userId,
+        account_type: 'end user',
+      },
+    },
+  };
+}
+
+function buildShellGainsight(ims, userSettings) {
+  const permissionsMap = Object.fromEntries(
+    (userSettings?.consents?.permissions ?? []).map(({ name, enabled }) => [name, enabled]),
+  );
+  return {
+    appId: imsClientId,
+    enabled: permissionsMap.gainsightUsageDataCollection ?? false,
+    environment: 'prod',
+    fulfillableItems: [],
+    omegaSuiteId: OMEGA_SUITE,
+    user: {
+      authId: ims.userId,
+      internal: ims.email?.endsWith('@adobe.com') ?? false,
+      permissions: permissionsMap,
+      roles: null,
+      theme: userSettings?.settings?.theme || 'light',
+      triggers: [],
+    },
+  };
+}
+
 /**
  * Appends the Adobe Launch (Omega) stage bootstrap to the end of
  * {@link document.body}. Only fires on DA authoring pages
  * ({@code da.live/canvas}, {@code da.live/browse}, or localhost)
  * when {@code ?nx=ew} or {@code ?nx=ew-omega-*} is in the URL.
  */
-export function initOmegaTracking() {
+export async function initOmegaTracking() {
   if (!trackingEnabled()) return;
-  appendLaunchScript();
+
+  const { loadIms } = await import('./ims.js');
+  const { loadUserSettings } = await import('./user-settings.js');
+  const [ims, userSettings] = await Promise.all([
+    loadIms().catch(() => null),
+    loadUserSettings().catch(() => null),
+  ]);
+
+  if (!hasTrackingConsent(userSettings?.consents)) return;
+
+  if (ims && !ims.anonymous) {
+    window.digitalData = await buildDigitalData(ims);
+    window.adobeMetrics = await buildAdobeMetrics(ims);
+    window.shellGainsight = await buildShellGainsight(ims);
+    appendLaunchScript();
+
+    // eslint-disable-next-line no-underscore-dangle
+    setTimeout(() => { window._satellite?.setVar('consentPrefVal', true); }, 500);
+  }
+}
+
+/**
+ * Fires a PDH interaction event via Adobe Launch.
+ * @see https://wiki.corp.adobe.com/spaces/OMEGA/pages/3189390074/
+ * @param {string} feature - Name of the feature where the interaction takes place
+ * @param {{ name: string, type: string }} widget - Widget the element belongs to.
+ *   `name`: friendly name for the element group e.g. "create offer".
+ *   `type`: widget type, mirrors CoralUI components e.g. "panel", "accordion".
+ * @param {string} element - Name of the UI element interacted with e.g. "create button".
+ * @param {string} type - Type of the element e.g. "list item", "calendar date".
+ * @param {string} action - DOM-style action without the "on" prefix e.g. "click", "submit", "drop".
+ */
+export function trackEvent(feature, widget, element, type, action) {
+  if (!window.digitalData) return;
+
+  const { pathname } = window.location;
+  const featurePreview = pathname.includes('canvas') ? 'experience-workspace:' : 'darkalley:';
+  const featureName = !feature.startsWith(featurePreview) ? featurePreview + feature : feature;
+
+  // eslint-disable-next-line no-underscore-dangle
+  window._satellite.track('event', {
+    feature: featureName,
+    element,
+    type,
+    action,
+    widget,
+  });
 }

--- a/nx2/utils/omega-tracking.js
+++ b/nx2/utils/omega-tracking.js
@@ -12,13 +12,10 @@
 
 import { getMetadata } from '../scripts/nx.js';
 
-// Adobe Experience Platform Launch (dev) — Omega / unified content stage
 const LAUNCH_HOST = 'https://exc-unifiedcontent.experience-stage.adobe.net';
 const LAUNCH_PATH = '/static/launch/d4d114c60e50/1bdb1b16530b'
   + '/launch-3e9e0f669557-development.min.js';
 const ADOBE_LAUNCH_SRC = `${LAUNCH_HOST}${LAUNCH_PATH}`;
-
-const GTM_ID_PATTERN = /^GTM-[A-Z0-9]+$/;
 
 const OMEGA_NX_PREFIX = 'ew-omega-';
 const DA_AUTHORING_PATHS = ['/canvas', '/browse'];
@@ -47,51 +44,21 @@ function trackingEnabled() {
   return getMetadata('omega-tracking') === 'on';
 }
 
-function appendExternalScript(src) {
-  if (document.querySelector(`script[src="${src}"]`)) return;
+function appendLaunchScript() {
+  if (document.querySelector(`script[src="${ADOBE_LAUNCH_SRC}"]`)) return;
   const el = document.createElement('script');
-  el.src = src;
+  el.src = ADOBE_LAUNCH_SRC;
   el.async = true;
   document.body.append(el);
 }
 
-function loadGoogleTagManager() {
-  const id = (getMetadata('gtm-id') || '').trim();
-  if (!id || !GTM_ID_PATTERN.test(id)) return;
-
-  const gtmSrc = `https://www.googletagmanager.com/gtm.js?id=${encodeURIComponent(id)}`;
-  if (document.querySelector(`script[src="${gtmSrc}"]`)) return;
-
-  window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push({ 'gtm.start': Date.now(), event: 'gtm.js' });
-
-  const g = document.createElement('script');
-  g.async = true;
-  g.src = gtmSrc;
-  document.body.append(g);
-
-  const noscript = document.createElement('noscript');
-  const iframe = document.createElement('iframe');
-  iframe.src = `https://www.googletagmanager.com/ns.html?id=${encodeURIComponent(id)}`;
-  iframe.height = '0';
-  iframe.width = '0';
-  iframe.style.display = 'none';
-  iframe.style.visibility = 'hidden';
-  iframe.setAttribute('aria-hidden', 'true');
-  noscript.append(iframe);
-  document.body.append(noscript);
-}
-
 /**
- * Injects GTM (when head meta {@code gtm-id} is a valid {@code GTM-…} id) and Adobe
- * Launch by appending scripts to the **end of {@link document.body}**, not
- * {@link document.head}, so Omega can verify behaviour vs a typical head snippet.
- * Only fires on DA authoring pages ({@code da.live/canvas}, {@code da.live/browse},
- * or {@code localhost} for local dev) when the URL query has {@code nx=ew} or
- * {@code nx} starting with {@code ew-omega-} (e.g. {@code nx=ew-omega-launch}).
+ * Appends the Adobe Launch (Omega) stage bootstrap to the end of
+ * {@link document.body}. Only fires on DA authoring pages
+ * ({@code da.live/canvas}, {@code da.live/browse}, or localhost)
+ * when {@code ?nx=ew} or {@code ?nx=ew-omega-*} is in the URL.
  */
 export function initOmegaTracking() {
   if (!trackingEnabled()) return;
-  loadGoogleTagManager();
-  appendExternalScript(ADOBE_LAUNCH_SRC);
+  appendLaunchScript();
 }

--- a/nx2/utils/user-settings.js
+++ b/nx2/utils/user-settings.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { getConfig } from '../scripts/nx.js';
+
+const { env, imsClientId } = getConfig();
+
+const EXC_ORIGINS = {
+  dev: 'https://exc-unifiedcontent.experience-stage.adobe.net',
+  stage: 'https://exc-unifiedcontent.experience-stage.adobe.net',
+  prod: 'https://exc-unifiedcontent.experience.adobe.net',
+};
+
+const API_KEY = 'exc_app';
+
+const QUERY = `
+  query shellInitDataQuery {
+    getSettings(appId: "userPreferences", groupId: "exc-preferences", level: "user", settings: {
+      defaultOrg: "LAST_LOGGED_IN",
+      showProductTours: true,
+      trackProductTours: true
+    }) {
+      settings
+    }
+    getConsentPermissions(globalConsentPath: true, useMpsCache: true) {
+      last_update_dts
+      permissions {
+        name
+        enabled
+        last_update_dts
+      }
+    }
+  }
+`;
+
+async function fetchSettings(token) {
+  const url = `${EXC_ORIGINS[env]}/api/gql/app/shell/graphql?appId=${imsClientId}`;
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        'x-api-key': API_KEY,
+      },
+      body: JSON.stringify({
+        operationName: 'shellInitDataQuery',
+        query: QUERY,
+        variables: {},
+      }),
+    });
+    if (!resp.ok) return null;
+    const { data } = await resp.json();
+    return {
+      settings: data?.getSettings?.settings ?? null,
+      consents: data?.getConsentPermissions ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Loads user preferences and consent data from the Experience Cloud shell API.
+ * Requires an authenticated IMS session — returns null for anonymous users or
+ * when the request fails. Memoized: the network call is made at most once.
+ * @returns {Promise<object|null>}
+ */
+export const loadUserSettings = (() => {
+  let request;
+
+  const load = async () => {
+    const { loadIms } = await import('./ims.js');
+    const ims = await loadIms().catch(() => null);
+    if (!ims || ims.anonymous) return null;
+    return fetchSettings(ims.accessToken.token);
+  };
+
+  return () => {
+    request ??= load();
+    return request;
+  };
+})();


### PR DESCRIPTION
## Summary

- After the nx2 shell loads (`scripts.js`), **append** the **Adobe Launch** stage bootstrap and (when configured) **Google Tag Manager** to the **end of `document.body`**, not to `<head>`, so Omega can test whether tracking still loads correctly with a **deferred / bottom-of-page** injection.
- Intended for Omega team validation on EW / branch previews (`*.da.live`, localhost) authoring pages.


## Why

- Omega requires Launch for analytics into Omega.
- We need to validate the **GTM script at the bottom of the page** (vs head) and to confirm things still load.

## What Changed

- New `nx2/utils/omega-tracking.js`: `initOmegaTracking()` gates on `env` (from `nx.js`): runs on non-`prod` hosts; on `prod` only if `<meta name="omega-tracking" content="on">` is present.
- **Placement:** Launch and GTM `script` nodes use `document.body.append(...)` after `loadPage()` — nothing from this module is inserted into `document.head`.
- **GTM when:** `<meta name="gtm-id" content="GTM-…">` must be set (strict `GTM-[A-Z0-9]+`); there is no hardcoded container id in repo. Same file builds `gtm.js` URL and appends the hidden `noscript` iframe to the body end.
- Launch URL is the fixed stage bootstrap: `exc-unifiedcontent.experience-stage.adobe.net/.../launch-3e9e0f669557-development.min.js`.
- `nx2/scripts/scripts.js` calls `initOmegaTracking()` immediately after `await loadPage()`.


## Test Plan

- [ ] **Placement:** In DevTools Elements, confirm new `script` tags for Launch (and GTM if meta set) are **last children of `body`**, not under `head`.
- [ ] Branch preview is branch `ew` or `ew-omega-*`
- [ ] Set `gtm-id` meta to a test container; confirm `gtm.js` and `dataLayer`.

https://ew-omega-launch--da-nx--adobe.aem.page/
