### PR TITLE
persist query param after redirect to preview.da.live domain

### DIFF
--- a/nx/public/plugins/quick-edit/quick-edit.js
+++ b/nx/public/plugins/quick-edit/quick-edit.js
@@ -27,7 +27,10 @@ function checkDomain() {
   const currentUrl = new URL(window.location.href);
   if (currentUrl.origin.endsWith('.aem.page')) {
     const newOrigin = currentUrl.origin.replace('.aem.page', '.preview.da.live');
-    const newHref = `${newOrigin}${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+    const params = new URLSearchParams(currentUrl.search);
+    if (!params.has('quick-edit')) params.set('quick-edit', 'on');
+    const search = params.toString() ? `?${params.toString()}` : '';
+    const newHref = `${newOrigin}${currentUrl.pathname}${search}${currentUrl.hash}`;
     window.location.replace(newHref);
   }
 }


### PR DESCRIPTION
https://qe-proxy-param--da-nx--adobe.aem.page
