### PR TITLE
# fix(chat): strip orphaned tool-call messages before sending to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ helix-importer-ui
 *.bak
 .idea
 .claude/settings.local.json
+PR-throwaways/

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -6,6 +6,33 @@ import { DA_AGENT } from '../../utils/utils.js';
 
 const AGENT_URL = `${DA_AGENT}/chat`;
 
+/**
+ * Drop assistant array-content messages whose tool-call IDs have no matching
+ * tool-result anywhere in the history. These orphans appear when the agent's
+ * streamText step-limit fires mid-tool-execution or when the client strips
+ * virtual (non-approval) tool results. Without this filter the Anthropic API
+ * rejects the request with "tool_use ids without tool_result blocks".
+ */
+function stripOrphanedToolCallMessages(messages) {
+  const resolvedIds = new Set();
+  for (const msg of messages) {
+    if (msg.role === ROLE.TOOL && Array.isArray(msg.content)) {
+      for (const p of msg.content) {
+        if (p.type === AGENT_EVENT.TOOL_RESULT && p.toolCallId) resolvedIds.add(p.toolCallId);
+      }
+    }
+  }
+
+  return messages.filter((msg) => {
+    if (msg.role !== ROLE.ASSISTANT || !Array.isArray(msg.content)) return true;
+    const calls = msg.content.filter((p) => p.type === AGENT_EVENT.TOOL_CALL);
+    if (calls.length === 0) return true;
+    const hasApproval = msg.content.some((p) => p.type === AGENT_EVENT.TOOL_APPROVAL_REQUEST);
+    if (hasApproval) return true;
+    return calls.every((c) => resolvedIds.has(c.toolCallId));
+  });
+}
+
 export default class ChatController {
   constructor({ onUpdate, onToolDone }) {
     this._onUpdate = onUpdate;
@@ -37,15 +64,7 @@ export default class ChatController {
     const { messages: cached, sessionId } = await loadMessages(room);
     this._sessionId = sessionId ?? this._sessionId;
     if (!cached.length) return;
-    // Strip orphaned tool-calls (assistant array-content without a tool-approval-request).
-    // These are from sessions before the current fix — they have no matching tool-result
-    // and cause "Tool result is missing". Complete approval sequences are kept so users
-    // see what the agent approved and did in prior conversations.
-    this._messages = cached.filter(
-      (msg) => !(msg.role === ROLE.ASSISTANT && Array.isArray(msg.content)
-        && !msg.virtual
-        && !msg.content.some((p) => p.type === AGENT_EVENT.TOOL_APPROVAL_REQUEST)),
-    );
+    this._messages = stripOrphanedToolCallMessages(cached);
     // Reconstruct tool cards from persisted approval messages so they render on reload.
     this._toolCards = new Map();
     for (const msg of this._messages) {
@@ -219,7 +238,7 @@ export default class ChatController {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        messages: this._messages.filter((msg) => !msg.virtual),
+        messages: stripOrphanedToolCallMessages(this._messages.filter((msg) => !msg.virtual)),
         pageContext,
         imsToken: accessToken?.token ?? null,
         room,

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -2,10 +2,9 @@ import { loadIms } from '../../utils/ims.js';
 import { AGENT_EVENT, ROLE, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
 import { loadMessages, saveMessages, resetSession } from './persistence.js';
+import { DA_AGENT } from '../../utils/utils.js';
 
-const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
-  ? 'http://localhost:4200/chat'
-  : 'https://agent.da.live/chat';
+const AGENT_URL = `${DA_AGENT}/chat`;
 
 export default class ChatController {
   constructor({ onUpdate, onToolDone }) {

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -2,9 +2,10 @@ import { loadIms } from '../../utils/ims.js';
 import { AGENT_EVENT, ROLE, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
 import { loadMessages, saveMessages, resetSession } from './persistence.js';
-import { DA_AGENT } from '../../utils/utils.js';
 
-const AGENT_URL = `${DA_AGENT}/chat`;
+const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
+  ? 'http://localhost:4200/chat'
+  : 'https://agent.da.live/chat';
 
 /**
  * Drop assistant array-content messages whose tool-call IDs have no matching

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -40,6 +40,14 @@ const DA_LIVE_PREVIEW_ENVS = {
   prod: 'https://preview.da.live',
 };
 
+const DA_AGENT_ENVS = {
+  local: 'http://localhost:4002',
+  dev: 'http://localhost:4002',
+  stage: 'https://agent.da.live',
+  ci: 'https://da-agent-ci.adobeaem.workers.dev',
+  prod: 'https://agent.da.live',
+};
+
 const DA_ETC_ENVS = {
   dev: 'http://localhost:8787',
   prod: 'https://da-etc.adobeaem.workers.dev',
@@ -61,6 +69,7 @@ export const DA_ADMIN = getEnv('da-admin', DA_ADMIN_ENVS);
 export const DA_COLLAB = getEnv('da-collab', DA_COLLAB_ENVS);
 export const DA_CONTENT = getEnv('da-content', DA_CONTENT_ENVS);
 export const DA_PREVIEW = getEnv('da-preview', DA_LIVE_PREVIEW_ENVS);
+export const DA_AGENT = getEnv('da-agent', DA_AGENT_ENVS);
 export const DA_ETC = getEnv('da-etc', DA_ETC_ENVS);
 
 export const HLX_ADMIN = 'https://admin.hlx.page';
@@ -68,6 +77,7 @@ export const AEM_API = 'https://api.aem.live';
 
 export const ALLOWED_TOKEN = [
   DA_ADMIN,
+  DA_AGENT,
   DA_COLLAB,
   DA_CONTENT,
   DA_PREVIEW,

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -40,14 +40,6 @@ const DA_LIVE_PREVIEW_ENVS = {
   prod: 'https://preview.da.live',
 };
 
-const DA_AGENT_ENVS = {
-  local: 'http://localhost:4002',
-  dev: 'http://localhost:4002',
-  stage: 'https://agent.da.live',
-  ci: 'https://da-agent-ci.adobeaem.workers.dev',
-  prod: 'https://agent.da.live',
-};
-
 const DA_ETC_ENVS = {
   dev: 'http://localhost:8787',
   prod: 'https://da-etc.adobeaem.workers.dev',
@@ -69,7 +61,6 @@ export const DA_ADMIN = getEnv('da-admin', DA_ADMIN_ENVS);
 export const DA_COLLAB = getEnv('da-collab', DA_COLLAB_ENVS);
 export const DA_CONTENT = getEnv('da-content', DA_CONTENT_ENVS);
 export const DA_PREVIEW = getEnv('da-preview', DA_LIVE_PREVIEW_ENVS);
-export const DA_AGENT = getEnv('da-agent', DA_AGENT_ENVS);
 export const DA_ETC = getEnv('da-etc', DA_ETC_ENVS);
 
 export const HLX_ADMIN = 'https://admin.hlx.page';
@@ -77,7 +68,6 @@ export const AEM_API = 'https://api.aem.live';
 
 export const ALLOWED_TOKEN = [
   DA_ADMIN,
-  DA_AGENT,
   DA_COLLAB,
   DA_CONTENT,
   DA_PREVIEW,


### PR DESCRIPTION
# fix(chat): strip orphaned tool-call messages before sending to agent

## Summary
- Client-side defense against the Anthropic "tool_use ids without tool_result" rejection
- Replaces the old blanket filter (which nuked all non-approval tool-call messages) with a precise ID-matching approach that only drops genuinely orphaned ones

## Why
- The Anthropic API rejects any request where a `tool_use` block has no corresponding `tool_result` in the immediately following message
- Orphans appear when `streamText` hits its step-limit mid-tool-execution, or when the client strips virtual (non-approval) tool results from persisted history
- The previous filter was overly aggressive — it stripped all assistant array-content messages without an approval request, which hid legitimate completed tool calls from the conversation on reload

## What Changed
- **`nx2/blocks/chat/chat-controller.js`**
  - Added `stripOrphanedToolCallMessages()` — collects all resolved `toolCallId`s from `tool-result` messages, then drops any assistant message whose tool-call IDs are not in that set (unless it contains an approval request, which is resolved server-side)
  - Applied in `loadInitialMessages()` (cached history on page load) and `_stream()` (outbound payload to the agent) so orphans never reach the API
- **`.gitignore`** — added `PR-throwaways/`

## Test Plan
- [ ] Trigger a multi-tool skill (e.g. translate) and verify tool-call / approval / result flow works end-to-end
- [ ] Kill/restart the agent mid-tool-execution, reload, and confirm the chat recovers without the "tool_use ids" error
- [ ] Verify that completed approval sequences still render correctly on page reload (not stripped by the new filter)
- [ ] Run `npm test` in da-nx and confirm existing tests pass

## Risks / Follow-ups
- Depends on the `refactor/centralize-agent-url` PR (for the `DA_AGENT` import in chat-controller)
- The server-side counterpart (`ensureOrphanedToolResults` in da-agent) is a separate PR — together they form defense-in-depth, but each is independently sufficient
- If the approval-request check in `stripOrphanedToolCallMessages` ever gets out of sync with da-agent's `resolveApprovals`, approval messages could be incorrectly dropped — low risk since both use the same `TOOL_APPROVAL_REQUEST` constant
