### PR TITLE
refactor(utils): centralize DA_AGENT URL via env resolver

### DIFF
--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -2,10 +2,9 @@ import { loadIms } from '../../utils/ims.js';
 import { AGENT_EVENT, ROLE, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
 import { loadMessages, saveMessages, resetSession } from './persistence.js';
+import { DA_AGENT } from '../../utils/utils.js';
 
-const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
-  ? 'http://localhost:4200/chat'
-  : 'https://agent.da.live/chat';
+const AGENT_URL = `${DA_AGENT}/chat`;
 
 export default class ChatController {
   constructor({ onUpdate, onToolDone }) {

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -40,6 +40,14 @@ const DA_LIVE_PREVIEW_ENVS = {
   prod: 'https://preview.da.live',
 };
 
+const DA_AGENT_ENVS = {
+  local: 'http://localhost:4002',
+  dev: 'http://localhost:4002',
+  stage: 'https://agent.da.live',
+  ci: 'https://da-agent-ci.adobeaem.workers.dev',
+  prod: 'https://agent.da.live',
+};
+
 const DA_ETC_ENVS = {
   dev: 'http://localhost:8787',
   prod: 'https://da-etc.adobeaem.workers.dev',
@@ -61,6 +69,7 @@ export const DA_ADMIN = getEnv('da-admin', DA_ADMIN_ENVS);
 export const DA_COLLAB = getEnv('da-collab', DA_COLLAB_ENVS);
 export const DA_CONTENT = getEnv('da-content', DA_CONTENT_ENVS);
 export const DA_PREVIEW = getEnv('da-preview', DA_LIVE_PREVIEW_ENVS);
+export const DA_AGENT = getEnv('da-agent', DA_AGENT_ENVS);
 export const DA_ETC = getEnv('da-etc', DA_ETC_ENVS);
 
 export const HLX_ADMIN = 'https://admin.hlx.page';
@@ -68,6 +77,7 @@ export const AEM_API = 'https://api.aem.live';
 
 export const ALLOWED_TOKEN = [
   DA_ADMIN,
+  DA_AGENT,
   DA_COLLAB,
   DA_CONTENT,
   DA_PREVIEW,


### PR DESCRIPTION
Adds DA_AGENT to the shared getEnv-based service resolver so the agent URL follows the same ?da-agent=local / ?da-agent=ci / ?da-agent=prod convention as DA_ADMIN, DA_COLLAB, DA_CONTENT, etc.

Previously chat-controller.js hardcoded the agent URL with a ?ref=local ternary that pointed to port 4200 (out of date with the actual da-agent dev port 4002), causing repeated confusion when running the chat against the local agent. The centralized resolver eliminates the port mismatch and keeps service URLs in one place.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

