### PR TITLE
feat(chat): add sessionId to chat sessions

### DIFF
--- a/docs/chat-ui-component.md
+++ b/docs/chat-ui-component.md
@@ -30,14 +30,14 @@ The component manages its own controller internally. No external wiring needed.
 { role: 'tool', ... }  // filtered from display automatically
 ```
 
-**Request body:** The controller POSTs `{ messages, pageContext, imsToken, room }` to the agent. Selection context is embedded on individual user messages (see [Selection context](#selection-context)) rather than as a top-level request field.
+**Request body:** The controller POSTs `{ messages, pageContext, imsToken, room, sessionId }` to the agent. `sessionId` is a UUID scoped to the current conversation session — it resets when the user clears the chat. Selection context is embedded on individual user messages (see [Selection context](#selection-context)) rather than as a top-level request field.
 
 ## Methods
 
 | Method | Description |
 |---|---|
 | `chat.addAttachment({ id, label, ...rest })` | Adds a pill above the textarea. `id` is required — duplicate ids are silently ignored. `label` is the display text. Any additional fields are forwarded to the agent as context alongside the next message. |
-| `chat.clear()` | Clears conversation history and resets IndexedDB for the current room. |
+| `chat.clear()` | Clears conversation history and writes a fresh `sessionId` for the current room. The new session ID takes effect immediately for subsequent agent requests. |
 
 **Current scope:** `addAttachment` supports simple content references — e.g. a block or element from the document editor. Binary file attachments (images, uploads) are not yet supported and will extend this same API when introduced.
 
@@ -171,19 +171,13 @@ Conversation history is persisted in IndexedDB, keyed by `org--site--userId`. Th
 
 - History is **shared across all pages within a site** — navigating between paths does not start a new conversation.
 - History is **user-specific** — different IMS users on the same site have separate histories.
-- `clear()` deletes the stored history for the current room.
+- `clear()` resets the stored history for the current room and generates a new `sessionId` — the record is updated rather than deleted so the new session ID survives a reload.
 
-### Future: sessions
+### Sessions
 
-Currently there is one conversation per `org--site--userId` — all or nothing. A session model would let users maintain multiple named conversations and switch between them.
+Each conversation has a `sessionId` (UUID) stored in IndexedDB alongside its messages. The ID is shared across tabs on the same room and survives page reloads. A new ID is generated on first open (no stored record) or when the user calls `clear()`. The agent receives `sessionId` on POST so it can scope server-side state to the current session and combine traces to a session for telemetry.
 
-When introduced, the room key would extend to `org--site--userId--sessionId`. The `sessionId` structure and generation strategy are to be defined. The component derives the full room key internally. Persistence and the agent's `room` parameter both use the full key, so sessions are isolated end-to-end. The host never interacts with IndexedDB directly.
-
-If no `session` is set, the component resumes the last active session. A `lastActiveSession` metadata entry in IndexedDB (keyed by `org--site--userId`, storing the active `sessionId`) tracks which session was most recently used and is updated on every switch. Session switching UI (picker, create/rename/delete) lives inside the chat component — the host has no role in session management.
-
-Each session would have a human-readable title so users can make informed switching decisions. The agent would emit a `session-title` stream event after the first exchange — a short generated summary of the conversation intent (e.g. "Update header copy"). The client stores it in session metadata and displays it in the picker. Users can rename sessions; the agent-provided title is only the initial suggestion.
-
-> **Agent team ask:** `session-title` is not yet supported by da-agent. Needs to be raised with the agent team — emit a `session-title` event (with a `title` field) after the first `text-end` in a new session.
+**Not yet implemented:** multiple named sessions per room, session switching UI, and agent-emitted `session-title` events. When introduced, the session picker and create/rename/delete UI would live inside the chat component — the host has no role in session management.
 
 ## Events out
 

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -37,7 +37,7 @@ export default class ChatController {
     this._messages = [];
     const room = await this._getRoom();
     const { messages: cached, sessionId } = await loadMessages(room);
-    this._sessionId = sessionId ?? crypto.randomUUID();
+    this._sessionId = sessionId ?? this._sessionId;
     if (!cached.length) return;
     // Strip orphaned tool-calls (assistant array-content without a tool-approval-request).
     // These are from sessions before the current fix — they have no matching tool-result

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -1,7 +1,7 @@
 import { loadIms } from '../../utils/ims.js';
 import { AGENT_EVENT, ROLE, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
-import { loadMessages, saveMessages, clearMessages } from './persistence.js';
+import { loadMessages, saveMessages, resetSession } from './persistence.js';
 
 // ?ref=local routes to a local da-agent dev server (port 5173).
 const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
@@ -35,7 +35,8 @@ export default class ChatController {
   async loadInitialMessages() {
     this._messages = [];
     const room = await this._getRoom();
-    const cached = await loadMessages(room);
+    const { messages: cached, sessionId } = await loadMessages(room);
+    this._sessionId = sessionId ?? crypto.randomUUID();
     if (!cached.length) return;
     // Strip orphaned tool-calls (assistant array-content without a tool-approval-request).
     // These are from sessions before the current fix — they have no matching tool-result
@@ -101,9 +102,10 @@ export default class ChatController {
     this._streamingText = undefined;
     this._toolCards = new Map();
     this._autoApprovedTools = new Set();
+    this._sessionId = crypto.randomUUID();
     this._update();
     const room = await this._getRoom();
-    clearMessages(room);
+    resetSession(room, this._sessionId);
   }
 
   destroy() {
@@ -222,6 +224,7 @@ export default class ChatController {
         pageContext,
         imsToken: accessToken?.token ?? null,
         room,
+        sessionId: this._sessionId,
         ...(this._requestedSkills?.length ? { requestedSkills: this._requestedSkills } : {}),
       }),
       signal: this._abortController.signal,
@@ -237,7 +240,7 @@ export default class ChatController {
         this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: text }];
         this._streamingText = '';
         this._update();
-        saveMessages(room, this._messages);
+        saveMessages(room, this._messages, this._sessionId);
       },
       onTool: this._onToolEvent,
     });

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -12,6 +12,7 @@ export default class ChatController {
   constructor({ onUpdate, onToolDone }) {
     this._onUpdate = onUpdate;
     this._onToolDone = onToolDone;
+    this._sessionId = crypto.randomUUID();
   }
 
   setContext(context) {

--- a/nx2/blocks/chat/persistence.js
+++ b/nx2/blocks/chat/persistence.js
@@ -1,6 +1,7 @@
 const DB_NAME = 'da-chat';
 const DB_VERSION = 1;
 const STORE_NAME = 'conversations';
+const EMPTY_STATE = { messages: [], sessionId: null };
 
 let dbPromise = null;
 
@@ -58,7 +59,7 @@ async function write(fn) {
 
 export async function loadMessages(room) {
   const db = await openDb();
-  if (!db) return { messages: [], sessionId: null };
+  if (!db) return EMPTY_STATE;
 
   return new Promise((resolve) => {
     try {
@@ -72,9 +73,9 @@ export async function loadMessages(room) {
           sessionId: result?.sessionId ?? null,
         });
       };
-      req.onerror = () => resolve({ messages: [], sessionId: null });
+      req.onerror = () => resolve(EMPTY_STATE);
     } catch {
-      resolve({ messages: [], sessionId: null });
+      resolve(EMPTY_STATE);
     }
   });
 }
@@ -83,10 +84,12 @@ export function saveMessages(room, messages, sessionId) {
   return write((store) => store.put({ room, messages, sessionId, updatedAt: Date.now() }));
 }
 
+// Deletes the record entirely — use resetSession instead when starting a new session.
 export function clearMessages(room) {
   return write((store) => store.delete(room));
 }
 
+// Clears messages but writes the new sessionId so a reload continues the same session boundary.
 export function resetSession(room, sessionId) {
   return write((store) => store.put({ room, messages: [], sessionId, updatedAt: Date.now() }));
 }

--- a/nx2/blocks/chat/persistence.js
+++ b/nx2/blocks/chat/persistence.js
@@ -84,11 +84,6 @@ export function saveMessages(room, messages, sessionId) {
   return write((store) => store.put({ room, messages, sessionId, updatedAt: Date.now() }));
 }
 
-// Deletes the record entirely — use resetSession instead when starting a new session.
-export function clearMessages(room) {
-  return write((store) => store.delete(room));
-}
-
 // Clears messages but writes the new sessionId so a reload continues the same session boundary.
 export function resetSession(room, sessionId) {
   return write((store) => store.put({ room, messages: [], sessionId, updatedAt: Date.now() }));

--- a/nx2/blocks/chat/persistence.js
+++ b/nx2/blocks/chat/persistence.js
@@ -58,7 +58,7 @@ async function write(fn) {
 
 export async function loadMessages(room) {
   const db = await openDb();
-  if (!db) return [];
+  if (!db) return { messages: [], sessionId: null };
 
   return new Promise((resolve) => {
     try {
@@ -67,19 +67,26 @@ export async function loadMessages(room) {
 
       req.onsuccess = (e) => {
         const { result } = e.target;
-        resolve(Array.isArray(result?.messages) ? result.messages : []);
+        resolve({
+          messages: Array.isArray(result?.messages) ? result.messages : [],
+          sessionId: result?.sessionId ?? null,
+        });
       };
-      req.onerror = () => resolve([]);
+      req.onerror = () => resolve({ messages: [], sessionId: null });
     } catch {
-      resolve([]);
+      resolve({ messages: [], sessionId: null });
     }
   });
 }
 
-export function saveMessages(room, messages) {
-  return write((store) => store.put({ room, messages, updatedAt: Date.now() }));
+export function saveMessages(room, messages, sessionId) {
+  return write((store) => store.put({ room, messages, sessionId, updatedAt: Date.now() }));
 }
 
 export function clearMessages(room) {
   return write((store) => store.delete(room));
+}
+
+export function resetSession(room, sessionId) {
+  return write((store) => store.put({ room, messages: [], sessionId, updatedAt: Date.now() }));
 }

--- a/test/nx2/blocks/chat/persistence.test.js
+++ b/test/nx2/blocks/chat/persistence.test.js
@@ -3,7 +3,6 @@ import {
   loadMessages,
   saveMessages,
   resetSession,
-  clearMessages,
 } from '../../../../nx2/blocks/chat/persistence.js';
 
 let counter = 0;
@@ -99,18 +98,6 @@ describe('persistence', () => {
       const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal([]);
       expect(result.sessionId).to.equal(id);
-    });
-  });
-
-  describe('clearMessages', () => {
-    it('removes the record entirely so loadMessages returns defaults', async () => {
-      const testRoom = room();
-      await saveMessages(testRoom, [{ role: 'user', content: 'x' }], crypto.randomUUID());
-      await clearMessages(testRoom);
-
-      const result = await loadMessages(testRoom);
-      expect(result.messages).to.deep.equal([]);
-      expect(result.sessionId).to.be.null;
     });
   });
 });

--- a/test/nx2/blocks/chat/persistence.test.js
+++ b/test/nx2/blocks/chat/persistence.test.js
@@ -21,31 +21,32 @@ describe('persistence', () => {
     });
 
     it('returns saved messages and sessionId', async () => {
-      const r = room();
+      const testRoom = room();
       const msgs = [{ role: 'user', content: 'hello' }];
       const id = crypto.randomUUID();
-      await saveMessages(r, msgs, id);
+      await saveMessages(testRoom, msgs, id);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal(msgs);
       expect(result.sessionId).to.equal(id);
     });
 
     it('returns null sessionId for old-format records without sessionId field', async () => {
-      const r = room();
+      const testRoom = room();
       const msgs = [{ role: 'user', content: 'legacy' }];
 
-      await new Promise((resolve) => {
+      await new Promise((resolve, reject) => {
         const req = indexedDB.open('da-chat', 1);
+        req.onerror = () => reject(req.error);
         req.onsuccess = (e) => {
           const db = e.target.result;
           const tx = db.transaction('conversations', 'readwrite');
-          tx.objectStore('conversations').put({ room: r, messages: msgs, updatedAt: Date.now() });
+          tx.objectStore('conversations').put({ room: testRoom, messages: msgs, updatedAt: Date.now() });
           tx.oncomplete = resolve;
         };
       });
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.have.lengthOf(1); // guard: write must have landed
       expect(result.messages).to.deep.equal(msgs);
       expect(result.sessionId).to.be.null;
@@ -54,22 +55,22 @@ describe('persistence', () => {
 
   describe('saveMessages', () => {
     it('stores messages and sessionId, retrievable via loadMessages', async () => {
-      const r = room();
+      const testRoom = room();
       const id = crypto.randomUUID();
-      await saveMessages(r, [{ role: 'user', content: 'first' }], id);
+      await saveMessages(testRoom, [{ role: 'user', content: 'first' }], id);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal([{ role: 'user', content: 'first' }]);
       expect(result.sessionId).to.equal(id);
     });
 
     it('overwrites previous messages and preserves sessionId', async () => {
-      const r = room();
+      const testRoom = room();
       const id = crypto.randomUUID();
-      await saveMessages(r, [{ role: 'user', content: 'first' }], id);
-      await saveMessages(r, [{ role: 'user', content: 'second' }], id);
+      await saveMessages(testRoom, [{ role: 'user', content: 'first' }], id);
+      await saveMessages(testRoom, [{ role: 'user', content: 'second' }], id);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.have.lengthOf(1);
       expect(result.messages[0].content).to.equal('second');
       expect(result.sessionId).to.equal(id);
@@ -78,24 +79,24 @@ describe('persistence', () => {
 
   describe('resetSession', () => {
     it('clears messages and stores the new sessionId', async () => {
-      const r = room();
+      const testRoom = room();
       const oldId = crypto.randomUUID();
-      await saveMessages(r, [{ role: 'user', content: 'hi' }], oldId);
+      await saveMessages(testRoom, [{ role: 'user', content: 'hi' }], oldId);
 
       const newId = crypto.randomUUID();
-      await resetSession(r, newId);
+      await resetSession(testRoom, newId);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal([]);
       expect(result.sessionId).to.equal(newId);
     });
 
     it('creates a record for a room with no prior messages', async () => {
-      const r = room();
+      const testRoom = room();
       const id = crypto.randomUUID();
-      await resetSession(r, id);
+      await resetSession(testRoom, id);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal([]);
       expect(result.sessionId).to.equal(id);
     });
@@ -103,11 +104,11 @@ describe('persistence', () => {
 
   describe('clearMessages', () => {
     it('removes the record entirely so loadMessages returns defaults', async () => {
-      const r = room();
-      await saveMessages(r, [{ role: 'user', content: 'x' }], crypto.randomUUID());
-      await clearMessages(r);
+      const testRoom = room();
+      await saveMessages(testRoom, [{ role: 'user', content: 'x' }], crypto.randomUUID());
+      await clearMessages(testRoom);
 
-      const result = await loadMessages(r);
+      const result = await loadMessages(testRoom);
       expect(result.messages).to.deep.equal([]);
       expect(result.sessionId).to.be.null;
     });

--- a/test/nx2/blocks/chat/persistence.test.js
+++ b/test/nx2/blocks/chat/persistence.test.js
@@ -46,6 +46,7 @@ describe('persistence', () => {
       });
 
       const result = await loadMessages(r);
+      expect(result.messages).to.have.lengthOf(1); // guard: write must have landed
       expect(result.messages).to.deep.equal(msgs);
       expect(result.sessionId).to.be.null;
     });

--- a/test/nx2/blocks/chat/persistence.test.js
+++ b/test/nx2/blocks/chat/persistence.test.js
@@ -1,0 +1,114 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  loadMessages,
+  saveMessages,
+  resetSession,
+  clearMessages,
+} from '../../../../nx2/blocks/chat/persistence.js';
+
+let counter = 0;
+const room = () => {
+  counter += 1;
+  return `test-room-${Date.now()}-${counter}`;
+};
+
+describe('persistence', () => {
+  describe('loadMessages', () => {
+    it('returns empty messages and null sessionId for unknown room', async () => {
+      const result = await loadMessages(room());
+      expect(result.messages).to.deep.equal([]);
+      expect(result.sessionId).to.be.null;
+    });
+
+    it('returns saved messages and sessionId', async () => {
+      const r = room();
+      const msgs = [{ role: 'user', content: 'hello' }];
+      const id = crypto.randomUUID();
+      await saveMessages(r, msgs, id);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal(msgs);
+      expect(result.sessionId).to.equal(id);
+    });
+
+    it('returns null sessionId for old-format records without sessionId field', async () => {
+      const r = room();
+      const msgs = [{ role: 'user', content: 'legacy' }];
+
+      await new Promise((resolve) => {
+        const req = indexedDB.open('da-chat', 1);
+        req.onsuccess = (e) => {
+          const db = e.target.result;
+          const tx = db.transaction('conversations', 'readwrite');
+          tx.objectStore('conversations').put({ room: r, messages: msgs, updatedAt: Date.now() });
+          tx.oncomplete = resolve;
+        };
+      });
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal(msgs);
+      expect(result.sessionId).to.be.null;
+    });
+  });
+
+  describe('saveMessages', () => {
+    it('stores messages and sessionId, retrievable via loadMessages', async () => {
+      const r = room();
+      const id = crypto.randomUUID();
+      await saveMessages(r, [{ role: 'user', content: 'first' }], id);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal([{ role: 'user', content: 'first' }]);
+      expect(result.sessionId).to.equal(id);
+    });
+
+    it('overwrites previous messages and preserves sessionId', async () => {
+      const r = room();
+      const id = crypto.randomUUID();
+      await saveMessages(r, [{ role: 'user', content: 'first' }], id);
+      await saveMessages(r, [{ role: 'user', content: 'second' }], id);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.have.lengthOf(1);
+      expect(result.messages[0].content).to.equal('second');
+      expect(result.sessionId).to.equal(id);
+    });
+  });
+
+  describe('resetSession', () => {
+    it('clears messages and stores the new sessionId', async () => {
+      const r = room();
+      const oldId = crypto.randomUUID();
+      await saveMessages(r, [{ role: 'user', content: 'hi' }], oldId);
+
+      const newId = crypto.randomUUID();
+      await resetSession(r, newId);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal([]);
+      expect(result.sessionId).to.equal(newId);
+    });
+
+    it('creates a record for a room with no prior messages', async () => {
+      const r = room();
+      const id = crypto.randomUUID();
+      await resetSession(r, id);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal([]);
+      expect(result.sessionId).to.equal(id);
+    });
+  });
+
+  describe('clearMessages', () => {
+    it('removes the record entirely so loadMessages returns defaults', async () => {
+      const r = room();
+      await saveMessages(r, [{ role: 'user', content: 'x' }], crypto.randomUUID());
+      await clearMessages(r);
+
+      const result = await loadMessages(r);
+      expect(result.messages).to.deep.equal([]);
+      expect(result.sessionId).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `sessionId` (UUID) to every chat conversation, stored in IndexedDB
  alongside messages so it survives page reloads and is shared across tabs
  on the same room
- New session ID is generated on first open (no existing record) and
  regenerated when the user clears the chat; sent to the agent in every
  POST body so it can scope server-side state per session
- `persistence.js` updated: `loadMessages` now returns `{ messages, sessionId }`,
  `saveMessages` accepts `sessionId`, new `resetSession` writes empty messages
  + new ID atomically (replaces `clearMessages` in the reset flow)

Sample Chat message:

```
{
  "messages": [
    {
      "role": "user",
      "content": "Please summarize the content of this page in a few sentences."
    }
  ],
  "pageContext": {
    "org": "exp-workspace",
    "site": "frescopa",
    "path": "coffee",
    "view": "drafts/hhertach/canvas"
  },
  "imsToken": "....",
  "room": "exp-workspace--frescopa--84361F84631C33D60A495C11@7eeb20f8631c0cb7495c06.e",
  "sessionId": "348c84e6-4eec-4dde-a7c4-7b2583bb194a"
}
```

URL: https://ew-session--da-nx--adobe.aem.live/

## Test Plan

- [ ] 8 new unit tests for the persistence layer pass (`npx wtr test/nx2/blocks/chat/persistence.test.js --node-resolve`)
- [ ] Verify IDB record contains `sessionId` after first message in browser DevTools (Application → IndexedDB → da-chat → conversations)
- [ ] Reload page — same `sessionId` appears in next agent POST (Network tab)
- [ ] Open second tab on same URL — same `sessionId` used
- [ ] Click "Clear chat" — new `sessionId` written to IDB, old one gone