### PR TITLE
fix(nx2): restore NX_BLOCKS routing for blocks under /nx

### DIFF
--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -12,6 +12,8 @@
 
 const LOG = async (ex, el) => (await import('../utils/error.js')).default(ex, el);
 
+const NX_BLOCKS = new Set(['importer']);
+
 const EW_ORIGINS = {
   dev: 'http://localhost:3001',
   stage: 'https://main--ew-extensions--adobe-rnd.aem.page',
@@ -109,7 +111,7 @@ export async function loadBlock(block) {
   const isNx = name.startsWith('nx-');
   if (isNx) {
     name = name.replace('nx-', '');
-    path = `${nxBase}/blocks`;
+    path = NX_BLOCKS.has(name) ? '/nx/blocks' : `${nxBase}/blocks`;
   } else {
     const prefix = name.split('-')[0];
     const provider = providers[prefix];

--- a/nx2/test/unit/nx/scripts/nx.test.js
+++ b/nx2/test/unit/nx/scripts/nx.test.js
@@ -366,6 +366,24 @@ describe('loadBlock', () => {
     expect(block.dataset.blockName).to.equal('skills-editor');
   });
 
+  it('routes nx- blocks in NX_BLOCKS to /nx/blocks', async () => {
+    const block = document.createElement('div');
+    block.classList.add('nx-importer');
+
+    await loadBlock(block);
+
+    expect(block.dataset.blockName).to.equal('importer');
+  });
+
+  it('routes other nx- blocks to nxBase/blocks', async () => {
+    const block = document.createElement('div');
+    block.classList.add('nx-sidenav');
+
+    await loadBlock(block);
+
+    expect(block.dataset.blockName).to.equal('sidenav');
+  });
+
   it('returns the block element', async () => {
     const block = document.createElement('div');
     block.classList.add('test');


### PR DESCRIPTION
## Summary
- Re-add `NX_BLOCKS` set so `nx-importer` resolves to `/nx/blocks/` instead of `/nx2/blocks/`
- Preserve the provider-based `loadBlock` architecture introduced in #446
- Add tests for legacy and standard `nx-` block routing

## Why
- PR #446 removed the old `NX_BLOCKS` set when refactoring `loadBlock` for provider support
- The importer block still lives at `/nx/blocks/importer/` (no nx2 port yet)
- Without the routing escape hatch, `nx-importer` resolves to `/nx2/blocks/importer/importer.js` which doesn't exist — breaking the import app

## What Changed
- **`nx2/scripts/nx.js`** — added `NX_BLOCKS = new Set(['importer'])`. In `loadBlock`, the `isNx` branch now checks this set: entries route to `/nx/blocks`, everything else routes to `nxBase/blocks` as before.
- **`nx2/test/unit/nx/scripts/nx.test.js`** — two new tests: `nx-importer` routes to `/nx/blocks`, `nx-sidenav` routes to `nxBase/blocks`.

## Test Plan
- [x] `npm test` — 997 pass, 2 pre-existing flaky failures unrelated to this change
- [ ] Local: visit a page with `nx-importer` block → verify it loads from `/nx/blocks/importer/importer.js`
- [ ] Verify other `nx-` blocks (e.g. `nx-sidenav`) still resolve to `/nx2/blocks/`

## Risks / Follow-ups
- No impact on provider routing (`ew-*`, `custom-*`) which takes a separate code path
