### PR TITLE
feat: add chat disclaimer

### DIFF
--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -464,6 +464,26 @@
   }
 }
 
+.chat-disclaimer {
+  max-width: 720px;
+  width: calc(100% - 2 * var(--s2-spacing-200));
+  margin: 0;
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-700);
+  line-height: 1.5;
+  box-sizing: border-box;
+
+  a {
+    color: inherit;
+    font-weight: bold;
+    text-decoration: underline;
+
+    &:hover {
+      color: var(--s2-gray-900);
+    }
+  }
+}
+
 @keyframes chat-thinking-shimmer {
   0% {
     background-position: 100% 50%;

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -7,7 +7,7 @@ import './welcome/welcome.js';
 import './prompts/prompts.js';
 import './pills/pills.js';
 import { loadSiteConfig } from './api.js';
-import { ADD_MENU_ITEMS, MENU_OPTIONS, ROLE, TOOL_STATE } from './constants.js';
+import { ADOBE_AI_GUIDELINES_URL, ADD_MENU_ITEMS, MENU_OPTIONS, ROLE, TOOL_STATE } from './constants.js';
 import { getConfig } from '../../scripts/nx.js';
 
 const styles = await loadStyle(import.meta.url);
@@ -411,6 +411,10 @@ class NxChat extends LitElement {
         </div>
         </form>
       </div>
+      <p class="chat-disclaimer">
+        Responses are generated using AI, and may be inaccurate. Check before using.
+        <a href="${ADOBE_AI_GUIDELINES_URL}" target="_blank" rel="noopener noreferrer">AI User Guidelines</a>
+      </p>
     `;
   }
 }

--- a/nx2/blocks/chat/constants.js
+++ b/nx2/blocks/chat/constants.js
@@ -1,3 +1,5 @@
+const ADOBE_AI_GUIDELINES_URL = 'https://www.adobe.com/legal/licenses-terms/adobe-dx-gen-ai-user-guidelines.html';
+
 const MENU_OPTIONS = {
   PROMPT: 'prompt',
   COMMAND: 'command',
@@ -68,5 +70,12 @@ const ROLE = {
 };
 
 export {
-  ADD_MENU_ITEMS, AGENT_EVENT, CHAT_ICONS, MENU_OPTIONS, ROLE, TOOL_INPUT, TOOL_STATE,
+  ADOBE_AI_GUIDELINES_URL,
+  ADD_MENU_ITEMS,
+  AGENT_EVENT,
+  CHAT_ICONS,
+  MENU_OPTIONS,
+  ROLE,
+  TOOL_INPUT,
+  TOOL_STATE,
 };


### PR DESCRIPTION
Adds disclaimer to chat footer with link to user guidelines
<img width="276" height="266" alt="disclaimer" src="https://github.com/user-attachments/assets/0b37f6a8-6b65-4bb1-ab23-e5006ca42a27" />


Fix #JIRA SITES-45763

cc: @martinbuergi 

Test URLs:
https://da.live/canvas?nx=feat-chat-ai-disclaimer#/exp-workspace/frescopa/index