### PR TITLE
fix(shared): guard customElements.define to prevent double-registration

### DIFF
--- a/nx2/blocks/shared/breadcrumb/breadcrumb.js
+++ b/nx2/blocks/shared/breadcrumb/breadcrumb.js
@@ -39,4 +39,4 @@ export default class NxBreadcrumb extends LitElement {
   }
 }
 
-customElements.define('nx-breadcrumb', NxBreadcrumb);
+if (!customElements.get('nx-breadcrumb')) customElements.define('nx-breadcrumb', NxBreadcrumb);

--- a/nx2/blocks/shared/dialog/dialog.js
+++ b/nx2/blocks/shared/dialog/dialog.js
@@ -65,4 +65,4 @@ class NxDialog extends LitElement {
   }
 }
 
-customElements.define('nx-dialog', NxDialog);
+if (!customElements.get('nx-dialog')) customElements.define('nx-dialog', NxDialog);

--- a/nx2/blocks/shared/menu/menu.js
+++ b/nx2/blocks/shared/menu/menu.js
@@ -142,4 +142,4 @@ class NxMenu extends LitElement {
   }
 }
 
-customElements.define('nx-menu', NxMenu);
+if (!customElements.get('nx-menu')) customElements.define('nx-menu', NxMenu);

--- a/nx2/blocks/shared/picker/picker.js
+++ b/nx2/blocks/shared/picker/picker.js
@@ -186,4 +186,4 @@ class NxPicker extends LitElement {
   }
 }
 
-customElements.define('nx-picker', NxPicker);
+if (!customElements.get('nx-picker')) customElements.define('nx-picker', NxPicker);

--- a/nx2/blocks/shared/popover/popover.js
+++ b/nx2/blocks/shared/popover/popover.js
@@ -149,4 +149,4 @@ class NxPopover extends LitElement {
   }
 }
 
-customElements.define('nx-popover', NxPopover);
+if (!customElements.get('nx-popover')) customElements.define('nx-popover', NxPopover);

--- a/nx2/blocks/shared/toast/toast.js
+++ b/nx2/blocks/shared/toast/toast.js
@@ -102,4 +102,4 @@ export function showToast({ text, variant = VARIANT_SUCCESS, timeout = 6000 } = 
   ensureHost().append(toast);
 }
 
-customElements.define('nx-toast', NxToast);
+if (!customElements.get('nx-toast')) customElements.define('nx-toast', NxToast);

--- a/nx2/test/unit/nx/blocks/shared/custom-element-guard.test.js
+++ b/nx2/test/unit/nx/blocks/shared/custom-element-guard.test.js
@@ -1,0 +1,43 @@
+import { expect } from '@esm-bundle/chai';
+
+const COMPONENTS = [
+  { name: 'nx-popover', path: '../../../../../blocks/shared/popover/popover.js' },
+  { name: 'nx-menu', path: '../../../../../blocks/shared/menu/menu.js' },
+  { name: 'nx-picker', path: '../../../../../blocks/shared/picker/picker.js' },
+  { name: 'nx-breadcrumb', path: '../../../../../blocks/shared/breadcrumb/breadcrumb.js' },
+  { name: 'nx-dialog', path: '../../../../../blocks/shared/dialog/dialog.js' },
+  { name: 'nx-toast', path: '../../../../../blocks/shared/toast/toast.js' },
+];
+
+describe('shared component define guards', () => {
+  for (const { name, path } of COMPONENTS) {
+    describe(name, () => {
+      it('registers the element when not already defined', async () => {
+        if (customElements.get(name)) return;
+        await import(path);
+        expect(customElements.get(name)).to.exist;
+      });
+
+      it('does not throw when the element is already registered', async () => {
+        const existing = customElements.get(name);
+        if (!existing) {
+          customElements.define(name, class extends HTMLElement {});
+        }
+        let threw = false;
+        try {
+          await import(`${path}?guard=${Date.now()}`);
+        } catch (e) {
+          threw = true;
+        }
+        expect(threw).to.be.false;
+      });
+
+      it('preserves the first registered class', async () => {
+        const registered = customElements.get(name);
+        expect(registered).to.exist;
+        await import(`${path}?preserve=${Date.now()}`);
+        expect(customElements.get(name)).to.equal(registered);
+      });
+    });
+  }
+});

--- a/nx2/test/unit/nx/scripts/nx.test.js
+++ b/nx2/test/unit/nx/scripts/nx.test.js
@@ -353,6 +353,19 @@ describe('loadBlock', () => {
     expect(config.log.called).to.be.true;
   });
 
+  it('strips only the first segment as provider prefix for multi-hyphen names', async () => {
+    const block = document.createElement('div');
+    block.classList.add('custom-skills-editor');
+
+    try {
+      await loadBlock(block);
+    } catch {
+      // Expected to fail in test environment
+    }
+
+    expect(block.dataset.blockName).to.equal('skills-editor');
+  });
+
   it('returns the block element', async () => {
     const block = document.createElement('div');
     block.classList.add('test');


### PR DESCRIPTION
Provider-loaded blocks import their own copies of shared components from a different origin. ES module caching is per-URL, so the browser treats them as distinct modules and define() fires twice, crashing with NotSupportedError. The guard skips registration when the element name is already taken.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/
