### PR TITLE
fix: add scope to agent change event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ helix-importer-ui
 *.bak
 .idea
 .claude/settings.local.json
+.cursor/*

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -1,5 +1,5 @@
 import { loadIms } from '../../utils/ims.js';
-import { AGENT_EVENT, ROLE, TOOL_NAME, TOOL_STATE } from './constants.js';
+import { AGENT_EVENT, ROLE, TOOL_NAME, TOOL_SCOPE, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
 import { loadMessages, saveMessages, resetSession } from './persistence.js';
 
@@ -215,6 +215,8 @@ export default class ChatController {
     if (approved) {
       try {
         await this._stream(this._pageContextForAgent());
+        const scope = TOOL_SCOPE[card.toolName];
+        if (scope) this._onToolDone?.(scope, affectedFolders(card.toolName, card.input));
       } catch (err) {
         if (err.name !== 'AbortError') {
           this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: `Error: ${err.message}` }];

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -1,7 +1,22 @@
 import { loadIms } from '../../utils/ims.js';
-import { AGENT_EVENT, ROLE, TOOL_STATE } from './constants.js';
+import { AGENT_EVENT, ROLE, TOOL_NAME, TOOL_STATE } from './constants.js';
 import { readStream } from './utils.js';
 import { loadMessages, saveMessages, resetSession } from './persistence.js';
+
+function affectedFolders(toolName, input) {
+  const { org, repo } = input ?? {};
+  if (!org || !repo) return [];
+  const toParent = (p) => {
+    const parts = (p ?? '').replace(/^\//, '').split('/').filter(Boolean);
+    parts.pop();
+    return `/${org}/${repo}${parts.length ? `/${parts.join('/')}` : ''}`;
+  };
+  if (toolName === TOOL_NAME.CONTENT_MOVE) {
+    return [...new Set([toParent(input.sourcePath), toParent(input.destinationPath)])];
+  }
+  if (toolName === TOOL_NAME.CONTENT_COPY) return [toParent(input.destinationPath)];
+  return input.path ? [toParent(input.path)] : [];
+}
 
 const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
   ? 'http://localhost:4200/chat'
@@ -114,7 +129,7 @@ export default class ChatController {
   }
 
   _onToolEvent = ({
-    type, toolCallId, toolName, input, output, isError, approvalId,
+    type, toolCallId, toolName, input, output, isError, approvalId, scope,
   }) => {
     const next = new Map(this._toolCards ?? []);
 
@@ -165,7 +180,7 @@ export default class ChatController {
             }],
           },
         ];
-        this._onToolDone?.();
+        this._onToolDone?.(scope, affectedFolders(toolName, prior.input));
       }
     }
 

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -161,8 +161,12 @@ class NxChat extends LitElement {
     this.shadowRoot.adoptedStyleSheets = [styles];
 
     this._controller = new ChatController({
-      onToolDone: () => {
-        this.dispatchEvent(new CustomEvent('nx-agent-change', { bubbles: true, composed: true }));
+      onToolDone: (scope, paths) => {
+        this.dispatchEvent(new CustomEvent('nx-agent-change', {
+          bubbles: true,
+          composed: true,
+          detail: { scope, paths },
+        }));
       },
       onUpdate: ({ messages, thinking, streamingText, connected, toolCards }) => {
         this.messages = streamingText

--- a/nx2/blocks/chat/constants.js
+++ b/nx2/blocks/chat/constants.js
@@ -48,6 +48,19 @@ const TOOL_STATE = {
 };
 
 /**
+ * Tool names emitted by da-agent — part of the agent-client contract.
+ * TODO: move to @da/agent-types once the agent team can publish one.
+ */
+const TOOL_NAME = {
+  CONTENT_CREATE: 'content_create',
+  CONTENT_DELETE: 'content_delete',
+  CONTENT_COPY: 'content_copy',
+  CONTENT_MOVE: 'content_move',
+  CONTENT_UPDATE: 'content_update',
+  CONTENT_UPLOAD: 'content_upload',
+};
+
+/**
  * Input field names used in tool approval summary rendering.
  * These are da-agent tool input schema field names — part of the agent-client contract.
  * TODO: move to @da/agent-types once the agent team can publish one.
@@ -61,6 +74,15 @@ const TOOL_INPUT = {
   NAME: 'name',
 };
 
+const TOOL_SCOPE = {
+  [TOOL_NAME.CONTENT_CREATE]: 'file',
+  [TOOL_NAME.CONTENT_DELETE]: 'file',
+  [TOOL_NAME.CONTENT_COPY]: 'file',
+  [TOOL_NAME.CONTENT_MOVE]: 'file',
+  [TOOL_NAME.CONTENT_UPDATE]: 'document',
+  [TOOL_NAME.CONTENT_UPLOAD]: 'document',
+};
+
 const ROLE = {
   USER: 'user',
   ASSISTANT: 'assistant',
@@ -68,5 +90,12 @@ const ROLE = {
 };
 
 export {
-  ADD_MENU_ITEMS, AGENT_EVENT, CHAT_ICONS, MENU_OPTIONS, ROLE, TOOL_INPUT, TOOL_STATE,
+  ADD_MENU_ITEMS,
+  AGENT_EVENT,
+  CHAT_ICONS,
+  MENU_OPTIONS,
+  ROLE, TOOL_INPUT,
+  TOOL_NAME,
+  TOOL_SCOPE,
+  TOOL_STATE,
 };

--- a/nx2/blocks/chat/utils.js
+++ b/nx2/blocks/chat/utils.js
@@ -1,4 +1,4 @@
-import { AGENT_EVENT as EVENT } from './constants.js';
+import { AGENT_EVENT as EVENT, TOOL_SCOPE } from './constants.js';
 
 function processEvent(event, streaming, callbacks) {
   const { onDelta, onText, onTool } = callbacks;
@@ -43,6 +43,7 @@ function processEvent(event, streaming, callbacks) {
       toolName: event.toolName,
       output: raw,
       isError,
+      scope: !isError ? TOOL_SCOPE[event.toolName] : undefined,
     });
   }
 


### PR DESCRIPTION
- Adds scope of change ie file or document level + affected folder paths to the agent change event

Preview: https://ew-event--da-live--adobe.aem.live/canvas?nx=ew-event&nxver=2#/exp-workspace/frescopa/index 

Fixes: [SITES-45681: Tool ↔ UI refresh eventing](https://jira.corp.adobe.com/browse/SITES-45681)
