### PR TITLE
fix: Return json for some api calls

### DIFF
--- a/nx/blocks/importer/index.js
+++ b/nx/blocks/importer/index.js
@@ -101,7 +101,7 @@ async function saveAllToDa(url, blob) {
   const body = blob;
 
   try {
-    const resp = await source.put({ org: toOrg, site: toRepo, path: formattedPath, body });
+    const resp = await source.save({ org: toOrg, site: toRepo, path: formattedPath, body });
     return resp.status;
   } catch {
     // eslint-disable-next-line no-console

--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -1,4 +1,4 @@
-import { source, hlx6ToDaList } from '../../../nx2/utils/api.js';
+import { source } from '../../../nx2/utils/api.js';
 
 export class Queue {
   constructor(callback, maxConcurrent = 500, onError = null, throttle = null) {
@@ -57,11 +57,9 @@ async function getChildren(path) {
     const opts = continuationToken
       ? { headers: { 'da-continuation-token': continuationToken } }
       : undefined;
-    const resp = await source.list(path, { opts });
-    if (!resp.ok) break;
+    const { ok, items, continuationToken: nextToken } = await source.list(path, { opts });
+    if (!ok) break;
 
-    const json = await resp.json();
-    const items = hlx6ToDaList(path, json);
     items.forEach((child) => {
       if (!child.name) {
         // eslint-disable-next-line no-console
@@ -75,7 +73,7 @@ async function getChildren(path) {
       }
     });
 
-    continuationToken = resp.headers?.get('da-continuation-token') || null;
+    continuationToken = nextToken;
   } while (continuationToken);
 
   return { files, folders };

--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -1,5 +1,4 @@
-import { daFetch } from '../../utils/daFetch.js';
-import { DA_ORIGIN } from './constants.js';
+import { source, hlx6ToDaList } from '../../../nx2/utils/api.js';
 
 export class Queue {
   constructor(callback, maxConcurrent = 500, onError = null, throttle = null) {
@@ -57,12 +56,13 @@ async function getChildren(path) {
   do {
     const opts = continuationToken
       ? { headers: { 'da-continuation-token': continuationToken } }
-      : {};
-    const resp = await daFetch(`${DA_ORIGIN}/list${path}`, opts);
+      : undefined;
+    const resp = await source.list(path, { opts });
     if (!resp.ok) break;
 
     const json = await resp.json();
-    json.forEach((child) => {
+    const items = hlx6ToDaList(path, json);
+    items.forEach((child) => {
       if (!child.name) {
         // eslint-disable-next-line no-console
         console.log(`This folder has a child with an empty name: ${child.path}`);
@@ -75,7 +75,7 @@ async function getChildren(path) {
       }
     });
 
-    continuationToken = resp.headers.get('da-continuation-token');
+    continuationToken = resp.headers?.get('da-continuation-token') || null;
   } while (continuationToken);
 
   return { files, folders };

--- a/nx2/utils/api.d.ts
+++ b/nx2/utils/api.d.ts
@@ -31,9 +31,9 @@ export function fromPath(fullPath: string): { org: string; site: string; path: s
 // ─── source ─────────────────────────────────────────────────────────────────
 
 export const source: {
-  get(arg: { org: string; site: string; path?: string }): Promise<ApiResponse>;
+  load(arg: { org: string; site: string; path?: string }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  get(fullPath: string): Promise<ApiResponse>;
+  load(fullPath: string): Promise<ApiResponse>;
 
   /**
    * List a folder. Pass `{ org }` (no site) to list sites at the org level —
@@ -43,19 +43,23 @@ export const source: {
   /** `fullPath` is a `/org/site/folder` string (omit trailing file for root). */
   list(fullPath: string): Promise<ApiResponse>;
 
-  put(arg: {
+  save(arg: {
     org: string;
     site: string;
     path: string;
-    /** File contents to upload. */
-    body: BodyInit;
+    /**
+     * File contents to upload. String, Blob, or File. On hlx6, the
+     * `Content-Type` header is set from the path extension (see TYPE_MAP)
+     * and overrides any auto-applied Blob type.
+     */
+    data: BodyInit;
   }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  put(
+  save(
     fullPath: string,
     extras: {
-      /** File contents to upload. */
-      body: BodyInit;
+      /** File contents to upload. See object-form docs above. */
+      data: BodyInit;
     },
   ): Promise<ApiResponse>;
 
@@ -194,52 +198,95 @@ export const status: {
 
 // ─── aem (preview + live) ───────────────────────────────────────────────────
 
+/** Parsed JSON from a single-path aem call when `returnJson` is true (default). */
+export type AemJson = unknown;
+
 export const aem: {
-  /** GET preview status (single only). */
-  getPreview(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** GET preview status (single only). Default: parsed JSON; `undefined` when not ok. */
+  getPreview(arg: { org: string; site: string; path: string; returnJson?: true }): Promise<AemJson | undefined>;
+  getPreview(arg: { org: string; site: string; path: string; returnJson: false }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  getPreview(fullPath: string): Promise<ApiResponse>;
+  getPreview(fullPath: string, extras?: { returnJson?: boolean }): Promise<AemJson | undefined | ApiResponse>;
 
-  /** GET publish status (single only). */
-  getPublish(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** GET publish status (single only). Default: parsed JSON; `undefined` when not ok. */
+  getPublish(arg: { org: string; site: string; path: string; returnJson?: true }): Promise<AemJson | undefined>;
+  getPublish(arg: { org: string; site: string; path: string; returnJson: false }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  getPublish(fullPath: string): Promise<ApiResponse>;
+  getPublish(fullPath: string, extras?: { returnJson?: boolean }): Promise<AemJson | undefined | ApiResponse>;
 
-  /** Update preview. `path` array of 2+ → bulk. `forceUpdate`/`forceSync` are bulk-only. */
+  /** Update preview. `path` array of 2+ → bulk (always `ApiResponse`). `forceUpdate`/`forceSync` are bulk-only. */
   preview(arg: {
     org: string;
     site: string;
-    path: string | string[];
-    /** Bulk only: force update even if source is unchanged. */
+    path: string;
+    returnJson?: true;
     forceUpdate?: boolean;
-    /** Bulk only: run synchronously and wait for the operation to complete. */
+    forceSync?: boolean;
+  }): Promise<AemJson | undefined>;
+  preview(arg: {
+    org: string;
+    site: string;
+    path: string;
+    returnJson: false;
+    forceUpdate?: boolean;
+    forceSync?: boolean;
+  }): Promise<ApiResponse>;
+  preview(arg: {
+    org: string;
+    site: string;
+    path: string[];
+    forceUpdate?: boolean;
     forceSync?: boolean;
   }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string (single only). */
-  preview(fullPath: string): Promise<ApiResponse>;
+  preview(
+    fullPath: string,
+    extras?: { returnJson?: boolean; forceUpdate?: boolean; forceSync?: boolean },
+  ): Promise<AemJson | undefined | ApiResponse>;
 
-  /** Remove from preview. `path` array of 2+ → bulk with `{ delete: true }`. */
-  unPreview(arg: { org: string; site: string; path: string | string[] }): Promise<ApiResponse>;
+  /** Remove from preview. Bulk (`path` array of 2+) always returns `ApiResponse`. */
+  unPreview(arg: { org: string; site: string; path: string; returnJson?: true }): Promise<AemJson | undefined>;
+  unPreview(arg: { org: string; site: string; path: string; returnJson: false }): Promise<ApiResponse>;
+  unPreview(arg: { org: string; site: string; path: string[] }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string (single only). */
-  unPreview(fullPath: string): Promise<ApiResponse>;
+  unPreview(fullPath: string, extras?: { returnJson?: boolean }): Promise<AemJson | undefined | ApiResponse>;
 
-  /** Publish. `path` array of 2+ → bulk. `forceUpdate`/`forceSync` are bulk-only. */
+  /** Publish. `path` array of 2+ → bulk (always `ApiResponse`). `forceUpdate`/`forceSync` are bulk-only. */
   publish(arg: {
     org: string;
     site: string;
-    path: string | string[];
-    /** Bulk only: force update even if source is unchanged. */
+    path: string;
+    returnJson?: true;
     forceUpdate?: boolean;
-    /** Bulk only: run synchronously and wait for the operation to complete. */
+    forceSync?: boolean;
+  }): Promise<AemJson | undefined>;
+  publish(arg: {
+    org: string;
+    site: string;
+    path: string;
+    returnJson: false;
+    forceUpdate?: boolean;
+    forceSync?: boolean;
+  }): Promise<ApiResponse>;
+  publish(arg: {
+    org: string;
+    site: string;
+    path: string[];
+    forceUpdate?: boolean;
     forceSync?: boolean;
   }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string (single only). */
-  publish(fullPath: string): Promise<ApiResponse>;
+  publish(
+    fullPath: string,
+    extras?: { returnJson?: boolean; forceUpdate?: boolean; forceSync?: boolean },
+  ): Promise<AemJson | undefined | ApiResponse>;
 
-  /** Unpublish. `path` array of 2+ → bulk with `{ delete: true }`. */
-  unPublish(arg: { org: string; site: string; path: string | string[] }): Promise<ApiResponse>;
+  /** Unpublish. Bulk (`path` array of 2+) always returns `ApiResponse`. */
+  unPublish(arg: { org: string; site: string; path: string; returnJson?: true }): Promise<AemJson | undefined>;
+  unPublish(arg: { org: string; site: string; path: string; returnJson: false }): Promise<ApiResponse>;
+  unPublish(arg: { org: string; site: string; path: string[] }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/file/path` string (single only). */
-  unPublish(fullPath: string): Promise<ApiResponse>;
+  unPublish(fullPath: string, extras?: { returnJson?: boolean }): Promise<AemJson | undefined | ApiResponse>;
 };
 
 // ─── snapshot ───────────────────────────────────────────────────────────────

--- a/nx2/utils/api.d.ts
+++ b/nx2/utils/api.d.ts
@@ -11,6 +11,36 @@ export interface ApiResponse extends Response {
   permissions: string[];
 }
 
+/** Normalized return shape for `source.list`. Items are always in the
+ * legacy `{ name, ext, path, lastModified, ... }` form regardless of whether
+ * the server is hlx6 (content-type entries) or legacy DA. */
+export interface ListResult {
+  ok: boolean;
+  /** Normalized children. Empty when `ok` is false. */
+  items: Array<{ name: string; path: string; ext?: string; lastModified?: number; contentType?: string }>;
+  /** Pass back in `opts.headers['da-continuation-token']` for the next page. Null when there's no more. */
+  continuationToken: string | null;
+  /** Same hint as `ApiResponse.permissions`. */
+  permissions?: string[];
+}
+
+/** Normalized return shape for `source.delete` / `source.copy` / `source.move`.
+ * Bulk operations paginate via `continuationToken`; pass it back via the
+ * method's `continuationToken` arg to fetch the next page. */
+export interface ActionResult {
+  ok: boolean;
+  status: number;
+  continuationToken: string | null;
+}
+
+/** Normalized return shape for `source.getMetadata`. The value of a HEAD
+ * request IS the headers (doc-id, last-modified, etc.). */
+export interface MetadataResult {
+  ok: boolean;
+  status: number;
+  headers: Headers;
+}
+
 // ─── low-level ──────────────────────────────────────────────────────────────
 
 export function daFetch(args: {
@@ -22,8 +52,6 @@ export function daFetch(args: {
 export function isHlx6(org: string, site: string): Promise<boolean>;
 
 export function signout(): void;
-
-export function hlx6ToDaList(parentPath: string, items: any[]): any[];
 
 /** Split `/org/site/file/path` into `{ org, site, path }`. */
 export function fromPath(fullPath: string): { org: string; site: string; path: string };
@@ -38,10 +66,17 @@ export const source: {
   /**
    * List a folder. Pass `{ org }` (no site) to list sites at the org level —
    * this falls back to DA-legacy `/list/{org}` (no hlx6 equivalent).
+   * Pass `opts.headers['da-continuation-token']` to request a subsequent page.
    */
-  list(arg: { org: string; site?: string; path?: string }): Promise<ApiResponse>;
+  list(arg: {
+    org: string;
+    site?: string;
+    path?: string;
+    /** Extra fetch options (e.g., pagination headers). */
+    opts?: RequestInit;
+  }): Promise<ListResult>;
   /** `fullPath` is a `/org/site/folder` string (omit trailing file for root). */
-  list(fullPath: string): Promise<ApiResponse>;
+  list(fullPath: string, extras?: { opts?: RequestInit }): Promise<ListResult>;
 
   save(arg: {
     org: string;
@@ -63,14 +98,22 @@ export const source: {
     },
   ): Promise<ApiResponse>;
 
-  getMetadata(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** HEAD request — returns `{ ok, status, headers }`. */
+  getMetadata(arg: { org: string; site: string; path: string }): Promise<MetadataResult>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  getMetadata(fullPath: string): Promise<ApiResponse>;
+  getMetadata(fullPath: string): Promise<MetadataResult>;
 
-  delete(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** Bulk delete. Pass back `continuationToken` from the previous result to fetch the next page. */
+  delete(arg: {
+    org: string;
+    site: string;
+    path: string;
+    continuationToken?: string;
+  }): Promise<ActionResult>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  delete(fullPath: string): Promise<ApiResponse>;
+  delete(fullPath: string, extras?: { continuationToken?: string }): Promise<ActionResult>;
 
+  /** Copy. Paginates via `continuationToken` for large trees. */
   copy(arg: {
     org: string;
     site: string;
@@ -80,7 +123,9 @@ export const source: {
     destination: string;
     /** Conflict policy when destination exists. e.g. `'overwrite'`. */
     collision?: 'overwrite' | string;
-  }): Promise<ApiResponse>;
+    /** Pagination token from a previous `copy` result. */
+    continuationToken?: string;
+  }): Promise<ActionResult>;
   /** `fullPath` is the source `/org/site/file/path` string. */
   copy(
     fullPath: string,
@@ -89,9 +134,11 @@ export const source: {
       destination: string;
       /** Conflict policy when destination exists. e.g. `'overwrite'`. */
       collision?: string;
+      continuationToken?: string;
     },
-  ): Promise<ApiResponse>;
+  ): Promise<ActionResult>;
 
+  /** Move. Paginates via `continuationToken` for large trees. */
   move(arg: {
     org: string;
     site: string;
@@ -101,7 +148,9 @@ export const source: {
     destination: string;
     /** Conflict policy when destination exists. e.g. `'overwrite'`. */
     collision?: 'overwrite' | string;
-  }): Promise<ApiResponse>;
+    /** Pagination token from a previous `move` result. */
+    continuationToken?: string;
+  }): Promise<ActionResult>;
   /** `fullPath` is the source `/org/site/file/path` string. */
   move(
     fullPath: string,
@@ -110,8 +159,9 @@ export const source: {
       destination: string;
       /** Conflict policy when destination exists. e.g. `'overwrite'`. */
       collision?: string;
+      continuationToken?: string;
     },
-  ): Promise<ApiResponse>;
+  ): Promise<ActionResult>;
 
   createFolder(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
   /** `fullPath` is a `/org/site/folder` string. */
@@ -190,10 +240,12 @@ export const org: {
 // ─── status ────────────────────────────────────────────────────────────────
 
 export const status: {
-  /** Single-path only. H6 has no bulk status endpoint. */
-  get(arg: { org: string; site: string; path: string }): Promise<ApiResponse>;
+  /** Single-path only. H6 has no bulk status endpoint. Returns parsed JSON
+   * (typically `{ preview, live, edit, ... }`) or `undefined` when the
+   * response is not ok or the body fails to parse. */
+  get(arg: { org: string; site: string; path: string }): Promise<unknown | undefined>;
   /** `fullPath` is a `/org/site/file/path` string. */
-  get(fullPath: string): Promise<ApiResponse>;
+  get(fullPath: string): Promise<unknown | undefined>;
 };
 
 // ─── aem (preview + live) ───────────────────────────────────────────────────

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -171,7 +171,7 @@ const jsonOpts = (method, payload) => ({
 // Array of length >= 2 routes to the bulk /* endpoint with { paths, delete? }.
 // `forceUpdate`/`forceSync` are bulk-only (server ignores them on single-path).
 const callPath = async ({
-  api, org, site, path, method, includeDelete = false, forceUpdate, forceSync,
+  api, org, site, path, method, includeDelete = false, forceUpdate, forceSync, returnJson = true,
 }) => {
   if (Array.isArray(path) && path.length >= 2) {
     const url = await getAemApiPath(api, org, site, '/*');
@@ -183,7 +183,14 @@ const callPath = async ({
   }
   const single = Array.isArray(path) ? path[0] : path;
   const url = await getAemApiPath(api, org, site, single);
-  return daFetch({ url, opts: { method } });
+  const resp = await daFetch({ url, opts: { method } });
+  if (!returnJson) return resp;
+  if (!resp.ok) return undefined;
+  try {
+    return resp.json();
+  } catch {
+    return undefined;
+  }
 };
 
 export const signout = () => {
@@ -376,7 +383,13 @@ export { orgNs as org };
 export const status = {
   get: withArgs(async ({ org, site, path }) => {
     const url = await getAemApiPath('status', org, site, path);
-    return daFetch({ url });
+    const resp = await daFetch({ url });
+    if (!resp.ok) return undefined;
+    try {
+      return resp.json();
+    } catch {
+      return undefined;
+    }
   }),
 };
 
@@ -384,32 +397,32 @@ export const status = {
 // preview/unPreview/publish/unPublish accept `path` as string or array (2+ -> bulk).
 // preview/publish also accept optional `forceUpdate`/`forceSync` flags.
 export const aem = {
-  getPreview: withArgs(({ org, site, path }) => callPath({
-    api: 'preview', org, site, path, method: 'GET',
+  getPreview: withArgs(({ org, site, path, returnJson = true }) => callPath({
+    api: 'preview', org, site, path, method: 'GET', returnJson,
   })),
 
-  getPublish: withArgs(({ org, site, path }) => callPath({
-    api: 'live', org, site, path, method: 'GET',
+  getPublish: withArgs(({ org, site, path, returnJson = true }) => callPath({
+    api: 'live', org, site, path, method: 'GET', returnJson,
   })),
 
   preview: withArgs(({
-    org, site, path, forceUpdate, forceSync,
+    org, site, path, forceUpdate, forceSync, returnJson = true,
   }) => callPath({
-    api: 'preview', org, site, path, method: 'POST', forceUpdate, forceSync,
+    api: 'preview', org, site, path, method: 'POST', forceUpdate, forceSync, returnJson,
   })),
 
-  unPreview: withArgs(({ org, site, path }) => callPath({
-    api: 'preview', org, site, path, method: 'DELETE', includeDelete: true,
+  unPreview: withArgs(({ org, site, path, returnJson = true }) => callPath({
+    api: 'preview', org, site, path, method: 'DELETE', includeDelete: true, returnJson,
   })),
 
   publish: withArgs(({
-    org, site, path, forceUpdate, forceSync,
+    org, site, path, forceUpdate, forceSync, returnJson = true,
   }) => callPath({
-    api: 'live', org, site, path, method: 'POST', forceUpdate, forceSync,
+    api: 'live', org, site, path, method: 'POST', forceUpdate, forceSync, returnJson,
   })),
 
-  unPublish: withArgs(({ org, site, path }) => callPath({
-    api: 'live', org, site, path, method: 'DELETE', includeDelete: true,
+  unPublish: withArgs(({ org, site, path, returnJson = true }) => callPath({
+    api: 'live', org, site, path, method: 'DELETE', includeDelete: true, returnJson,
   })),
 };
 

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -11,9 +11,18 @@ const CONFIG = 'config';
 const VERSIONS = 'versions';
 const REF = 'main';
 
-const TEXT_TYPES = {
+const TYPE_MAP = {
   '.html': 'text/html',
   '.json': 'application/json',
+  '.link': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.mp4': 'video/mp4',
+  '.pdf': 'application/pdf',
 };
 
 export const daFetch = async ({ url, opts = { method: 'GET' }, redirect = false }) => {
@@ -201,41 +210,37 @@ export const signout = () => {
 // { org, site, path, ...extras } or a `/org/site/file/path` string.
 // `extras` (second arg) merges with parsed args when arg is a string.
 export const source = {
-  get: withArgs(async ({ org, site, path }) => {
+  load: withArgs(async ({ org, site, path }) => {
     const url = await getDaApiPath(SOURCE, org, site, path);
     return daFetch({ url });
   }),
 
-  list: withArgs(async ({ org, site, path }) => {
+  list: withArgs(async ({ org, site, path, opts }) => {
     // Org-only list (no site) is DA-legacy only; hlx6 has no equivalent.
     if (site) {
       const hlx6 = await isHlx6(org, site);
       if (hlx6) {
         const slashed = path?.endsWith('/') ? path : `${path ?? ''}/`;
         const url = await getDaApiPath(SOURCE, org, site, slashed);
-        return daFetch({ url });
+        return daFetch({ url, opts });
       }
     }
     const url = await getDaApiPath(LIST, org, site, path);
-    return daFetch({ url });
+    return daFetch({ url, opts });
   }),
 
-  put: withArgs(async ({ org, site, path, body }) => {
+  save: withArgs(async ({ org, site, path, data }) => {
     const hlx6 = await isHlx6(org, site);
     const url = await getDaApiPath(SOURCE, org, site, path);
     const opts = { method: 'POST' };
     if (hlx6) {
-      const textExt = Object.keys(TEXT_TYPES).find((e) => path.endsWith(e));
-      if (textExt) {
-        opts.body = body instanceof Blob ? await body.text() : body;
-        opts.headers = { 'Content-Type': TEXT_TYPES[textExt] };
-      } else {
-        opts.body = body;
-      }
+      const ext = Object.keys(TYPE_MAP).find((e) => path.endsWith(e));
+      opts.body = data;
+      if (ext) opts.headers = { 'Content-Type': TYPE_MAP[ext] };
       return daFetch({ url, opts });
     }
     const formData = new FormData();
-    formData.append('data', body);
+    formData.append('data', data);
     opts.body = formData;
     return daFetch({ url, opts });
   }),

--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -149,6 +149,55 @@ export const fromPath = (str) => {
   return { org, site, path: parts.length ? `/${parts.join('/')}` : '' };
 };
 
+// Normalize a bulk action response (delete/copy/move) into the common
+// `{ ok, status, continuationToken }` shape. Pagination continues when the
+// server returns `{ continuationToken: ... }` in the JSON body; on 204
+// (no content) or non-2xx there's nothing more to read.
+async function wrapActionResp(resp) {
+  const ok = !!resp?.ok;
+  const status = resp?.status ?? 0;
+  if (!ok || status === 204) return { ok, status, continuationToken: null };
+  let body;
+  try {
+    body = await resp.json();
+  } catch { body = null; }
+  return { ok, status, continuationToken: body?.continuationToken || null };
+}
+
+function hlx6ToDaList(parentPath, items) {
+  return items.map((item) => {
+    const contentType = item['content-type'];
+
+    // Only HLX6 has a content type
+    if (!contentType) return item;
+
+    // Normalize folder
+    const isFolder = item.name.endsWith('/');
+    let name = isFolder ? item.name.slice(0, -1) : item.name;
+
+    // Set the path before extension removal
+    const path = `${parentPath}/${name}`;
+
+    // Remove extension for display
+    const nameSplit = name.split('.');
+    name = nameSplit.length > 1 ? nameSplit[0] : name;
+
+    // Scaffold out the basics
+    const daItem = { name, path, contentType };
+
+    const ext = nameSplit.length > 1 && nameSplit.pop();
+    if (ext) daItem.ext = ext;
+
+    const lastModified = item['last-modified'];
+    if (lastModified) {
+      const unixTime = Math.floor(new Date(lastModified).getTime());
+      daItem.lastModified = unixTime;
+    }
+
+    return daItem;
+  });
+}
+
 // HOF: wraps a method body so it receives resolved args. The first arg
 // can be either `{ org, site, path, ...extras }` or a `/org/site/file/path`
 // string; `extras` (second positional) merges in when arg is a string.
@@ -215,18 +264,33 @@ export const source = {
     return daFetch({ url });
   }),
 
+  // Returns `{ ok, items, continuationToken, permissions }`
   list: withArgs(async ({ org, site, path, opts }) => {
+    const cleanPath = (path || '').replace(/\/$/, '');
+    const parentPath = `/${org}${site ? `/${site}` : ''}${cleanPath}`;
+    let resp;
     // Org-only list (no site) is DA-legacy only; hlx6 has no equivalent.
     if (site) {
       const hlx6 = await isHlx6(org, site);
       if (hlx6) {
         const slashed = path?.endsWith('/') ? path : `${path ?? ''}/`;
         const url = await getDaApiPath(SOURCE, org, site, slashed);
-        return daFetch({ url, opts });
+        resp = await daFetch({ url, opts });
       }
     }
-    const url = await getDaApiPath(LIST, org, site, path);
-    return daFetch({ url, opts });
+    if (!resp) {
+      const url = await getDaApiPath(LIST, org, site, path);
+      resp = await daFetch({ url, opts });
+    }
+    const continuationToken = resp?.headers?.get?.('da-continuation-token') || null;
+    const { permissions } = resp || {};
+    if (!resp?.ok) return { ok: false, items: [], continuationToken, permissions };
+    let raw;
+    try {
+      raw = await resp.json();
+    } catch { raw = []; }
+    const items = Array.isArray(raw) ? hlx6ToDaList(parentPath, raw) : [];
+    return { ok: true, items, continuationToken, permissions };
   }),
 
   save: withArgs(async ({ org, site, path, data }) => {
@@ -245,55 +309,75 @@ export const source = {
     return daFetch({ url, opts });
   }),
 
+  // Returns `{ ok, status, headers }`. HEAD request — the value is the
+  // headers (doc-id, last-modified, etc.). `headers` is the raw Headers
+  // object so callers can call `.get(name)` on it as usual.
   getMetadata: withArgs(async ({ org, site, path }) => {
     const url = await getDaApiPath(SOURCE, org, site, path);
-    return daFetch({ url, opts: { method: 'HEAD' } });
+    const resp = await daFetch({ url, opts: { method: 'HEAD' } });
+    return { ok: !!resp?.ok, status: resp?.status ?? 0, headers: resp?.headers };
   }),
 
-  delete: withArgs(async ({ org, site, path }) => {
-    const url = await getDaApiPath(SOURCE, org, site, path);
-    return daFetch({ url, opts: { method: 'DELETE' } });
+  // Returns `{ ok, status, continuationToken }`. Bulk delete paginates
+  // via `continuationToken` in the response body; pass it back via the
+  // method's `continuationToken` arg to fetch the next page.
+  delete: withArgs(async ({ org, site, path, continuationToken }) => {
+    const baseUrl = await getDaApiPath(SOURCE, org, site, path);
+    const url = new URL(baseUrl);
+    if (continuationToken) url.searchParams.set('continuation-token', continuationToken);
+    const resp = await daFetch({ url: url.toString(), opts: { method: 'DELETE' } });
+    return wrapActionResp(resp);
   }),
 
+  // Returns `{ ok, status, continuationToken }`. See `delete` for the
+  // pagination contract.
   copy: withArgs(async ({
     org, site, path, destination, collision, continuationToken,
   }) => {
     const hlx6 = await isHlx6(org, site);
+    let resp;
     if (hlx6) {
       const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
       url.searchParams.set('source', path);
       if (collision) url.searchParams.set('collision', collision);
       if (continuationToken) url.searchParams.set('continuation-token', continuationToken);
-      return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+      resp = await daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+    } else {
+      const formData = new FormData();
+      formData.append('destination', destination);
+      if (continuationToken) formData.append('continuation-token', continuationToken);
+      resp = await daFetch({
+        url: `${DA_ADMIN}/copy/${org}/${site}${path}`,
+        opts: { method: 'POST', body: formData },
+      });
     }
-    const formData = new FormData();
-    formData.append('destination', destination);
-    if (continuationToken) formData.append('continuation-token', continuationToken);
-    return daFetch({
-      url: `${DA_ADMIN}/copy/${org}/${site}${path}`,
-      opts: { method: 'POST', body: formData },
-    });
+    return wrapActionResp(resp);
   }),
 
+  // Returns `{ ok, status, continuationToken }`. See `delete` for the
+  // pagination contract.
   move: withArgs(async ({
     org, site, path, destination, collision, continuationToken,
   }) => {
     const hlx6 = await isHlx6(org, site);
+    let resp;
     if (hlx6) {
       const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
       url.searchParams.set('source', path);
       url.searchParams.set('move', 'true');
       if (collision) url.searchParams.set('collision', collision);
       if (continuationToken) url.searchParams.set('continuation-token', continuationToken);
-      return daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+      resp = await daFetch({ url: url.toString(), opts: { method: 'PUT' } });
+    } else {
+      const formData = new FormData();
+      formData.append('destination', destination);
+      if (continuationToken) formData.append('continuation-token', continuationToken);
+      resp = await daFetch({
+        url: `${DA_ADMIN}/move/${org}/${site}${path}`,
+        opts: { method: 'POST', body: formData },
+      });
     }
-    const formData = new FormData();
-    formData.append('destination', destination);
-    if (continuationToken) formData.append('continuation-token', continuationToken);
-    return daFetch({
-      url: `${DA_ADMIN}/move/${org}/${site}${path}`,
-      opts: { method: 'POST', body: formData },
-    });
+    return wrapActionResp(resp);
   }),
 
   createFolder: withArgs(async ({ org, site, path }) => {
@@ -416,9 +500,14 @@ export const aem = {
     api: 'preview', org, site, path, method: 'POST', forceUpdate, forceSync, returnJson,
   })),
 
-  unPreview: withArgs(({ org, site, path, returnJson = true }) => callPath({
-    api: 'preview', org, site, path, method: 'DELETE', includeDelete: true, returnJson,
-  })),
+  unPreview: withArgs(async ({ org, site, path, returnJson = true }) => {
+    const resp = await callPath({
+      api: 'preview', org, site, path, method: 'DELETE', includeDelete: true, returnJson: false,
+    });
+    if (!returnJson) return resp;
+    if (resp.ok && resp.status === 204) return { ok: true, status: 204 };
+    return undefined;
+  }),
 
   publish: withArgs(({
     org, site, path, forceUpdate, forceSync, returnJson = true,
@@ -426,9 +515,14 @@ export const aem = {
     api: 'live', org, site, path, method: 'POST', forceUpdate, forceSync, returnJson,
   })),
 
-  unPublish: withArgs(({ org, site, path, returnJson = true }) => callPath({
-    api: 'live', org, site, path, method: 'DELETE', includeDelete: true, returnJson,
-  })),
+  unPublish: withArgs(async ({ org, site, path, returnJson = true }) => {
+    const resp = await callPath({
+      api: 'live', org, site, path, method: 'DELETE', includeDelete: true, returnJson: false,
+    });
+    if (!returnJson) return resp;
+    if (resp.ok && resp.status === 204) return { ok: true, status: 204 };
+    return undefined;
+  }),
 };
 
 // snapshot: snapshot CRUD and review/publish actions.
@@ -505,37 +599,3 @@ export const jobs = {
     return daFetch({ url, opts: { method: 'DELETE' } });
   },
 };
-
-export function hlx6ToDaList(parentPath, items) {
-  return items.map((item) => {
-    const contentType = item['content-type'];
-
-    // Only HLX6 has a content type
-    if (!contentType) return item;
-
-    // Normalize folder
-    const isFolder = item.name.endsWith('/');
-    let name = isFolder ? item.name.slice(0, -1) : item.name;
-
-    // Set the path before extension removal
-    const path = `${parentPath}/${name}`;
-
-    // Remove extension for display
-    const nameSplit = name.split('.');
-    name = nameSplit.length > 1 ? nameSplit[0] : name;
-
-    // Scaffold out the basics
-    const daItem = { name, path, contentType };
-
-    const ext = nameSplit.length > 1 && nameSplit.pop();
-    if (ext) daItem.ext = ext;
-
-    const lastModified = item['last-modified'];
-    if (lastModified) {
-      const unixTime = Math.floor(new Date(lastModified).getTime());
-      daItem.lastModified = unixTime;
-    }
-
-    return daItem;
-  });
-}

--- a/nx2/utils/api.md
+++ b/nx2/utils/api.md
@@ -47,14 +47,18 @@ versions.get('/adobe/aem-boilerplate/index.html', { versionId: 'abc' });
 
 ## Return values
 
-Most methods return the **`Response` object from `fetch`**, with two augmentations performed by `daFetch`:
+Methods fall into a few return-shape categories:
 
-- `resp.permissions: string[]` — parsed from the `x-da-child-actions` header (preferred), `x-da-actions` (fallback), or defaulted to `['read', 'write']`.
-- For two methods (`config.getAggregated` is the current case) that are hlx6-only, calling them on a non-upgraded site returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` instead of a `Response`.
+**Raw `Response`** — `source.load`, `source.save`, `source.createFolder`, `source.deleteFolder`, all of `versions`, `config`, `org`, `snapshot`, `jobs`, and bulk `aem` calls. The response is augmented by `daFetch` with `resp.permissions: string[]` — parsed from the `x-da-child-actions` header (preferred), `x-da-actions` (fallback), or defaulted to `['read', 'write']`. Treat like any `fetch` result: `await resp.json()`, check `resp.ok`, etc.
 
-Treat the return like any `fetch` result: `await resp.json()`, check `resp.ok`, etc.
+**Normalized objects** for `source` mutation/listing methods:
+- `source.list` → `{ ok, items, continuationToken, permissions }` — `items` is the normalized list (legacy DA shape regardless of server).
+- `source.delete` / `source.copy` / `source.move` → `{ ok, status, continuationToken }` — pass `continuationToken` back into the same call to fetch the next page.
+- `source.getMetadata` → `{ ok, status, headers }` — the raw `Headers` object (HEAD request value is in the headers).
 
-**`aem` (single-path only):** by default, single-path calls parse the response body and return JSON (`returnJson: true`). On non-ok responses or parse failures, the return is `undefined`. Pass `returnJson: false` to get the raw augmented `Response` instead. **Bulk** calls (`path` as an array of length ≥ 2) always return a `Response` — `returnJson` does not apply.
+**Parsed JSON or `undefined`** — `status.get` and `aem` single-path calls (the default `returnJson: true`). Returns the parsed body on success, `undefined` when the response is not ok or the body fails to parse. For `aem`, pass `returnJson: false` to get the raw augmented `Response` instead. **Bulk** `aem` calls (`path` as an array of length ≥ 2) always return a `Response` — `returnJson` does not apply.
+
+**Sentinel objects** — `config.getAggregated` is hlx6-only; calling it on a non-upgraded site returns `{ error: 'Requires Helix 6 upgrade', status: 501 }`. `aem.unPreview` / `aem.unPublish` return `{ ok: true, status: 204 }` on a successful single-path delete (default `returnJson: true`), and `undefined` otherwise.
 
 ---
 
@@ -92,13 +96,13 @@ Document CRUD on `source` paths. Bridges DA's `/source` and AEM's `/sites/{site}
 
 | Method         | Signature                                                                                     | Notes                                                                                                                                                                                          |
 | -------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `load`         | `({ org, site, path })` or `(fullPath)`                                                       | GET                                                                                                                                                                                            |
-| `list`         | `({ org, site, path? })` or `(fullPath)`                                                      | List a folder. Pass `{ org }` (no site) to list at org level — DA-legacy only.                                                                                                                 |
-| `save`         | `({ org, site, path, data })` or `(fullPath, { data })`                                       | Upload. POST for both branches. **DA-legacy**: wraps `data` in `multipart/form-data` field `data`. **hlx6**: sends `data` raw (string, Blob, or File); `Content-Type` is set from the path extension via `TYPE_MAP` and overrides any auto-applied Blob type. Extensions not in `TYPE_MAP` send no `Content-Type`. |
-| `getMetadata`  | `({ org, site, path })` or `(fullPath)`                                                       | HEAD — returns headers only (`doc-id`, `last-modified`, etc.)                                                                                                                                  |
-| `delete`       | `({ org, site, path })` or `(fullPath)`                                                       | DELETE                                                                                                                                                                                         |
-| `copy`         | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | `path` = source, `destination` = target. **hlx6**: PUT to dest URL with `?source=…&collision=…` query. **DA**: POST `/copy/{org}/{site}{path}` with `multipart/form-data` field `destination`. |
-| `move`         | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | Same shape as `copy` but adds `?move=true` (hlx6) or POSTs to `/move/{org}/{site}{path}` (DA).                                                                                                 |
+| `load`         | `({ org, site, path })` or `(fullPath)`                                                       | GET — raw `Response`.                                                                                                                                                                          |
+| `list`         | `({ org, site, path? })` or `(fullPath)`                                                      | List a folder. Returns `{ ok, items, continuationToken, permissions }` (normalized — items match legacy DA shape regardless of server). Pass `{ org }` (no site) to list at org level — DA-legacy only. |
+| `save`         | `({ org, site, path, data })` or `(fullPath, { data })`                                       | Upload — raw `Response`. POST for both branches. **DA-legacy**: wraps `data` in `multipart/form-data` field `data`. **hlx6**: sends `data` raw (string, Blob, or File); `Content-Type` is set from the path extension via `TYPE_MAP` and overrides any auto-applied Blob type. Extensions not in `TYPE_MAP` send no `Content-Type`. |
+| `getMetadata`  | `({ org, site, path })` or `(fullPath)`                                                       | HEAD — returns `{ ok, status, headers }`. `headers` is the raw `Headers` object (`doc-id`, `last-modified`, etc.).                                                                            |
+| `delete`       | `({ org, site, path, continuationToken? })` or `(fullPath, { continuationToken? })`           | Returns `{ ok, status, continuationToken }`. Bulk deletes paginate — pass `continuationToken` back into the next call.                                                                         |
+| `copy`         | `({ org, site, path, destination, collision?, continuationToken? })` or `(fullPath, { destination, collision?, continuationToken? })` | `path` = source, `destination` = target. Returns `{ ok, status, continuationToken }`. **hlx6**: PUT to dest URL with `?source=…&collision=…` query. **DA**: POST `/copy/{org}/{site}{path}` with `multipart/form-data` field `destination`. |
+| `move`         | `({ org, site, path, destination, collision?, continuationToken? })` or `(fullPath, { destination, collision?, continuationToken? })` | Same shape as `copy` (and same return) but adds `?move=true` (hlx6) or POSTs to `/move/{org}/{site}{path}` (DA).                              |
 | `createFolder` | `({ org, site, path })` or `(fullPath)`                                                       | POST on `${path}/` (trailing slash).                                                                                                                                                           |
 | `deleteFolder` | `({ org, site, path })` or `(fullPath)`                                                       | DELETE on `${path}/`.                                                                                                                                                                          |
 
@@ -127,18 +131,24 @@ await source.save('/adobe/aem-boilerplate/page.html', { data: '<main>…</main>'
 // Upload a binary file (e.g., from <input type=file>)
 await source.save('/adobe/aem-boilerplate/img/logo.png', { data: file });
 
-// List a folder
-const list = await source.list('/adobe/aem-boilerplate/folder');
-const items = await list.json();
+// List a folder — returns { ok, items, continuationToken, permissions }
+const { ok, items } = await source.list('/adobe/aem-boilerplate/folder');
 
-// Copy
-await source.copy({
+// Copy — returns { ok, status, continuationToken }
+let { ok: copied, continuationToken } = await source.copy({
   org: 'adobe',
   site: 'aem-boilerplate',
   path: '/old.html',          // source
   destination: '/new.html',   // dest
   collision: 'overwrite',
 });
+// Continue pagination if the server signals more work
+while (copied && continuationToken) {
+  ({ ok: copied, continuationToken } = await source.copy({
+    org: 'adobe', site: 'aem-boilerplate', path: '/old.html',
+    destination: '/new.html', continuationToken,
+  }));
+}
 ```
 
 ---
@@ -225,9 +235,9 @@ Organization-level operations. hlx6-only (no DA-legacy fallback exists at org le
 Resource status (preview + live combined view). **Single-path only** — H6 has no bulk status endpoint.
 
 
-| Method | Signature                               | Notes                |
-| ------ | --------------------------------------- | -------------------- |
-| `get`  | `({ org, site, path })` or `(fullPath)` | GET `/status/{path}` |
+| Method | Signature                               | Notes                                                                       |
+| ------ | --------------------------------------- | --------------------------------------------------------------------------- |
+| `get`  | `({ org, site, path })` or `(fullPath)` | GET `/status/{path}`. Returns parsed JSON; `undefined` if not ok or unparseable. |
 
 
 ### URL shapes
@@ -241,8 +251,9 @@ Resource status (preview + live combined view). **Single-path only** — H6 has 
 ### Example
 
 ```js
-const resp = await status.get('/adobe/aem-boilerplate/index.html');
-const { preview, live, edit } = await resp.json();
+const info = await status.get('/adobe/aem-boilerplate/index.html');
+if (!info) return; // not ok or unparseable
+const { preview, live, edit } = info;
 ```
 
 ---
@@ -407,10 +418,12 @@ const resp = await daFetch({
 
 ## Error handling
 
-Every namespace method returns a `Response` (or a Response-shaped object — see hlx6-only methods below). No method throws on HTTP failure; callers should branch on `resp.ok` or `resp.status`.
+No method throws on HTTP failure. The branching idiom depends on the return category (see [Return values](#return-values)):
+
+**Raw `Response` methods** — branch on `resp.ok` / `resp.status`:
 
 ```js
-const resp = await source.get(path);
+const resp = await source.load(path);
 if (!resp.ok) {
   // 4xx/5xx — handle as appropriate
   return;
@@ -418,7 +431,14 @@ if (!resp.ok) {
 const json = await resp.json();
 ```
 
-For `aem` single-path calls with the default `returnJson: true`, check for `undefined` instead of `resp.ok`:
+**Normalized `source` methods** — branch on `ok`:
+
+```js
+const { ok, items } = await source.list(path);
+if (!ok) return;
+```
+
+**Parsed-JSON methods** (`status.get`, `aem` single-path default) — check for `undefined`:
 
 ```js
 const data = await aem.getPreview({ org, site, path: '/index.html' });
@@ -432,8 +452,7 @@ if (data === undefined) {
 
 - `daFetch` returns `{}` (empty object) when no IMS access token is available.
 - `config.getAggregated` returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` when the site isn't hlx6.
-
-These are the **only** non-`Response` return values outside of `aem` single-path calls (which return parsed JSON or `undefined` by default). All other methods always return a real `Response`.
+- `aem.unPreview` / `aem.unPublish` return `{ ok: true, status: 204 }` on a successful single-path delete (default `returnJson: true`), and `undefined` otherwise.
 
 `**console.error` on bad args:** when an invalid first argument is passed (missing `org`), the module logs a console error but doesn't throw — the bad call still flows through and produces a malformed URL that the server will reject. The console message is the only signal from the client side; rely on the server's response status for handling.
 

--- a/nx2/utils/api.md
+++ b/nx2/utils/api.md
@@ -2,7 +2,7 @@
 
 A unified client for talking to **DA admin** (`admin.da.live`) and the **AEM admin API** in either its legacy form (`admin.hlx.page`, "helix5") or its new form (`api.aem.live`, "helix6"). Every method auto-routes by the per-site **hlx6** upgrade flag — once a site has been upgraded, calls flow to the new origin; otherwise they fall back to the legacy origin.
 
-The module ships its low-level primitive (`daFetch`), an upgrade detector (`isHlx6`), helpers (`fromPath`, `signout`, `hlx6ToDaList`), and **eight namespaced surfaces**: `source`, `versions`, `config`, `org`, `status`, `aem`, `snapshot`, `jobs`. Type definitions live in [`api.d.ts`](./api.d.ts) — VSCode picks them up automatically and surfaces overloads, field-level docs, and inline shapes.
+The module ships its low-level primitive (`daFetch`), an upgrade detector (`isHlx6`), helpers (`fromPath`, `signout`, `hlx6ToDaList`), and **eight namespaced surfaces**: `source`, `versions`, `config`, `org`, `status`, `aem`, `snapshot`, `jobs`. Type definitions live in `[api.d.ts](./api.d.ts)` — VSCode picks them up automatically and surfaces overloads, field-level docs, and inline shapes.
 
 > **Routing model.** Some endpoints are owned by DA itself (`source`, `list`, `config`, `versions`) and DA proxies them to AEM when the site is upgraded. Others are AEM-only (`status`, `preview`, `live`, `snapshots`, `jobs`) and live on either `admin.hlx.page` (legacy) or `api.aem.live` (hlx6). The module hides this distinction; callers always pass `{ org, site, path }` and get a `Response` back.
 
@@ -28,14 +28,14 @@ Most methods accept the first argument as **either** an object or a path string.
 **Object form** — pass parts explicitly:
 
 ```js
-source.get({ org: 'adobe', site: 'aem-boilerplate', path: '/index.html' });
+source.load({ org: 'adobe', site: 'aem-boilerplate', path: '/index.html' });
 ```
 
 **Path-string form** — pass a `/org/site/file/path` string. The helper splits it for you. Method-specific extras go in a second positional argument:
 
 ```js
-source.get('/adobe/aem-boilerplate/index.html');
-source.put('/adobe/aem-boilerplate/page.html', { body: '<main>…</main>' });
+source.load('/adobe/aem-boilerplate/index.html');
+source.save('/adobe/aem-boilerplate/page.html', { data: '<main>…</main>' });
 versions.get('/adobe/aem-boilerplate/index.html', { versionId: 'abc' });
 ```
 
@@ -47,12 +47,14 @@ versions.get('/adobe/aem-boilerplate/index.html', { versionId: 'abc' });
 
 ## Return values
 
-Every method returns the **`Response` object from `fetch`**, with two augmentations performed by `daFetch`:
+Most methods return the **`Response` object from `fetch`**, with two augmentations performed by `daFetch`:
 
 - `resp.permissions: string[]` — parsed from the `x-da-child-actions` header (preferred), `x-da-actions` (fallback), or defaulted to `['read', 'write']`.
 - For two methods (`config.getAggregated` is the current case) that are hlx6-only, calling them on a non-upgraded site returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` instead of a `Response`.
 
 Treat the return like any `fetch` result: `await resp.json()`, check `resp.ok`, etc.
+
+**`aem` (single-path only):** by default, single-path calls parse the response body and return JSON (`returnJson: true`). On non-ok responses or parse failures, the return is `undefined`. Pass `returnJson: false` to get the raw augmented `Response` instead. **Bulk** calls (`path` as an array of length ≥ 2) always return a `Response` — `returnJson` does not apply.
 
 ---
 
@@ -87,36 +89,43 @@ Most callers don't call `isHlx6` directly — they let the namespace methods do 
 
 Document CRUD on `source` paths. Bridges DA's `/source` and AEM's `/sites/{site}/source` (hlx6).
 
-| Method | Signature | Notes |
-|---|---|---|
-| `get` | `({ org, site, path })` or `(fullPath)` | GET |
-| `list` | `({ org, site, path? })` or `(fullPath)` | List a folder. Pass `{ org }` (no site) to list at org level — DA-legacy only. |
-| `put` | `({ org, site, path, body })` or `(fullPath, { body })` | Upload. PUT for both branches. **DA**: wraps body in `multipart/form-data` field `data`. **hlx6**: sends body raw with `Content-Type` sniffed from path extension. |
-| `getMetadata` | `({ org, site, path })` or `(fullPath)` | HEAD — returns headers only (`doc-id`, `last-modified`, etc.) |
-| `delete` | `({ org, site, path })` or `(fullPath)` | DELETE |
-| `copy` | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | `path` = source, `destination` = target. **hlx6**: PUT to dest URL with `?source=…&collision=…` query. **DA**: POST `/copy/{org}/{site}{path}` with `multipart/form-data` field `destination`. |
-| `move` | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | Same shape as `copy` but adds `?move=true` (hlx6) or POSTs to `/move/{org}/{site}{path}` (DA). |
-| `createFolder` | `({ org, site, path })` or `(fullPath)` | POST on `${path}/` (trailing slash). |
-| `deleteFolder` | `({ org, site, path })` or `(fullPath)` | DELETE on `${path}/`. |
+
+| Method         | Signature                                                                                     | Notes                                                                                                                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load`         | `({ org, site, path })` or `(fullPath)`                                                       | GET                                                                                                                                                                                            |
+| `list`         | `({ org, site, path? })` or `(fullPath)`                                                      | List a folder. Pass `{ org }` (no site) to list at org level — DA-legacy only.                                                                                                                 |
+| `save`         | `({ org, site, path, data })` or `(fullPath, { data })`                                       | Upload. POST for both branches. **DA-legacy**: wraps `data` in `multipart/form-data` field `data`. **hlx6**: sends `data` raw (string, Blob, or File); `Content-Type` is set from the path extension via `TYPE_MAP` and overrides any auto-applied Blob type. Extensions not in `TYPE_MAP` send no `Content-Type`. |
+| `getMetadata`  | `({ org, site, path })` or `(fullPath)`                                                       | HEAD — returns headers only (`doc-id`, `last-modified`, etc.)                                                                                                                                  |
+| `delete`       | `({ org, site, path })` or `(fullPath)`                                                       | DELETE                                                                                                                                                                                         |
+| `copy`         | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | `path` = source, `destination` = target. **hlx6**: PUT to dest URL with `?source=…&collision=…` query. **DA**: POST `/copy/{org}/{site}{path}` with `multipart/form-data` field `destination`. |
+| `move`         | `({ org, site, path, destination, collision? })` or `(fullPath, { destination, collision? })` | Same shape as `copy` but adds `?move=true` (hlx6) or POSTs to `/move/{org}/{site}{path}` (DA).                                                                                                 |
+| `createFolder` | `({ org, site, path })` or `(fullPath)`                                                       | POST on `${path}/` (trailing slash).                                                                                                                                                           |
+| `deleteFolder` | `({ org, site, path })` or `(fullPath)`                                                       | DELETE on `${path}/`.                                                                                                                                                                          |
+
 
 ### URL shapes
 
-| Method | hlx6 | legacy DA |
-|---|---|---|
-| get / list / put / head / delete | `${AEM_API}/{org}/sites/{site}/source{path}` | `${DA_ADMIN}/source/{org}/{site}{path}` |
-| list (org-only) | n/a | `${DA_ADMIN}/list/{org}` |
-| list (with site, legacy) | n/a | `${DA_ADMIN}/list/{org}/{site}{path}` |
-| copy / move | PUT to dest URL with `?source=&collision=&move=` | POST to `${DA_ADMIN}/copy/{org}/{site}{path}` (or `/move`) with `destination` form field |
+
+| Method                                       | hlx6                                             | legacy DA                                                                                |
+| -------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| load / list / save / getMetadata / delete    | `${AEM_API}/{org}/sites/{site}/source{path}`     | `${DA_ADMIN}/source/{org}/{site}{path}`                                                  |
+| list (org-only)                  | n/a                                              | `${DA_ADMIN}/list/{org}`                                                                 |
+| list (with site, legacy)         | n/a                                              | `${DA_ADMIN}/list/{org}/{site}{path}`                                                    |
+| copy / move                      | PUT to dest URL with `?source=&collision=&move=` | POST to `${DA_ADMIN}/copy/{org}/{site}{path}` (or `/move`) with `destination` form field |
+
 
 ### Examples
 
 ```js
 // Read
-const resp = await source.get('/adobe/aem-boilerplate/index.html');
+const resp = await source.load('/adobe/aem-boilerplate/index.html');
 const html = await resp.text();
 
-// Write (path string + body extra)
-await source.put('/adobe/aem-boilerplate/page.html', { body: '<main>…</main>' });
+// Write (path string + data extra)
+await source.save('/adobe/aem-boilerplate/page.html', { data: '<main>…</main>' });
+
+// Upload a binary file (e.g., from <input type=file>)
+await source.save('/adobe/aem-boilerplate/img/logo.png', { data: file });
 
 // List a folder
 const list = await source.list('/adobe/aem-boilerplate/folder');
@@ -138,11 +147,13 @@ await source.copy({
 
 Document version history. Versions are document-scoped, so all methods take a `path`.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `list` | `({ org, site, path })` or `(fullPath)` | List versions. **hlx6**: `…/source{path}/.versions`. **DA**: `${DA_ADMIN}/versionlist/{org}/{site}{path}`. |
-| `get` | `({ org, site, path, versionId })` or `(fullPath, { versionId })` | Retrieve specific version content. **hlx6**: `versionId` is the ULID returned by `list`. **DA**: `versionId` is the trailing `{versionGuid}/{fileGuid}.{ext}` segment from the list response. |
-| `create` | `({ org, site, path, operation?, comment? })` or `(fullPath, { operation?, comment? })` | Create a version snapshot. **hlx6**: POSTs `{ operation, comment }` JSON body. **DA**: POSTs `{ label }` JSON body, with `comment` mapped to `label`. |
+
+| Method   | Signature                                                                               | Notes                                                                                                                                                                                         |
+| -------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list`   | `({ org, site, path })` or `(fullPath)`                                                 | List versions. **hlx6**: `…/source{path}/.versions`. **DA**: `${DA_ADMIN}/versionlist/{org}/{site}{path}`.                                                                                    |
+| `get`    | `({ org, site, path, versionId })` or `(fullPath, { versionId })`                       | Retrieve specific version content. **hlx6**: `versionId` is the ULID returned by `list`. **DA**: `versionId` is the trailing `{versionGuid}/{fileGuid}.{ext}` segment from the list response. |
+| `create` | `({ org, site, path, operation?, comment? })` or `(fullPath, { operation?, comment? })` | Create a version snapshot. **hlx6**: POSTs `{ operation, comment }` JSON body. **DA**: POSTs `{ label }` JSON body, with `comment` mapped to `label`.                                         |
+
 
 ### Example
 
@@ -163,19 +174,23 @@ const versions = await list.json();
 
 Org or site-level configuration JSON. The `site` argument is **optional** — omit it for org-level config.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `get` | `({ org, site? })` | Read |
-| `put` | `({ org, site?, body })` | Update. Sent as `multipart/form-data` with field `config`. **NOTE:** This wire shape currently doesn't match what the H5/H6 admin endpoints expect (JSON body) and may need realignment — see [Known issues](#known-issues). |
-| `delete` | `({ org, site? })` | DELETE |
-| `getAggregated` | `({ org, site })` | hlx6-only. Returns `{ error, status: 501 }` on legacy. Hits `${AEM_API}/{org}/aggregated/{site}/config.json`. |
+
+| Method          | Signature                | Notes                                                                                                                                                                                                                        |
+| --------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get`           | `({ org, site? })`       | Read                                                                                                                                                                                                                         |
+| `put`           | `({ org, site?, body })` | Update. Sent as `multipart/form-data` with field `config`. **NOTE:** This wire shape currently doesn't match what the H5/H6 admin endpoints expect (JSON body) and may need realignment — see [Known issues](#known-issues). |
+| `delete`        | `({ org, site? })`       | DELETE                                                                                                                                                                                                                       |
+| `getAggregated` | `({ org, site })`        | hlx6-only. Returns `{ error, status: 501 }` on legacy. Hits `${AEM_API}/{org}/aggregated/{site}/config.json`.                                                                                                                |
+
 
 ### URL shapes
 
-| | hlx6 | legacy DA |
-|---|---|---|
-| org-level | `${AEM_API}/{org}/config.json` | `${DA_ADMIN}/config/{org}/` |
+
+|            | hlx6                                        | legacy DA                          |
+| ---------- | ------------------------------------------- | ---------------------------------- |
+| org-level  | `${AEM_API}/{org}/config.json`              | `${DA_ADMIN}/config/{org}/`        |
 | site-level | `${AEM_API}/{org}/sites/{site}/config.json` | `${DA_ADMIN}/config/{org}/{site}/` |
+
 
 ### Example
 
@@ -197,9 +212,11 @@ if (agg.status === 501) {
 
 Organization-level operations. hlx6-only (no DA-legacy fallback exists at org level).
 
-| Method | Signature | Notes |
-|---|---|---|
+
+| Method      | Signature   | Notes                                                            |
+| ----------- | ----------- | ---------------------------------------------------------------- |
 | `listSites` | `({ org })` | GETs `${AEM_API}/{org}/sites`. Returns 404 on non-migrated orgs. |
+
 
 ---
 
@@ -207,15 +224,19 @@ Organization-level operations. hlx6-only (no DA-legacy fallback exists at org le
 
 Resource status (preview + live combined view). **Single-path only** — H6 has no bulk status endpoint.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `get` | `({ org, site, path })` or `(fullPath)` | GET `/status/{path}` |
+
+| Method | Signature                               | Notes                |
+| ------ | --------------------------------------- | -------------------- |
+| `get`  | `({ org, site, path })` or `(fullPath)` | GET `/status/{path}` |
+
 
 ### URL shapes
 
-| hlx6 | legacy |
-|---|---|
+
+| hlx6                                         | legacy                                        |
+| -------------------------------------------- | --------------------------------------------- |
 | `${AEM_API}/{org}/sites/{site}/status{path}` | `${HLX_ADMIN}/status/{org}/{site}/main{path}` |
+
 
 ### Example
 
@@ -232,34 +253,48 @@ Combined preview + live (publish) operations. The `path` argument can be a **str
 
 `forceUpdate` and `forceSync` are **bulk-only** — server ignores them on single-path calls.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `getPreview` | `({ org, site, path })` or `(fullPath)` | GET preview status (single only) |
-| `getPublish` | `({ org, site, path })` or `(fullPath)` | GET publish status (single only) |
-| `preview` | `({ org, site, path, forceUpdate?, forceSync? })` | string → POST `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, forceUpdate?, forceSync? }`. |
-| `unPreview` | `({ org, site, path })` | string → DELETE `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, delete: true }`. |
-| `publish` | `({ org, site, path, forceUpdate?, forceSync? })` | string → POST `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, forceUpdate?, forceSync? }`. |
-| `unPublish` | `({ org, site, path })` | string → DELETE `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, delete: true }`. |
+**Returns:** single-path methods default to **parsed JSON** (`returnJson: true`). Set `returnJson: false` for the raw `Response`. Bulk operations always return a `Response`.
+
+
+| Method       | Signature                                                              | Notes                                                                                                            |
+| ------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `getPreview` | `({ org, site, path, returnJson? })` or `(fullPath, { returnJson? })` | GET preview status (single only). Default: JSON; `undefined` if not ok.                                          |
+| `getPublish` | `({ org, site, path, returnJson? })` or `(fullPath, { returnJson? })` | GET publish status (single only). Default: JSON; `undefined` if not ok.                                          |
+| `preview`    | `({ org, site, path, forceUpdate?, forceSync?, returnJson? })`         | string → POST `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, forceUpdate?, forceSync? }`. |
+| `unPreview`  | `({ org, site, path, returnJson? })`                                   | string → DELETE `/preview/{path}`. Array of 2+ → POST `/preview/.../*` with `{ paths, delete: true }`.           |
+| `publish`    | `({ org, site, path, forceUpdate?, forceSync?, returnJson? })`         | string → POST `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, forceUpdate?, forceSync? }`.       |
+| `unPublish`  | `({ org, site, path, returnJson? })`                                   | string → DELETE `/live/{path}`. Array of 2+ → POST `/live/.../*` with `{ paths, delete: true }`.                 |
+
 
 ### URL shapes
 
-| | hlx6 | legacy |
-|---|---|---|
+
+|                     | hlx6                                                    | legacy                                                   |
+| ------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
 | preview / unPreview | `${AEM_API}/{org}/sites/{site}/preview{path}` (or `/*`) | `${HLX_ADMIN}/preview/{org}/{site}/main{path}` (or `/*`) |
-| publish / unPublish | `${AEM_API}/{org}/sites/{site}/live{path}` (or `/*`) | `${HLX_ADMIN}/live/{org}/{site}/main{path}` (or `/*`) |
+| publish / unPublish | `${AEM_API}/{org}/sites/{site}/live{path}` (or `/*`)    | `${HLX_ADMIN}/live/{org}/{site}/main{path}` (or `/*`)    |
+
 
 ### Examples
 
 ```js
-// Single preview
-await aem.preview('/adobe/aem-boilerplate/index.html');
+// Single preview — returns parsed JSON by default
+const previewJob = await aem.preview('/adobe/aem-boilerplate/index.html');
 
-// Bulk publish with extras
-await aem.publish({
+// Single preview — raw Response when you need headers/permissions
+const resp = await aem.preview('/adobe/aem-boilerplate/index.html', { returnJson: false });
+if (resp.ok) { /* … */ }
+
+// GET preview status (parsed JSON)
+const status = await aem.getPreview({ org, site, path: '/index.html' });
+
+// Bulk publish with extras — always returns Response
+const bulkResp = await aem.publish({
   org, site,
   path: ['/a.html', '/b.html', '/c.html'],
   forceUpdate: true,
 });
+const bulkJson = await bulkResp.json();
 
 // Bulk unpublish — body becomes { paths, delete: true }
 await aem.unPublish({ org, site, path: ['/old.html', '/legacy.html'] });
@@ -271,16 +306,18 @@ await aem.unPublish({ org, site, path: ['/old.html', '/legacy.html'] });
 
 Snapshot CRUD plus review/publish actions. Snapshots are AEM-only. New API uses plural `snapshots` in the URL; legacy uses singular `snapshot`.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `list` | `({ org, site })` | List all snapshots |
-| `get` | `({ org, site, snapshotId })` | Retrieve manifest |
-| `update` | `({ org, site, snapshotId, body? })` | POST manifest |
-| `delete` | `({ org, site, snapshotId })` | DELETE |
-| `addPath` | `({ org, site, snapshotId, path })` | string → POST `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths }`. |
-| `removePath` | `({ org, site, snapshotId, path })` | string → DELETE `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths, delete: true }`. |
-| `publish` | `({ org, site, snapshotId })` | POST `?publish=true` |
-| `review` | `({ org, site, snapshotId, action })` | POST `?review=…`. `action`: `'request'` \| `'approve'` \| `'reject'` |
+
+| Method       | Signature                             | Notes                                                                                                         |
+| ------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `list`       | `({ org, site })`                     | List all snapshots                                                                                            |
+| `get`        | `({ org, site, snapshotId })`         | Retrieve manifest                                                                                             |
+| `update`     | `({ org, site, snapshotId, body? })`  | POST manifest                                                                                                 |
+| `delete`     | `({ org, site, snapshotId })`         | DELETE                                                                                                        |
+| `addPath`    | `({ org, site, snapshotId, path })`   | string → POST `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths }`.                 |
+| `removePath` | `({ org, site, snapshotId, path })`   | string → DELETE `…/{snapshotId}{path}`. Array of 2+ → POST `…/{snapshotId}/*` with `{ paths, delete: true }`. |
+| `publish`    | `({ org, site, snapshotId })`         | POST `?publish=true`                                                                                          |
+| `review`     | `({ org, site, snapshotId, action })` | POST `?review=…`. `action`: `'request'` | `'approve'` | `'reject'`                                            |
+
 
 ### Example
 
@@ -302,18 +339,22 @@ await snapshot.publish({ org, site, snapshotId: 'snap-1' });
 
 Background job control.
 
-| Method | Signature | Notes |
-|---|---|---|
-| `get` | `({ org, site, topic, name? })` | Omit `name` to list jobs in the topic. |
-| `details` | `({ org, site, topic, name })` | GET on `…/details` — progress data |
-| `stop` | `({ org, site, topic, name })` | DELETE — stop a running job |
+
+| Method    | Signature                       | Notes                                  |
+| --------- | ------------------------------- | -------------------------------------- |
+| `get`     | `({ org, site, topic, name? })` | Omit `name` to list jobs in the topic. |
+| `details` | `({ org, site, topic, name })`  | GET on `…/details` — progress data     |
+| `stop`    | `({ org, site, topic, name })`  | DELETE — stop a running job            |
+
 
 ### URL shapes
 
-| | hlx6 | legacy |
-|---|---|---|
+
+|            | hlx6                                                | legacy                                                               |
+| ---------- | --------------------------------------------------- | -------------------------------------------------------------------- |
 | Single job | `${AEM_API}/{org}/sites/{site}/jobs/{topic}/{name}` | `${HLX_ADMIN}/job/{org}/{site}/main/{topic}/{name}` (singular `job`) |
-| Job list | `${AEM_API}/{org}/sites/{site}/jobs/{topic}` | `${HLX_ADMIN}/job/{org}/{site}/main/{topic}` |
+| Job list   | `${AEM_API}/{org}/sites/{site}/jobs/{topic}`        | `${HLX_ADMIN}/job/{org}/{site}/main/{topic}`                         |
+
 
 ### Example
 
@@ -377,14 +418,24 @@ if (!resp.ok) {
 const json = await resp.json();
 ```
 
+For `aem` single-path calls with the default `returnJson: true`, check for `undefined` instead of `resp.ok`:
+
+```js
+const data = await aem.getPreview({ org, site, path: '/index.html' });
+if (data === undefined) {
+  // non-ok or unparseable body
+  return;
+}
+```
+
 **Special return shapes:**
 
 - `daFetch` returns `{}` (empty object) when no IMS access token is available.
 - `config.getAggregated` returns `{ error: 'Requires Helix 6 upgrade', status: 501 }` when the site isn't hlx6.
 
-These are the **only** non-`Response` return values. All other methods always return a real `Response`.
+These are the **only** non-`Response` return values outside of `aem` single-path calls (which return parsed JSON or `undefined` by default). All other methods always return a real `Response`.
 
-**`console.error` on bad args:** when an invalid first argument is passed (missing `org`), the module logs a console error but doesn't throw — the bad call still flows through and produces a malformed URL that the server will reject. The console message is the only signal from the client side; rely on the server's response status for handling.
+`**console.error` on bad args:** when an invalid first argument is passed (missing `org`), the module logs a console error but doesn't throw — the bad call still flows through and produces a malformed URL that the server will reject. The console message is the only signal from the client side; rely on the server's response status for handling.
 
 ---
 
@@ -400,11 +451,11 @@ These are the **only** non-`Response` return values. All other methods always re
 
 These are not exported, but understanding them helps when reading the source.
 
-- **`getDaApiPath(api, org, site, path)`** — URL builder for endpoints DA proxies (`source`, `list`, `config`, `versions`). Branches on `isHlx6` to choose `DA_ADMIN` or `AEM_API`.
-- **`getAemApiPath(api, org, site, path)`** — URL builder for AEM-only endpoints (`status`, `preview`, `live`, `snapshots`, `jobs`). Branches on `isHlx6` to choose `HLX_ADMIN` (with hardcoded `ref=main`) or `AEM_API`.
-- **`withArgs(fn)`** — HOF that resolves the first arg (object or path string) and forwards a normalized `{ org, site, path, ...extras }` object to `fn`. Handles the bad-arg `console.error` for missing org.
-- **`callPath({ api, org, site, path, method, … })`** — Dispatcher used by `aem.*` methods. Handles the string-vs-array branching for bulk preview/publish operations and folds `forceUpdate`/`forceSync` into the bulk JSON body.
-- **`jsonOpts(method, payload)`** — small helper that builds `{ method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }`.
+- `**getDaApiPath(api, org, site, path)`** — URL builder for endpoints DA proxies (`source`, `list`, `config`, `versions`). Branches on `isHlx6` to choose `DA_ADMIN` or `AEM_API`.
+- `**getAemApiPath(api, org, site, path)**` — URL builder for AEM-only endpoints (`status`, `preview`, `live`, `snapshots`, `jobs`). Branches on `isHlx6` to choose `HLX_ADMIN` (with hardcoded `ref=main`) or `AEM_API`.
+- `**withArgs(fn)**` — HOF that resolves the first arg (object or path string) and forwards a normalized `{ org, site, path, ...extras }` object to `fn`. Handles the bad-arg `console.error` for missing org.
+- `**callPath({ api, org, site, path, method, … })**` — Dispatcher used by `aem.*` methods. Handles the string-vs-array branching for bulk preview/publish operations, folds `forceUpdate`/`forceSync` into the bulk JSON body, and on single-path calls parses JSON when `returnJson` is true (default).
+- `**jsonOpts(method, payload)**` — small helper that builds `{ method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) }`.
 
 ---
 
@@ -412,20 +463,26 @@ These are not exported, but understanding them helps when reading the source.
 
 Imported from `./utils.js`:
 
-| Constant | Value | Used for |
-|---|---|---|
-| `DA_ADMIN` | `https://admin.da.live` (env-aware) | DA admin origin |
-| `HLX_ADMIN` | `https://admin.hlx.page` | Legacy AEM admin |
-| `AEM_API` | `https://api.aem.live` | New AEM admin (hlx6) |
-| `ALLOWED_TOKEN` | array of origins | Auth header allowlist |
+
+| Constant        | Value                               | Used for              |
+| --------------- | ----------------------------------- | --------------------- |
+| `DA_ADMIN`      | `https://admin.da.live` (env-aware) | DA admin origin       |
+| `HLX_ADMIN`     | `https://admin.hlx.page`            | Legacy AEM admin      |
+| `AEM_API`       | `https://api.aem.live`              | New AEM admin (hlx6)  |
+| `ALLOWED_TOKEN` | array of origins                    | Auth header allowlist |
+
 
 Defined locally:
 
-| Constant | Value | Used for |
-|---|---|---|
-| `REF` | `'main'` | Hardcoded ref for legacy AEM URLs |
-| `STORAGE_KEY` | `'hlx6-upgrade'` | localStorage key for hlx6 cache |
-| `TEXT_TYPES` | `{ '.html': 'text/html', '.json': 'application/json' }` | Content-Type sniffing for `source.put` on hlx6 |
+
+| Constant      | Value                                              | Used for                                        |
+| ------------- | -------------------------------------------------- | ----------------------------------------------- |
+| `REF`         | `'main'`                                           | Hardcoded ref for legacy AEM URLs               |
+| `STORAGE_KEY` | `'hlx6-upgrade'`                                   | localStorage key for hlx6 cache                 |
+| `TYPE_MAP`    | extension → MIME map (see below)                   | Content-Type sniffing for `source.save` on hlx6 |
+
+`TYPE_MAP` entries: `.html` → `text/html`, `.json` → `application/json`, `.link` → `application/json`, `.svg` → `image/svg+xml`, `.ico` → `image/x-icon`, `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `image/png`, `.gif` → `image/gif`, `.mp4` → `video/mp4`, `.pdf` → `application/pdf`.
+
 
 ---
 
@@ -433,14 +490,14 @@ Defined locally:
 
 These are tracked but not yet resolved. They don't block typical usage; flagged here for completeness.
 
-- **`config.put` wire shape**: currently sends `multipart/form-data` with field `config`. The H5/H6 admin endpoints actually expect raw JSON body. DA's exact requirement is undocumented; existing da-live tests assert PUT instead of POST. Needs verification against running servers.
-- **`forceSync` field name**: the H6 server source reads `forceAsync` (with inverse meaning), not `forceSync`. Currently sending `forceSync: true` is silently ignored by the server. This affects the `aem.preview`/`aem.publish` bulk paths and `start/index.js` in da-live.
+- `**config.put` wire shape**: currently sends `multipart/form-data` with field `config`. The H5/H6 admin endpoints actually expect raw JSON body. DA's exact requirement is undocumented; existing da-live tests assert PUT instead of POST. Needs verification against running servers.
+- `**forceSync` field name**: the H6 server source reads `forceAsync` (with inverse meaning), not `forceSync`. Currently sending `forceSync: true` is silently ignored by the server. This affects the `aem.preview`/`aem.publish` bulk paths and `start/index.js` in da-live.
 
 ---
 
 ## Testing
 
-Tests live in [`test/nx2/utils/api.test.js`](../../test/nx2/utils/api.test.js). Pattern: stub `window.fetch` with a recording fake, call the method, assert URL/method/body/headers.
+Tests live in `[test/nx2/utils/api.test.js](../../test/nx2/utils/api.test.js)`. Pattern: stub `window.fetch` with a recording fake, call the method, assert URL/method/body/headers.
 
 ```js
 window.fetch = async (url, opts = {}) => {

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -154,18 +154,18 @@ describe('api.js', () => {
   });
 
   describe('source', () => {
-    it('source.get hits DA on legacy', async () => {
+    it('source.load hits DA on legacy', async () => {
       const { org: o, site: s } = makeOrgSite();
       // Trigger a ping fetch by querying — it returns no upgrade header → legacy
-      await source.get({ org: o, site: s, path: '/index.html' });
+      await source.load({ org: o, site: s, path: '/index.html' });
       const last = lastCall();
       expect(last.url).to.equal(`${DA_ADMIN}/source/${o}/${s}/index.html`);
       expect(last.method).to.equal('GET');
     });
 
-    it('source.get hits AEM_API on hlx6', async () => {
+    it('source.load hits AEM_API on hlx6', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.get({ org: o, site: s, path: '/index.html' });
+      await source.load({ org: o, site: s, path: '/index.html' });
       expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/index.html`);
     });
 
@@ -193,31 +193,58 @@ describe('api.js', () => {
       expect(lastCall().url).to.equal(`${DA_ADMIN}/list/${o}`);
     });
 
-    it('source.put DA wraps body in FormData', async () => {
+    it('source.list forwards opts (e.g., pagination headers) to fetch', async () => {
       const { org: o, site: s } = makeOrgSite();
-      const body = new Blob(['<html></html>'], { type: 'text/html' });
-      await source.put({ org: o, site: s, path: '/page.html', body });
+      await source.list({
+        org: o,
+        site: s,
+        path: '/folder',
+        opts: { headers: { 'da-continuation-token': 'tok-1' } },
+      });
+      expect(lastCall().headers['da-continuation-token']).to.equal('tok-1');
+    });
+
+    it('source.save DA wraps data in FormData', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      const data = new Blob(['<html></html>'], { type: 'text/html' });
+      await source.save({ org: o, site: s, path: '/page.html', data });
       const last = lastCall();
       expect(last.method).to.equal('POST');
       expect(last.body).to.be.instanceof(FormData);
       const stored = last.body.get('data');
       expect(stored).to.be.instanceof(Blob);
-      expect(stored.size).to.equal(body.size);
+      expect(stored.size).to.equal(data.size);
     });
 
-    it('source.put hlx6 sets Content-Type for known text exts', async () => {
+    it('source.save hlx6 sets Content-Type for known text exts', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.put({ org: o, site: s, path: '/page.html', body: '<main></main>' });
+      await source.save({ org: o, site: s, path: '/page.html', data: '<main></main>' });
       const last = lastCall();
       expect(last.method).to.equal('POST');
       expect(last.headers['Content-Type']).to.equal('text/html');
       expect(last.body).to.equal('<main></main>');
     });
 
-    it('source.put hlx6 passes body as-is for non-text exts', async () => {
+    it('source.save hlx6 sets image Content-Type and preserves binary Blob body', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
       const blob = new Blob(['binary'], { type: 'image/png' });
-      await source.put({ org: o, site: s, path: '/img.png', body: blob });
+      await source.save({ org: o, site: s, path: '/img.png', data: blob });
+      const last = lastCall();
+      expect(last.headers['Content-Type']).to.equal('image/png');
+      // Blob passes through untouched — no UTF-8 decoding that would corrupt binary.
+      expect(last.body).to.equal(blob);
+    });
+
+    it('source.save hlx6 maps .link to application/json', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      await source.save({ org: o, site: s, path: '/foo.link', data: '{"externalUrl":"https://x"}' });
+      expect(lastCall().headers['Content-Type']).to.equal('application/json');
+    });
+
+    it('source.save hlx6 omits Content-Type for unknown extensions', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const blob = new Blob(['payload']);
+      await source.save({ org: o, site: s, path: '/file.xyz', data: blob });
       const last = lastCall();
       expect(last.headers['Content-Type']).to.be.undefined;
       expect(last.body).to.equal(blob);
@@ -275,15 +302,15 @@ describe('api.js', () => {
       expect(last.body.get('destination')).to.equal('/dest.html');
     });
 
-    it('source.get accepts a full /org/site/path string', async () => {
+    it('source.load accepts a full /org/site/path string', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.get(`/${o}/${s}/index.html`);
+      await source.load(`/${o}/${s}/index.html`);
       expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/source/index.html`);
     });
 
-    it('source.put accepts a path string with extras', async () => {
+    it('source.save accepts a path string with extras', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.put(`/${o}/${s}/page.html`, { body: '<main></main>' });
+      await source.save(`/${o}/${s}/page.html`, { data: '<main></main>' });
       const last = lastCall();
       expect(last.url).to.equal(`${AEM_API}/${o}/sites/${s}/source/page.html`);
       expect(last.body).to.equal('<main></main>');
@@ -301,12 +328,12 @@ describe('api.js', () => {
       expect(u.searchParams.get('collision')).to.equal('overwrite');
     });
 
-    it('source.get logs an error when org is missing', async () => {
+    it('source.load logs an error when org is missing', async () => {
       const origErr = console.error;
       let errored = false;
       console.error = () => { errored = true; };
       try {
-        await source.get('');
+        await source.load('');
       } finally {
         console.error = origErr;
       }
@@ -548,6 +575,36 @@ describe('api.js', () => {
       await aem.getPublish({ org: o, site: s, path: '/x' });
       expect(lastCall().url).to.equal(`${AEM_API}/${o}/sites/${s}/live/x`);
       expect(lastCall().method).to.equal('GET');
+    });
+
+    it('aem.getPreview returns parsed JSON by default', async () => {
+      restoreFetch();
+      installFetch({ body: '{"state":"complete"}' });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await aem.getPreview({ org: o, site: s, path: '/x' });
+      expect(result).to.deep.equal({ state: 'complete' });
+    });
+
+    it('aem.getPreview returns undefined when response is not ok', async () => {
+      restoreFetch();
+      installFetch({ status: 404 });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await aem.getPreview({ org: o, site: s, path: '/x' });
+      expect(result).to.equal(undefined);
+    });
+
+    it('aem.getPreview returns Response when returnJson is false', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await aem.getPreview({ org: o, site: s, path: '/x', returnJson: false });
+      expect(result).to.have.property('ok', true);
+      expect(result.permissions).to.deep.equal(['read', 'write']);
+    });
+
+    it('aem.preview bulk returns Response even with returnJson default', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await aem.preview({ org: o, site: s, path: ['/a', '/b'] });
+      expect(result).to.have.property('ok', true);
+      expect(result.permissions).to.deep.equal(['read', 'write']);
     });
   });
 

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -5,7 +5,6 @@ import {
   daFetch,
   isHlx6,
   signout,
-  hlx6ToDaList,
   fromPath,
   source,
   versions,
@@ -204,6 +203,59 @@ describe('api.js', () => {
       expect(lastCall().headers['da-continuation-token']).to.equal('tok-1');
     });
 
+    it('source.list returns { ok, items, continuationToken, permissions } with legacy items normalized', async () => {
+      restoreFetch();
+      installFetch({
+        body: JSON.stringify([
+          { path: '/o/s/folder/page.html', name: 'page', ext: 'html', lastModified: 1 },
+        ]),
+        headers: { 'da-continuation-token': 'tok-next' },
+      });
+      const { org: o, site: s } = makeOrgSite();
+      const result = await source.list({ org: o, site: s, path: '/folder' });
+      expect(result.ok).to.equal(true);
+      expect(result.items).to.have.length(1);
+      expect(result.items[0]).to.deep.equal({
+        path: '/o/s/folder/page.html', name: 'page', ext: 'html', lastModified: 1,
+      });
+      expect(result.continuationToken).to.equal('tok-next');
+      expect(result.permissions).to.deep.equal(['read', 'write']);
+    });
+
+    it('source.list normalizes hlx6 items via hlx6ToDaList using the parent path', async () => {
+      restoreFetch();
+      installFetch({
+        // Make every non-ping fetch (including the source listing) return this body.
+        // The hlx6 ping response (empty body, no upgrade header) keeps isHlx6 false…
+        // so to exercise the hlx6 branch we use a pre-cached site.
+        body: JSON.stringify([
+          { name: 'demo.json', size: 1, 'content-type': 'application/json', 'last-modified': '2026-05-03T19:05:03.000Z' },
+          { name: 'sub/', 'content-type': 'application/folder' },
+        ]),
+      });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const result = await source.list({ org: o, site: s, path: '/parent' });
+      expect(result.ok).to.equal(true);
+      expect(result.items).to.have.length(2);
+      const file = result.items.find((i) => i.name === 'demo');
+      expect(file.ext).to.equal('json');
+      expect(file.path).to.equal(`/${o}/${s}/parent/demo.json`);
+      expect(file.lastModified).to.equal(new Date('2026-05-03T19:05:03.000Z').getTime());
+      const folder = result.items.find((i) => i.name === 'sub');
+      expect(folder.ext).to.be.undefined;
+      expect(folder.path).to.equal(`/${o}/${s}/parent/sub`);
+    });
+
+    it('source.list returns { ok: false, items: [] } on non-ok response', async () => {
+      restoreFetch();
+      installFetch({ status: 403, body: '' });
+      const { org: o, site: s } = makeOrgSite();
+      const result = await source.list({ org: o, site: s, path: '/folder' });
+      expect(result.ok).to.equal(false);
+      expect(result.items).to.deep.equal([]);
+      expect(result.continuationToken).to.equal(null);
+    });
+
     it('source.save DA wraps data in FormData', async () => {
       const { org: o, site: s } = makeOrgSite();
       const data = new Blob(['<html></html>'], { type: 'text/html' });
@@ -250,16 +302,50 @@ describe('api.js', () => {
       expect(last.body).to.equal(blob);
     });
 
-    it('source.getMetadata sends HEAD', async () => {
+    it('source.getMetadata sends HEAD and returns { ok, status, headers }', async () => {
+      restoreFetch();
+      installFetch({ status: 200, headers: { 'last-modified': 'Mon, 01 Jan 2025 00:00:00 GMT' } });
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.getMetadata({ org: o, site: s, path: '/x.html' });
+      const result = await source.getMetadata({ org: o, site: s, path: '/x.html' });
       expect(lastCall().method).to.equal('HEAD');
+      expect(result.ok).to.equal(true);
+      expect(result.status).to.equal(200);
+      expect(result.headers.get('last-modified')).to.equal('Mon, 01 Jan 2025 00:00:00 GMT');
     });
 
-    it('source.delete sends DELETE', async () => {
+    it('source.getMetadata returns ok:false on 404', async () => {
+      restoreFetch();
+      installFetch({ status: 404 });
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.delete({ org: o, site: s, path: '/x.html' });
+      const result = await source.getMetadata({ org: o, site: s, path: '/missing' });
+      expect(result.ok).to.equal(false);
+      expect(result.status).to.equal(404);
+    });
+
+    it('source.delete sends DELETE and returns { ok, status, continuationToken: null } on 204', async () => {
+      restoreFetch();
+      // 204 is a null-body status; Response constructor rejects a non-null body.
+      installFetch({ status: 204, body: null });
+      const { org: o, site: s } = makeOrgSite();
+      const result = await source.delete({ org: o, site: s, path: '/x.html' });
       expect(lastCall().method).to.equal('DELETE');
+      expect(result).to.deep.equal({ ok: true, status: 204, continuationToken: null });
+    });
+
+    it('source.delete returns continuationToken from response body when paginated', async () => {
+      restoreFetch();
+      installFetch({ status: 200, body: JSON.stringify({ continuationToken: 'tok-next' }) });
+      const { org: o, site: s } = makeOrgSite();
+      const result = await source.delete({ org: o, site: s, path: '/folder' });
+      expect(result.ok).to.equal(true);
+      expect(result.continuationToken).to.equal('tok-next');
+    });
+
+    it('source.delete forwards continuationToken arg as query param', async () => {
+      const { org: o, site: s } = makeOrgSite();
+      await source.delete({ org: o, site: s, path: '/folder', continuationToken: 'prev-tok' });
+      const u = new URL(lastCall().url);
+      expect(u.searchParams.get('continuation-token')).to.equal('prev-tok');
     });
 
     it('source.copy hlx6 PUTs with source/collision query params', async () => {
@@ -735,37 +821,6 @@ describe('api.js', () => {
         site: 'site',
         path: '',
       });
-    });
-  });
-
-  describe('hlx6ToDaList', () => {
-    it('passes through items without content-type unchanged', () => {
-      const items = [{ name: 'foo', path: '/foo' }];
-      expect(hlx6ToDaList('/parent', items)).to.deep.equal(items);
-    });
-
-    it('strips trailing slash for folders', () => {
-      const result = hlx6ToDaList('/parent', [
-        { name: 'subfolder/', 'content-type': 'application/folder' },
-      ]);
-      expect(result[0].name).to.equal('subfolder');
-      expect(result[0].path).to.equal('/parent/subfolder');
-    });
-
-    it('extracts ext and strips it from display name', () => {
-      const result = hlx6ToDaList('/parent', [
-        { name: 'page.html', 'content-type': 'text/html' },
-      ]);
-      expect(result[0].name).to.equal('page');
-      expect(result[0].ext).to.equal('html');
-      expect(result[0].path).to.equal('/parent/page.html');
-    });
-
-    it('converts last-modified to unix timestamp', () => {
-      const result = hlx6ToDaList('/parent', [
-        { name: 'x.html', 'content-type': 'text/html', 'last-modified': '2025-01-01T00:00:00.000Z' },
-      ]);
-      expect(result[0].lastModified).to.equal(new Date('2025-01-01T00:00:00.000Z').getTime());
     });
   });
 

--- a/test/utils/tree.test.js
+++ b/test/utils/tree.test.js
@@ -313,6 +313,38 @@ describe('getChildren (via crawl)', () => {
     expect(files.length).to.equal(0);
   });
 
+  it('Normalizes hlx6 list response (content-type entries with trailing-slash folders)', async () => {
+    // hlx6 returns a bare array where files have content-type/last-modified/size
+    // and folders are entries whose name ends with `/`.
+    const hlx6Response = [
+      { name: 'demo-sheet-two.json', size: 114, 'content-type': 'application/json', 'last-modified': '2026-05-03T19:05:03.000Z' },
+      { name: 'chrisp/', 'content-type': 'application/folder' },
+    ];
+    window.fetch = async (url) => {
+      // Only the root path returns items; recursed folder is empty.
+      const isRoot = !url.includes('/chrisp');
+      return {
+        ok: true,
+        json: async () => (isRoot ? hlx6Response : []),
+        headers: { get: () => null },
+      };
+    };
+
+    const { results } = crawl({
+      path: '/aem-sandbox/block-collection/drafts',
+      callback: null,
+      concurrent: 10,
+      throttle: 10,
+    });
+
+    const files = await results;
+    expect(files).to.have.length(1);
+    expect(files[0].name).to.equal('demo-sheet-two');
+    expect(files[0].ext).to.equal('json');
+    expect(files[0].path).to.equal('/aem-sandbox/block-collection/drafts/demo-sheet-two.json');
+    expect(files[0].lastModified).to.equal(new Date('2026-05-03T19:05:03.000Z').getTime());
+  });
+
   it('Batches list results using da-continuation-token when >1000 children', async () => {
     const page1 = [
       { path: '/big/file1.html', name: 'file1', ext: 'html', lastModified: 1753691701858 },


### PR DESCRIPTION
Normalize source api returns and parse status JSON
- source.list/delete/copy/move/getMetadata now return normalized
  objects ({ ok, items?, continuationToken?, headers? }) instead of
  raw Response, hiding hlx6 vs legacy shape differences and exposing
  pagination via continuationToken.
- status.get parses JSON and returns undefined on non-ok/unparseable.
- Rename source.get->load and source.put->save.
- Update api.d.ts and api.md sidecars and tests to match.
