### PR TITLE
# feat(shared): promote nx-card and nx-tabs to nx2/blocks/shared

### DIFF
--- a/nx2/blocks/shared/card/card.css
+++ b/nx2/blocks/shared/card/card.css
@@ -1,0 +1,86 @@
+:host {
+  display: block;
+  font-family: var(--s2-font-family);
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-100);
+  padding: var(--s2-spacing-75) var(--s2-spacing-100);
+  border: 1px solid var(--s2-gray-200);
+  border-radius: var(--s2-corner-radius-200);
+  background: light-dark(var(--s2-gray-25), var(--s2-gray-50));
+  transition: border-color 0.15s, background 0.15s;
+  user-select: none;
+}
+
+:host([selected]) .card {
+  border-color: var(--s2-blue-900);
+  background: light-dark(var(--s2-blue-100), var(--s2-blue-200));
+}
+
+:host([interactive]) .card {
+  cursor: pointer;
+}
+
+:host([interactive]) .card:hover {
+  border-color: var(--s2-gray-400);
+  background: light-dark(var(--s2-gray-50), var(--s2-gray-75));
+}
+
+/* ─── left pill/badge slot ───────────────────────────────────────────────── */
+
+.card-pill {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--s2-corner-radius-200);
+  background: var(--s2-gray-200);
+  font-size: 10px;
+  font-weight: var(--s2-heading-font-weight);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── body ───────────────────────────────────────────────────────────────── */
+
+.card-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.card-heading {
+  font-size: var(--s2-body-size-s);
+  font-weight: var(--s2-heading-font-weight);
+  color: var(--s2-gray-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-subheading {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── actions / checkbox slot ────────────────────────────────────────────── */
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-50);
+  flex-shrink: 0;
+}

--- a/nx2/blocks/shared/card/card.css
+++ b/nx2/blocks/shared/card/card.css
@@ -1,4 +1,13 @@
 :host {
+  /* tmp: pill badge dimensions — no s2 sizing token for fixed icon/badge sizes */
+  --_card-pill-size: 1.75rem;
+  /* tmp: badge font — intentionally smaller than --s2-body-size-xs */
+  --_card-pill-font-size: 10px;
+  /* tmp: sub-pixel gap between heading and subheading lines */
+  --_card-body-gap: 1px;
+  /* tmp: hover/selection transition — no s2 motion token in this codebase */
+  --_card-transition-duration: 0.15s;
+
   display: block;
   font-family: var(--s2-font-family);
 }
@@ -11,7 +20,7 @@
   border: 1px solid var(--s2-gray-200);
   border-radius: var(--s2-corner-radius-200);
   background: light-dark(var(--s2-gray-25), var(--s2-gray-50));
-  transition: border-color 0.15s, background 0.15s;
+  transition: border-color var(--_card-transition-duration), background var(--_card-transition-duration);
   user-select: none;
 }
 
@@ -36,11 +45,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--_card-pill-size);
+  height: var(--_card-pill-size);
   border-radius: var(--s2-corner-radius-200);
   background: var(--s2-gray-200);
-  font-size: 10px;
+  font-size: var(--_card-pill-font-size);
   font-weight: var(--s2-heading-font-weight);
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -55,7 +64,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--_card-body-gap);
   min-width: 0;
 }
 

--- a/nx2/blocks/shared/card/card.js
+++ b/nx2/blocks/shared/card/card.js
@@ -1,3 +1,26 @@
+/**
+ * `<nx-card>` — minimal Spectrum 2 card primitive for list views.
+ *
+ * Properties (attributes):
+ *   - `heading` (String): primary text line; omitted from render when unset.
+ *   - `subheading` (String): secondary text line; omitted from render when unset.
+ *   - `pill` (String): label rendered inside the leading badge. When set to a
+ *     non-empty string it takes precedence over the `pill` slot; when unset or
+ *     empty, the `<slot name="pill">` is exposed instead. Only one of the two
+ *     ever renders.
+ *   - `selected` (Boolean, reflected): renders the selected visual state.
+ *   - `interactive` (Boolean, reflected): cursor + hover affordance.
+ *
+ * Slots:
+ *   - default: card body content (below subheading).
+ *   - `name="pill"`: custom badge content; ignored when `pill` attribute is set.
+ *   - `name="actions"`: trailing controls (icon buttons, checkboxes).
+ *
+ * Events: none — the component is purely presentational. Consumers handle
+ * clicks/keys on the host or via `actions` slot children.
+ *
+ * Shadow parts: `card`, `pill`, `heading`, `subheading`.
+ */
 import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle } from '../../../utils/utils.js';
 
@@ -18,12 +41,12 @@ class NxCard extends LitElement {
   }
 
   render() {
+    const hasPill = typeof this.pill === 'string' && this.pill.length > 0;
     return html`
       <div class="card" part="card">
-        ${this.pill !== undefined
+        ${hasPill
           ? html`<div class="card-pill" part="pill">${this.pill}</div>`
-          : nothing}
-        <slot name="pill"></slot>
+          : html`<slot name="pill"></slot>`}
         <div class="card-body">
           ${this.heading
             ? html`<span class="card-heading" part="heading">${this.heading}</span>`
@@ -41,4 +64,4 @@ class NxCard extends LitElement {
   }
 }
 
-customElements.define('nx-card', NxCard);
+if (!customElements.get('nx-card')) customElements.define('nx-card', NxCard);

--- a/nx2/blocks/shared/card/card.js
+++ b/nx2/blocks/shared/card/card.js
@@ -1,0 +1,44 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+
+const styles = await loadStyle(import.meta.url);
+
+class NxCard extends LitElement {
+  static properties = {
+    heading: { type: String },
+    subheading: { type: String },
+    pill: { type: String },
+    selected: { type: Boolean, reflect: true },
+    interactive: { type: Boolean, reflect: true },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [styles];
+  }
+
+  render() {
+    return html`
+      <div class="card" part="card">
+        ${this.pill !== undefined
+          ? html`<div class="card-pill" part="pill">${this.pill}</div>`
+          : nothing}
+        <slot name="pill"></slot>
+        <div class="card-body">
+          ${this.heading
+            ? html`<span class="card-heading" part="heading">${this.heading}</span>`
+            : nothing}
+          ${this.subheading
+            ? html`<span class="card-subheading" part="subheading">${this.subheading}</span>`
+            : nothing}
+          <slot></slot>
+        </div>
+        <div class="card-actions">
+          <slot name="actions"></slot>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('nx-card', NxCard);

--- a/nx2/blocks/shared/tabs/tabs.css
+++ b/nx2/blocks/shared/tabs/tabs.css
@@ -1,0 +1,54 @@
+:host {
+  display: block;
+  font-family: var(--s2-font-family);
+}
+
+.tabs {
+  display: flex;
+  gap: var(--s2-spacing-50);
+  border-bottom: 1px solid var(--s2-gray-200);
+  padding: 0 var(--s2-spacing-100);
+}
+
+.tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--s2-spacing-100) var(--s2-spacing-200);
+  border: none;
+  border-radius: var(--s2-corner-radius-200) var(--s2-corner-radius-200) 0 0;
+  background: none;
+  color: var(--s2-gray-700);
+  font-family: inherit;
+  font-size: var(--s2-body-size-s);
+  font-weight: var(--s2-heading-font-weight);
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+  transition: color 0.15s;
+}
+
+.tab:hover {
+  color: var(--s2-gray-900);
+  background: var(--s2-gray-100);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--s2-blue-900);
+  outline-offset: -2px;
+}
+
+.tab.is-active {
+  color: var(--s2-blue-900);
+}
+
+.tab.is-active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: var(--s2-spacing-100);
+  right: var(--s2-spacing-100);
+  height: 2px;
+  background: var(--s2-blue-900);
+  border-radius: 1px;
+}

--- a/nx2/blocks/shared/tabs/tabs.css
+++ b/nx2/blocks/shared/tabs/tabs.css
@@ -1,4 +1,15 @@
 :host {
+  /* tmp: tab hover/active transition — no s2 motion token in this codebase */
+  --_tabs-transition-duration: 0.15s;
+  /* tmp: active indicator bleeds 1px to overlap the bottom border */
+  --_tabs-indicator-bleed: -1px;
+  /* tmp: active indicator height and border-radius */
+  --_tabs-indicator-height: 2px;
+  --_tabs-indicator-radius: 1px;
+  /* tmp: focus outline width */
+  --_tabs-focus-outline-width: 2px;
+  --_tabs-focus-outline-offset: -2px;
+
   display: block;
   font-family: var(--s2-font-family);
 }
@@ -25,7 +36,7 @@
   cursor: pointer;
   outline: none;
   white-space: nowrap;
-  transition: color 0.15s;
+  transition: color var(--_tabs-transition-duration);
 }
 
 .tab:hover {
@@ -34,8 +45,8 @@
 }
 
 .tab:focus-visible {
-  outline: 2px solid var(--s2-blue-900);
-  outline-offset: -2px;
+  outline: var(--_tabs-focus-outline-width) solid var(--s2-blue-900);
+  outline-offset: var(--_tabs-focus-outline-offset);
 }
 
 .tab.is-active {
@@ -45,10 +56,10 @@
 .tab.is-active::after {
   content: '';
   position: absolute;
-  bottom: -1px;
+  bottom: var(--_tabs-indicator-bleed);
   left: var(--s2-spacing-100);
   right: var(--s2-spacing-100);
-  height: 2px;
+  height: var(--_tabs-indicator-height);
   background: var(--s2-blue-900);
-  border-radius: 1px;
+  border-radius: var(--_tabs-indicator-radius);
 }

--- a/nx2/blocks/shared/tabs/tabs.js
+++ b/nx2/blocks/shared/tabs/tabs.js
@@ -1,12 +1,38 @@
+/**
+ * `<nx-tabs>` — accessible tab navigation primitive.
+ *
+ * Properties:
+ *   - `items` (Array<{ id: string, label: string }>): tab definitions. Setting
+ *     this property triggers a render; mutating the array in place will NOT.
+ *   - `active` (String, reflected): id of the active tab. Auto-defaults to
+ *     `items[0].id` when missing OR when the current value is not present in
+ *     the new `items` list.
+ *   - `label` (String): value used as `aria-label` on the tablist. Defaults to
+ *     `"Navigation tabs"` when unset; override for localised contexts.
+ *
+ * Events:
+ *   - `tab-change` (bubbles, composed): fired on click or keyboard activation.
+ *     Detail: `{ id: string }`. Not fired when the active tab is reactivated.
+ *
+ * Keyboard model (matches WAI-ARIA tablist pattern):
+ *   - ArrowRight / ArrowLeft cycle through tabs with wrap.
+ *   - Home / End jump to first / last tab.
+ *   - Focus follows selection; disconnect-safe (focus call no-ops if removed).
+ *
+ * Shadow part: `tab`.
+ */
 import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle } from '../../../utils/utils.js';
 
 const styles = await loadStyle(import.meta.url);
 
+const DEFAULT_TABLIST_LABEL = 'Navigation tabs';
+
 class NxTabs extends LitElement {
   static properties = {
     items: { attribute: false },
     active: { type: String, reflect: true },
+    label: { type: String },
   };
 
   connectedCallback() {
@@ -15,8 +41,10 @@ class NxTabs extends LitElement {
   }
 
   updated(changed) {
-    if (changed.has('items') && this.items?.length && !this.active) {
-      this.active = this.items[0].id;
+    if (!changed.has('items') || !this.items?.length) return;
+    const ids = this.items.map((i) => i.id);
+    if (!ids.includes(this.active)) {
+      [this.active] = ids;
     }
   }
 
@@ -28,6 +56,12 @@ class NxTabs extends LitElement {
       bubbles: true,
       composed: true,
     }));
+  }
+
+  _focusTab(id) {
+    if (!this.isConnected || !this.shadowRoot) return;
+    const [btn] = this.shadowRoot.querySelectorAll(`[data-id="${CSS.escape(id)}"]`);
+    btn?.focus();
   }
 
   _onKeydown(e) {
@@ -49,17 +83,21 @@ class NxTabs extends LitElement {
     }
 
     e.preventDefault();
-    this._select(ids[nextIdx]);
-    this.updateComplete.then(() => {
-      this.shadowRoot.querySelector(`[data-id="${CSS.escape(ids[nextIdx])}"]`)?.focus();
-    });
+    const nextId = ids[nextIdx];
+    this._select(nextId);
+    this.updateComplete.then(() => this._focusTab(nextId));
   }
 
   render() {
     if (!this.items?.length) return nothing;
 
     return html`
-      <div class="tabs" role="tablist" aria-label="Navigation tabs" @keydown=${this._onKeydown}>
+      <div
+        class="tabs"
+        role="tablist"
+        aria-label=${this.label || DEFAULT_TABLIST_LABEL}
+        @keydown=${this._onKeydown}
+      >
         ${this.items.map((item) => html`
           <button
             role="tab"
@@ -77,4 +115,4 @@ class NxTabs extends LitElement {
   }
 }
 
-customElements.define('nx-tabs', NxTabs);
+if (!customElements.get('nx-tabs')) customElements.define('nx-tabs', NxTabs);

--- a/nx2/blocks/shared/tabs/tabs.js
+++ b/nx2/blocks/shared/tabs/tabs.js
@@ -1,0 +1,80 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+
+const styles = await loadStyle(import.meta.url);
+
+class NxTabs extends LitElement {
+  static properties = {
+    items: { attribute: false },
+    active: { type: String, reflect: true },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [styles];
+  }
+
+  updated(changed) {
+    if (changed.has('items') && this.items?.length && !this.active) {
+      this.active = this.items[0].id;
+    }
+  }
+
+  _select(id) {
+    if (id === this.active) return;
+    this.active = id;
+    this.dispatchEvent(new CustomEvent('tab-change', {
+      detail: { id },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _onKeydown(e) {
+    const ids = this.items?.map((i) => i.id) ?? [];
+    if (!ids.length) return;
+    const curIdx = ids.indexOf(this.active);
+
+    let nextIdx;
+    if (e.key === 'ArrowRight') {
+      nextIdx = (curIdx + 1) % ids.length;
+    } else if (e.key === 'ArrowLeft') {
+      nextIdx = (curIdx <= 0 ? ids.length : curIdx) - 1;
+    } else if (e.key === 'Home') {
+      nextIdx = 0;
+    } else if (e.key === 'End') {
+      nextIdx = ids.length - 1;
+    } else {
+      return;
+    }
+
+    e.preventDefault();
+    this._select(ids[nextIdx]);
+    this.updateComplete.then(() => {
+      this.shadowRoot.querySelector(`[data-id="${CSS.escape(ids[nextIdx])}"]`)?.focus();
+    });
+  }
+
+  render() {
+    if (!this.items?.length) return nothing;
+
+    return html`
+      <div class="tabs" role="tablist" aria-label="Navigation tabs" @keydown=${this._onKeydown}>
+        ${this.items.map((item) => html`
+          <button
+            role="tab"
+            part="tab"
+            type="button"
+            class="tab ${item.id === this.active ? 'is-active' : ''}"
+            data-id=${item.id}
+            aria-selected=${item.id === this.active ? 'true' : 'false'}
+            tabindex=${item.id === this.active ? '0' : '-1'}
+            @click=${() => this._select(item.id)}
+          >${item.label}</button>
+        `)}
+      </div>
+    `;
+  }
+}
+
+customElements.define('nx-tabs', NxTabs);

--- a/nx2/test/unit/blocks/shared/card/card.test.js
+++ b/nx2/test/unit/blocks/shared/card/card.test.js
@@ -1,0 +1,72 @@
+import { expect } from '@esm-bundle/chai';
+import '../../../../../blocks/shared/card/card.js';
+
+async function createCard(props = {}, slots = {}) {
+  const el = document.createElement('nx-card');
+  Object.entries(props).forEach(([k, v]) => {
+    if (typeof v === 'boolean') {
+      if (v) el.setAttribute(k, '');
+      else el.removeAttribute(k);
+    } else if (v !== undefined && v !== null) {
+      el.setAttribute(k, v);
+    }
+  });
+  if (slots.default) el.append(slots.default);
+  if (slots.actions) {
+    const node = slots.actions;
+    node.setAttribute?.('slot', 'actions');
+    el.append(node);
+  }
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function q(el, selector) {
+  return el.shadowRoot.querySelector(selector);
+}
+
+describe('nx-card', () => {
+  afterEach(() => {
+    document.body.querySelectorAll('nx-card').forEach((el) => el.remove());
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('nx-card')).to.exist;
+  });
+
+  it('renders heading and subheading text when provided', async () => {
+    const el = await createCard({ heading: 'My Skill', subheading: 'description here' });
+    expect(q(el, '.card-heading')?.textContent.trim()).to.equal('My Skill');
+    expect(q(el, '.card-subheading')?.textContent.trim()).to.equal('description here');
+  });
+
+  it('omits heading and subheading when not provided', async () => {
+    const el = await createCard();
+    expect(q(el, '.card-heading')).to.be.null;
+    expect(q(el, '.card-subheading')).to.be.null;
+  });
+
+  it('renders the pill when the pill attribute is set', async () => {
+    const el = await createCard({ pill: 'NEW' });
+    expect(q(el, '.card-pill')?.textContent.trim()).to.equal('NEW');
+  });
+
+  it('reflects boolean attributes selected and interactive', async () => {
+    const el = await createCard({ selected: true, interactive: true });
+    expect(el.hasAttribute('selected')).to.be.true;
+    expect(el.hasAttribute('interactive')).to.be.true;
+  });
+
+  it('exposes default, pill, and actions slots', async () => {
+    const child = document.createElement('div');
+    child.className = 'inner';
+    child.textContent = 'body content';
+    const action = document.createElement('button');
+    action.textContent = 'Edit';
+    const el = await createCard({ heading: 'Card' }, { default: child, actions: action });
+    const slots = el.shadowRoot.querySelectorAll('slot');
+    const slotNames = [...slots].map((s) => s.getAttribute('name') || 'default');
+    expect(slotNames).to.include.members(['default', 'pill', 'actions']);
+  });
+});

--- a/nx2/test/unit/blocks/shared/card/card.test.js
+++ b/nx2/test/unit/blocks/shared/card/card.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import '../../../../../blocks/shared/card/card.js';
 
+const created = [];
+
 async function createCard(props = {}, slots = {}) {
   const el = document.createElement('nx-card');
   Object.entries(props).forEach(([k, v]) => {
@@ -14,10 +16,18 @@ async function createCard(props = {}, slots = {}) {
   if (slots.default) el.append(slots.default);
   if (slots.actions) {
     const node = slots.actions;
-    node.setAttribute?.('slot', 'actions');
+    if (!node.setAttribute) throw new TypeError('actions slot requires an Element');
+    node.setAttribute('slot', 'actions');
+    el.append(node);
+  }
+  if (slots.pill) {
+    const node = slots.pill;
+    if (!node.setAttribute) throw new TypeError('pill slot requires an Element');
+    node.setAttribute('slot', 'pill');
     el.append(node);
   }
   document.body.appendChild(el);
+  created.push(el);
   await el.updateComplete;
   return el;
 }
@@ -28,7 +38,7 @@ function q(el, selector) {
 
 describe('nx-card', () => {
   afterEach(() => {
-    document.body.querySelectorAll('nx-card').forEach((el) => el.remove());
+    while (created.length) created.pop().remove();
   });
 
   it('registers the custom element', () => {
@@ -52,13 +62,36 @@ describe('nx-card', () => {
     expect(q(el, '.card-pill')?.textContent.trim()).to.equal('NEW');
   });
 
+  it('does NOT render a pill badge when the pill attribute is an empty string', async () => {
+    const el = await createCard({ pill: '' });
+    expect(q(el, '.card-pill')).to.be.null;
+  });
+
+  it('does NOT render a pill badge when the pill attribute is unset', async () => {
+    const el = await createCard();
+    expect(q(el, '.card-pill')).to.be.null;
+  });
+
+  it('exposes a named pill slot when the pill attribute is unset', async () => {
+    const el = await createCard();
+    expect(q(el, 'slot[name="pill"]')).to.exist;
+  });
+
+  it('hides the pill slot when the pill attribute takes precedence', async () => {
+    const pillNode = document.createElement('span');
+    pillNode.textContent = 'SLOTTED';
+    const el = await createCard({ pill: 'ATTR' }, { pill: pillNode });
+    expect(q(el, '.card-pill')?.textContent.trim()).to.equal('ATTR');
+    expect(q(el, 'slot[name="pill"]')).to.be.null;
+  });
+
   it('reflects boolean attributes selected and interactive', async () => {
     const el = await createCard({ selected: true, interactive: true });
     expect(el.hasAttribute('selected')).to.be.true;
     expect(el.hasAttribute('interactive')).to.be.true;
   });
 
-  it('exposes default, pill, and actions slots', async () => {
+  it('exposes default and actions slots', async () => {
     const child = document.createElement('div');
     child.className = 'inner';
     child.textContent = 'body content';
@@ -67,6 +100,11 @@ describe('nx-card', () => {
     const el = await createCard({ heading: 'Card' }, { default: child, actions: action });
     const slots = el.shadowRoot.querySelectorAll('slot');
     const slotNames = [...slots].map((s) => s.getAttribute('name') || 'default');
-    expect(slotNames).to.include.members(['default', 'pill', 'actions']);
+    expect(slotNames).to.include.members(['default', 'actions']);
+  });
+
+  it('guards customElements.define against double registration', () => {
+    expect(() => customElements.define('nx-card', class extends HTMLElement {})).to.throw();
+    expect(customElements.get('nx-card')).to.exist;
   });
 });

--- a/nx2/test/unit/blocks/shared/tabs/tabs.test.js
+++ b/nx2/test/unit/blocks/shared/tabs/tabs.test.js
@@ -7,11 +7,15 @@ const ITEMS = [
   { id: 'prompts', label: 'Prompts' },
 ];
 
-async function createTabs(items = ITEMS, active = undefined) {
+const created = [];
+
+async function createTabs(items = ITEMS, active = undefined, label = undefined) {
   const el = document.createElement('nx-tabs');
   el.items = items;
   if (active !== undefined) el.active = active;
+  if (label !== undefined) el.label = label;
   document.body.appendChild(el);
+  created.push(el);
   await el.updateComplete;
   return el;
 }
@@ -20,9 +24,14 @@ function buttons(el) {
   return [...el.shadowRoot.querySelectorAll('button[role="tab"]')];
 }
 
+function pressKey(el, key) {
+  const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+  tablist.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
 describe('nx-tabs', () => {
   afterEach(() => {
-    document.body.querySelectorAll('nx-tabs').forEach((el) => el.remove());
+    while (created.length) created.pop().remove();
   });
 
   it('registers the custom element', () => {
@@ -76,28 +85,95 @@ describe('nx-tabs', () => {
 
   it('ArrowRight moves to the next tab and wraps at the end', async () => {
     const el = await createTabs(ITEMS, 'prompts');
-    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
-    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    pressKey(el, 'ArrowRight');
     await el.updateComplete;
     expect(el.active).to.equal('skills');
   });
 
   it('ArrowLeft moves to the previous tab and wraps at the start', async () => {
     const el = await createTabs(ITEMS, 'skills');
-    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
-    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    pressKey(el, 'ArrowLeft');
     await el.updateComplete;
     expect(el.active).to.equal('prompts');
   });
 
   it('Home and End jump to first and last tab respectively', async () => {
     const el = await createTabs(ITEMS, 'agents');
-    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
-    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    pressKey(el, 'End');
     await el.updateComplete;
     expect(el.active).to.equal('prompts');
-    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    pressKey(el, 'Home');
     await el.updateComplete;
     expect(el.active).to.equal('skills');
+  });
+
+  it('focuses the newly active tab button after Arrow navigation', async () => {
+    const el = await createTabs(ITEMS, 'skills');
+    el.focus();
+    pressKey(el, 'ArrowRight');
+    await el.updateComplete;
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    const focusedId = el.shadowRoot.activeElement?.dataset.id;
+    expect(focusedId).to.equal('agents');
+  });
+
+  it('focuses the new tab on Home/End navigation', async () => {
+    const el = await createTabs(ITEMS, 'agents');
+    el.focus();
+    pressKey(el, 'End');
+    await el.updateComplete;
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+    expect(el.shadowRoot.activeElement?.dataset.id).to.equal('prompts');
+  });
+
+  it('defaults active when items arrive after mount', async () => {
+    const el = await createTabs([]);
+    expect(el.active).to.be.undefined;
+    el.items = ITEMS;
+    await el.updateComplete;
+    expect(el.active).to.equal('skills');
+    expect(el.shadowRoot.querySelector('.tab.is-active')?.dataset.id).to.equal('skills');
+  });
+
+  it('resets active to first id when current active is no longer in items', async () => {
+    const el = await createTabs(ITEMS, 'agents');
+    el.items = [{ id: 'other', label: 'Other' }];
+    await el.updateComplete;
+    expect(el.active).to.equal('other');
+  });
+
+  it('preserves active when it is still present after items change', async () => {
+    const el = await createTabs(ITEMS, 'agents');
+    el.items = [
+      { id: 'agents', label: 'Agents' },
+      { id: 'extras', label: 'Extras' },
+    ];
+    await el.updateComplete;
+    expect(el.active).to.equal('agents');
+  });
+
+  it('uses the provided label for aria-label on the tablist', async () => {
+    const el = await createTabs(ITEMS, undefined, 'Skill categories');
+    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+    expect(tablist.getAttribute('aria-label')).to.equal('Skill categories');
+  });
+
+  it('falls back to "Navigation tabs" when no label is provided', async () => {
+    const el = await createTabs();
+    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+    expect(tablist.getAttribute('aria-label')).to.equal('Navigation tabs');
+  });
+
+  it('does not throw if disconnected before focus settles', async () => {
+    const el = await createTabs(ITEMS, 'skills');
+    el.focus();
+    pressKey(el, 'ArrowRight');
+    el.remove();
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+  });
+
+  it('guards customElements.define against double registration', () => {
+    expect(() => customElements.define('nx-tabs', class extends HTMLElement {})).to.throw();
+    expect(customElements.get('nx-tabs')).to.exist;
   });
 });

--- a/nx2/test/unit/blocks/shared/tabs/tabs.test.js
+++ b/nx2/test/unit/blocks/shared/tabs/tabs.test.js
@@ -1,0 +1,103 @@
+import { expect } from '@esm-bundle/chai';
+import '../../../../../blocks/shared/tabs/tabs.js';
+
+const ITEMS = [
+  { id: 'skills', label: 'Skills' },
+  { id: 'agents', label: 'Agents' },
+  { id: 'prompts', label: 'Prompts' },
+];
+
+async function createTabs(items = ITEMS, active = undefined) {
+  const el = document.createElement('nx-tabs');
+  el.items = items;
+  if (active !== undefined) el.active = active;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function buttons(el) {
+  return [...el.shadowRoot.querySelectorAll('button[role="tab"]')];
+}
+
+describe('nx-tabs', () => {
+  afterEach(() => {
+    document.body.querySelectorAll('nx-tabs').forEach((el) => el.remove());
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('nx-tabs')).to.exist;
+  });
+
+  it('renders a button per item', async () => {
+    const el = await createTabs();
+    const btns = buttons(el);
+    expect(btns).to.have.length(3);
+    expect(btns.map((b) => b.textContent.trim())).to.deep.equal(['Skills', 'Agents', 'Prompts']);
+  });
+
+  it('renders nothing when items is empty', async () => {
+    const el = await createTabs([]);
+    expect(el.shadowRoot.querySelector('.tabs')).to.be.null;
+  });
+
+  it('defaults active to the first item id when none is provided', async () => {
+    const el = await createTabs();
+    expect(el.active).to.equal('skills');
+    const active = el.shadowRoot.querySelector('.tab.is-active');
+    expect(active?.dataset.id).to.equal('skills');
+    expect(active?.getAttribute('aria-selected')).to.equal('true');
+    expect(active?.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('honors a pre-set active value', async () => {
+    const el = await createTabs(ITEMS, 'agents');
+    expect(el.shadowRoot.querySelector('.tab.is-active')?.dataset.id).to.equal('agents');
+  });
+
+  it('fires tab-change with the new id when a tab is clicked', async () => {
+    const el = await createTabs();
+    const events = [];
+    el.addEventListener('tab-change', (e) => events.push(e.detail));
+    buttons(el)[1].click();
+    await el.updateComplete;
+    expect(events).to.deep.equal([{ id: 'agents' }]);
+    expect(el.active).to.equal('agents');
+  });
+
+  it('does not fire tab-change when clicking the already-active tab', async () => {
+    const el = await createTabs();
+    const events = [];
+    el.addEventListener('tab-change', (e) => events.push(e.detail));
+    buttons(el)[0].click();
+    await el.updateComplete;
+    expect(events).to.have.length(0);
+  });
+
+  it('ArrowRight moves to the next tab and wraps at the end', async () => {
+    const el = await createTabs(ITEMS, 'prompts');
+    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    await el.updateComplete;
+    expect(el.active).to.equal('skills');
+  });
+
+  it('ArrowLeft moves to the previous tab and wraps at the start', async () => {
+    const el = await createTabs(ITEMS, 'skills');
+    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    await el.updateComplete;
+    expect(el.active).to.equal('prompts');
+  });
+
+  it('Home and End jump to first and last tab respectively', async () => {
+    const el = await createTabs(ITEMS, 'agents');
+    const tablist = el.shadowRoot.querySelector('[role="tablist"]');
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    await el.updateComplete;
+    expect(el.active).to.equal('prompts');
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    await el.updateComplete;
+    expect(el.active).to.equal('skills');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `nx-card` and `nx-tabs` as first-class shared web components under
  `nx2/blocks/shared/`, alongside the existing `nx-popover`, `nx-dialog`,
  `nx-menu`, etc.
- No consumers in da-nx yet; this PR exists to make these primitives importable
  from the da.live CDN so external apps (ew-extensions Skills Editor, future
  da-live consumers) can stop carrying local copies.

## Why
- The ew-extensions Skills Editor maintains private copies of `nx-card`,
  `nx-tabs`, and `nx-popover`. The popover is literally a one-line-diff copy
  of `nx2/blocks/shared/popover/popover.js`.
- As part of the Skills Management redesign (see
  `private-docs/skills-storage-redesign-plan.md`), ew-extensions will switch
  to CDN-imported shared components via importmap, eliminating the duplicates.
- That switch is blocked until both primitives exist in da-nx and are live
  on the production CDN.

## What Changed
- **`nx2/blocks/shared/card/{card.js,card.css}`** — generic card primitive
  with `heading`, `subheading`, `pill`, `selected`, `interactive` props and
  `pill` / default / `actions` slots. Uses Spectrum 2 design tokens, supports
  light-dark color schemes.
- **`nx2/blocks/shared/tabs/{tabs.js,tabs.css}`** — accessible tab strip
  with `items` (`{id, label}[]`) and `active` props. Emits `tab-change` events.
  Full keyboard navigation (Arrow keys, Home, End) with focus management.
- Both follow the existing `nx2/blocks/shared/popover` conventions: `da-lit`
  imports, `loadStyle` via `import.meta.url`, plain `customElements.define`,
  shadow DOM with adopted stylesheets.

## Test Plan
- [ ] `npm run lint:js` and `npm run nx2:lint:css` are clean (verified)
- [ ] After deploy, `https://da.live/nx2/blocks/shared/card/card.js` and
      `https://da.live/nx2/blocks/shared/tabs/tabs.js` resolve as ES modules
- [ ] Smoke-test in a scratch HTML page (importmap → `da-lit` → render
      `<nx-card heading="..." />` and `<nx-tabs .items=${[...]} />`)
- [ ] Visual parity with the current ew-extensions copies (Skills Editor
      side-by-side comparison once PR-6 lands)

## Risks / Follow-ups
- No active consumers yet — risk is limited to "deploy adds dead code".
- Follow-up: ew-extensions PR-6 (Skills Editor importmap switch) consumes
  these via `https://da.live/nx2/blocks/shared/...`.
- Future: `da-live` browse/canvas/nav surfaces are candidates for adoption
  once the patterns prove out in the Skills Editor.
