### PR TITLE
fix: prompt filtering and fallback label

### DIFF
--- a/nx2/blocks/chat/prompts/prompts.js
+++ b/nx2/blocks/chat/prompts/prompts.js
@@ -15,9 +15,11 @@ class NxPrompts extends LitElement {
     _category: { state: true },
   };
 
-  _search = '';
-
-  _category = ALL_CATEGORY;
+  constructor() {
+    super();
+    this._search = '';
+    this._category = ALL_CATEGORY;
+  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/nx2/blocks/chat/welcome/welcome.js
+++ b/nx2/blocks/chat/welcome/welcome.js
@@ -36,7 +36,7 @@ class NxChatWelcome extends LitElement {
           ${prompts.slice(0, 3).map((card) => html`
             <button class="prompt-card" @click=${() => this.onSend?.(card.prompt)}>
               <svg class="prompt-card-icon" viewBox="0 0 20 20" aria-hidden="true"><use href="${codeBase}/img/icons/s2-icon-aichat-20-n.svg#icon"></use></svg>
-              <span class="prompt-card-description">${card.description}</span>
+              <span class="prompt-card-description">${card.description ?? card.title}</span>
             </button>
           `)}
         </div>


### PR DESCRIPTION
Fixes prompt issue raised in https://adobe.enterprise.slack.com/docs/T02CAQ0B2/F0B5EPXCAHZ

Details: _"Configured prompts don't have a title/description, and the full menu doesn't filter. The UI should be probably be picking up the title from the prompts sheet?"_


Preview at https://da.live/canvas?nx=ew-chat&nxver=2#/exp-workspace/frescopa/index
