### PR TITLE
feat(ew): provider support

### DIFF
--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -291,6 +291,15 @@ class NxChat extends LitElement {
     if (id === MENU_OPTIONS.PROMPT) this._openPrompts();
     if (id === MENU_OPTIONS.COMMAND) this._slashMenu.insertSlash(this.shadowRoot.querySelector('.chat-input'));
     if (id === MENU_OPTIONS.FILES) this._openFilePicker();
+    if (id === 'prompts' || id === 'skills') {
+      const { org, site } = this._context ?? {};
+      if (!org || !site) return;
+      const url = new URL(window.location.href);
+      url.pathname = '/app';
+      url.search = `?tab=${id}`;
+      url.hash = `#/${org}/${site}/tools/skills`;
+      window.open(url.href, '_blank', 'noopener,noreferrer');
+    }
   }
 
   _onDragEnter(e) {

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -85,15 +85,28 @@ export const loc = ([first], ...values) => {
 };
 
 export async function loadBlock(block) {
-  const { nxBase, codeBase, log } = getConfig();
+  const { nxBase, codeBase, providers, log } = getConfig();
   const { classList } = block;
   let name = classList[0];
+
+  let path;
   const isNx = name.startsWith('nx-');
-  name = isNx ? name.replace('nx-', '') : name;
+  if (isNx) {
+    name = name.replace('nx-', '');
+    path = `${nxBase}/blocks`;
+  } else {
+    const prefix = name.split('-')[0];
+    const provider = providers[prefix];
+    if (provider) {
+      name = name.slice(prefix.length + 1);
+      path = `${provider}/apps`;
+    } else {
+      path = `${codeBase}/blocks`;
+    }
+  }
+
   block.dataset.blockName = name;
-  const path = isNx ? `${nxBase}/blocks` : `${codeBase}/blocks`;
   const blockPath = `${path}/${name}/${name}`;
-  block.dataset.blockName = name;
   try {
     await (await import(`${blockPath}.js`)).default(block);
   } catch (ex) {

--- a/nx2/scripts/scripts.js
+++ b/nx2/scripts/scripts.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { loadArea, setConfig } from './nx.js';
+import { loadArea, setConfig, env } from './nx.js';
 
 const hostnames = ['nx.live'];
 
@@ -40,6 +40,12 @@ const decorateArea = ({ area = document }) => {
   eagerLoad(area, 'img');
 };
 
+const EW_ORIGINS = {
+  dev: 'http://localhost:3001',
+  stage: 'https://main--ew-extensions--exp-workspace.aem.page',
+  prod: 'https://main--ew-extensions--exp-workspace.aem.live',
+};
+
 const conf = {
   hostnames,
   locales,
@@ -47,6 +53,9 @@ const conf = {
   imsScope,
   linkBlocks,
   decorateArea,
+  providers: {
+    ew: EW_ORIGINS[env],
+  },
 };
 
 export async function loadPage() {

--- a/nx2/test/unit/nx/scripts/nx.test.js
+++ b/nx2/test/unit/nx/scripts/nx.test.js
@@ -130,7 +130,12 @@ describe('setConfig / getConfig', () => {
 // ─── loadBlock ───────────────────────────────────────────────────────────────
 
 describe('loadBlock', () => {
-  before(async () => { await setConfig(BASE_CONFIG); });
+  before(async () => {
+    await setConfig({
+      ...BASE_CONFIG,
+      providers: { ew: 'https://ext.example.com' },
+    });
+  });
 
   it('sets blockName on the dataset', async () => {
     const block = document.createElement('div');
@@ -151,6 +156,20 @@ describe('loadBlock', () => {
     block.className = 'first-name second-name';
     await loadBlock(block);
     expect(block.dataset.blockName).to.equal('first-name');
+  });
+
+  it('strips provider prefix and sets blockName to the remainder', async () => {
+    const block = document.createElement('div');
+    block.classList.add('ew-skills');
+    await loadBlock(block);
+    expect(block.dataset.blockName).to.equal('skills');
+  });
+
+  it('leaves blockName intact when no provider matches', async () => {
+    const block = document.createElement('div');
+    block.classList.add('unknown-thing');
+    await loadBlock(block);
+    expect(block.dataset.blockName).to.equal('unknown-thing');
   });
 });
 


### PR DESCRIPTION
## Summary
- Add provider resolution to `loadBlock` so blocks prefixed with a registered provider key (e.g. `ew-skills`) are loaded from an external origin
- Register `ew` provider in `scripts.js` with env-aware origins (localhost / aem.page / aem.live)
- Wire "Manage Skills" and "Manage Prompts" in the chat + menu to open the skills app with `?tab=` deep-link

## Why
- The skills editor lives in the `ew-extensions` repo, deployed as its own AEM site
- da-nx needs a way to load blocks from external providers without bundling them
- The `providers` config key already existed in `setConfig` but was never consumed by `loadBlock`

## What Changed
- **`nx2/scripts/nx.js`** — `loadBlock` now checks `providers[prefix]` between the `nx-` check and the `codeBase` fallback. Resolution: `ew-skills` → `${providers.ew}/apps/skills/skills.js`
- **`nx2/scripts/scripts.js`** — imports `env`, adds `EW_ORIGINS` map and `providers: { ew }` to the config
- **`nx2/blocks/chat/chat.js`** — `_handleMenuSelect` opens `/app?tab={skills|prompts}#/{org}/{site}/tools/skills` for the Manage menu items
- **`nx2/test/unit/nx/scripts/nx.test.js`** — two new tests: provider prefix stripping + no-match passthrough

## Test Plan
- [ ] `npm test` — all existing + new tests pass (703+ green)
- [ ] Local: start da-nx on :6456, ew-extensions on :3001, visit browse with `nx=local` — verify `getConfig().providers.ew` is `http://localhost:3001`
- [ ] Create a div with class `ew-skills`, call `loadBlock` — verify import resolves to `:3001/apps/skills/skills.js`
- [ ] Click "Manage Skills" in chat + menu — opens skills app on skills tab
- [ ] Click "Manage Prompts" — opens skills app on prompts tab

## Risks / Follow-ups
- The `/app` route must exist in da-live for the deep-links to land (not part of this PR)
- Provider blocks that don't export a default `decorate(block)` function will silently fail (logged by `log()`)
