### PR TITLE
fix: agent doesn't see tools after approval

### DIFF
--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -12,6 +12,7 @@ export default class ChatController {
     this._onUpdate = onUpdate;
     this._onToolDone = onToolDone;
     this._sessionId = crypto.randomUUID();
+    this._currentTurnId = crypto.randomUUID();
   }
 
   setContext(context) {
@@ -103,6 +104,7 @@ export default class ChatController {
     this._toolCards = new Map();
     this._autoApprovedTools = new Set();
     this._sessionId = crypto.randomUUID();
+    this._currentTurnId = crypto.randomUUID();
     this._update();
     const room = await this._getRoom();
     resetSession(room, this._sessionId);
@@ -154,12 +156,17 @@ export default class ChatController {
       next.set(toolCallId, { ...prior, state, output });
       if (state === TOOL_STATE.DONE) {
         // Add a virtual message so the tool renders in the conversation at the right
-        // position and persists across refreshes, without being sent back to the agent.
+        // position and persists across refreshes. Virtual messages are not POSTed
+        // verbatim; _messagesForAgent() decides what (if anything) to send. We stamp
+        // the turn and stash the output so the current turn's non-approval tool calls
+        // (e.g. content_read) can be replayed to the stateless agent on a resume POST.
         this._messages = [
           ...this._messages,
           {
             role: ROLE.ASSISTANT,
             virtual: true,
+            turnId: this._currentTurnId,
+            toolResult: { output },
             content: [{
               type: AGENT_EVENT.TOOL_CALL, toolCallId, toolName: prior.toolName, input: prior.input,
             }],
@@ -212,6 +219,49 @@ export default class ChatController {
     }
   };
 
+  // The agent is stateless: it rebuilds the model context purely from the messages
+  // we POST. Completed tool calls live in the UI as `virtual` messages, which we must
+  // NOT send verbatim (an output-less, unpaired tool-call would break the model history).
+  // Instead:
+  // - Approval tools (content_replace, …) are already represented by their real
+  //   tool-call + approval-response messages; the agent reconstructs their result, so
+  //   we drop their virtual twin to avoid a duplicate tool-call id.
+  // - Non-approval tools (content_read) exist ONLY as virtual messages. For the current
+  //   turn we replay them as a proper tool-call + tool-result pair (carrying the output)
+  //   so that across an approval round-trip the agent still "sees" what it just read and
+  //   doesn't pointlessly re-read. Prior turns' tool I/O is dropped to bound the payload.
+  _messagesForAgent() {
+    const represented = new Set();
+    this._messages.forEach((msg) => {
+      if (msg.virtual || msg.role !== ROLE.ASSISTANT || !Array.isArray(msg.content)) return;
+      msg.content.forEach((part) => {
+        if (part.type === AGENT_EVENT.TOOL_CALL) represented.add(part.toolCallId);
+      });
+    });
+
+    return this._messages.flatMap((msg) => {
+      if (!msg.virtual) return [msg];
+      if (msg.turnId !== this._currentTurnId || !msg.toolResult) return [];
+      const call = msg.content?.find((p) => p.type === AGENT_EVENT.TOOL_CALL);
+      if (!call || represented.has(call.toolCallId)) return [];
+      const { output } = msg.toolResult;
+      const { toolCallId, toolName, input } = call;
+      const wrapped = typeof output === 'string'
+        ? { type: 'text', value: output }
+        : { type: 'json', value: output };
+      return [
+        {
+          role: ROLE.ASSISTANT,
+          content: [{ type: AGENT_EVENT.TOOL_CALL, toolCallId, toolName, input }],
+        },
+        {
+          role: ROLE.TOOL,
+          content: [{ type: AGENT_EVENT.TOOL_RESULT, toolCallId, toolName, output: wrapped }],
+        },
+      ];
+    });
+  }
+
   async _stream(pageContext) {
     const [{ accessToken }, room] = await Promise.all([loadIms(), this._getRoom()]);
     this._abortController = new AbortController();
@@ -220,7 +270,7 @@ export default class ChatController {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        messages: this._messages.filter((msg) => !msg.virtual),
+        messages: this._messagesForAgent(),
         pageContext,
         imsToken: accessToken?.token ?? null,
         room,
@@ -249,6 +299,10 @@ export default class ChatController {
   async sendMessage(message, context = [], { requestedSkills = [] } = {}) {
     if (this._thinking || !this._connected) return;
 
+    // New user turn. An approval round-trip (approveToolCall → _stream) keeps this id so
+    // the tool calls done earlier in the same turn are still replayed; a new sendMessage
+    // rolls it so the previous turn's tool I/O drops out of the POST.
+    this._currentTurnId = crypto.randomUUID();
     this._requestedSkills = requestedSkills;
     const selectionContext = context
       .filter((item) => typeof item.proseIndex === 'number' || item.blockName)

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -196,11 +196,8 @@ export default class ChatController {
           ),
         );
         if (!hasApprovalMessage) {
-          // Virtual message: renders the tool card in conversation position and persists
-          // across refreshes. Not POSTed verbatim — _messagesForAgent() replays the current
-          // turn's non-approval tool calls (e.g. content_read) as a tool-call + tool-result
-          // pair so the stateless agent still "sees" what it read across an approval
-          // round-trip. We stamp the turn and stash the output for that replay.
+          // Virtual message: renders the tool card and persists across refreshes.
+          // turnId + toolResult let _messagesForAgent() replay this read to the agent.
           this._messages = [
             ...this._messages,
             {
@@ -278,17 +275,7 @@ export default class ChatController {
     }
   };
 
-  // The agent is stateless: it rebuilds the model context purely from the messages
-  // we POST. Completed tool calls live in the UI as `virtual` messages, which we must
-  // NOT send verbatim (an output-less, unpaired tool-call would break the model history).
-  // Instead:
-  // - Approval tools (content_replace, …) are already represented by their real
-  //   tool-call + approval-response messages; the agent reconstructs their result, so
-  //   we drop their virtual twin to avoid a duplicate tool-call id.
-  // - Non-approval tools (content_read) exist ONLY as virtual messages. For the current
-  //   turn we replay them as a proper tool-call + tool-result pair (carrying the output)
-  //   so that across an approval round-trip the agent still "sees" what it just read and
-  //   doesn't pointlessly re-read. Prior turns' tool I/O is dropped to bound the payload.
+  // Adds in the tool calls and tool results for the current turn so the agent can replay them.
   _messagesForAgent() {
     const represented = new Set();
     this._messages.forEach((msg) => {
@@ -359,9 +346,7 @@ export default class ChatController {
   async sendMessage(message, context = [], { requestedSkills = [], attachments = [] } = {}) {
     if (this._thinking || !this._connected) return;
 
-    // New user turn. An approval round-trip (approveToolCall → _stream) keeps this id so
-    // the tool calls done earlier in the same turn are still replayed; a new sendMessage
-    // rolls it so the previous turn's tool I/O drops out of the POST.
+    // New turn id; an approval round-trip keeps it, so this turn's reads stay replayable.
     this._currentTurnId = crypto.randomUUID();
     this._requestedSkills = requestedSkills;
     const selectionContext = context

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -18,30 +18,35 @@ const DA_DEFAULT_ENV = env === 'dev' ? 'stage' : env;
 
 const DA_ADMIN_ENVS = {
   dev: 'http://localhost:8787',
+  local: 'http://localhost:8787',
   stage: 'https://stage-admin.da.live',
   prod: 'https://admin.da.live',
 };
 
 const DA_COLLAB_ENVS = {
   dev: 'ws://localhost:4711',
+  local: 'ws://localhost:4711',
   stage: 'wss://stage-collab.da.live',
   prod: 'wss://collab.da.live',
 };
 
 const DA_CONTENT_ENVS = {
   dev: 'http://localhost:8788',
+  local: 'http://localhost:8788',
   stage: 'https://stage-content.da.live',
   prod: 'https://content.da.live',
 };
 
 const DA_LIVE_PREVIEW_ENVS = {
   dev: 'https://localhost:8000',
+  local: 'https://localhost:8000',
   stage: 'https://stage-preview.da.live',
   prod: 'https://preview.da.live',
 };
 
 const DA_ETC_ENVS = {
   dev: 'http://localhost:8787',
+  local: 'http://localhost:8787',
   prod: 'https://da-etc.adobeaem.workers.dev',
 };
 

--- a/nx2/utils/utils.js
+++ b/nx2/utils/utils.js
@@ -18,35 +18,30 @@ const DA_DEFAULT_ENV = env === 'dev' ? 'stage' : env;
 
 const DA_ADMIN_ENVS = {
   dev: 'http://localhost:8787',
-  local: 'http://localhost:8787',
   stage: 'https://stage-admin.da.live',
   prod: 'https://admin.da.live',
 };
 
 const DA_COLLAB_ENVS = {
   dev: 'ws://localhost:4711',
-  local: 'ws://localhost:4711',
   stage: 'wss://stage-collab.da.live',
   prod: 'wss://collab.da.live',
 };
 
 const DA_CONTENT_ENVS = {
   dev: 'http://localhost:8788',
-  local: 'http://localhost:8788',
   stage: 'https://stage-content.da.live',
   prod: 'https://content.da.live',
 };
 
 const DA_LIVE_PREVIEW_ENVS = {
   dev: 'https://localhost:8000',
-  local: 'https://localhost:8000',
   stage: 'https://stage-preview.da.live',
   prod: 'https://preview.da.live',
 };
 
 const DA_ETC_ENVS = {
   dev: 'http://localhost:8787',
-  local: 'http://localhost:8787',
   prod: 'https://da-etc.adobeaem.workers.dev',
 };
 

--- a/test/nx2/blocks/chat/chat-controller.test.js
+++ b/test/nx2/blocks/chat/chat-controller.test.js
@@ -1,0 +1,105 @@
+import { expect } from '@esm-bundle/chai';
+import ChatController from '../../../../nx2/blocks/chat/chat-controller.js';
+
+const TURN = 'turn-current';
+const OTHER_TURN = 'turn-previous';
+
+// Build a controller with a known message history and current turn, then read back
+// what would actually be POSTed to the (stateless) agent.
+function agentMessages(messages, currentTurnId = TURN) {
+  const controller = new ChatController({ onUpdate() {}, onToolDone() {} });
+  controller._messages = messages;
+  controller._currentTurnId = currentTurnId;
+  return controller._messagesForAgent();
+}
+
+// A completed non-approval tool call (e.g. content_read) as the UI stores it.
+const virtualRead = (toolCallId, turnId, output) => ({
+  role: 'assistant',
+  virtual: true,
+  turnId,
+  toolResult: { output },
+  content: [{ type: 'tool-call', toolCallId, toolName: 'content_read', input: { path: '/x' } }],
+});
+
+describe('chat-controller _messagesForAgent', () => {
+  it('passes non-virtual messages through unchanged', () => {
+    const msgs = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ];
+    expect(agentMessages(msgs)).to.deep.equal(msgs);
+  });
+
+  it('replays a current-turn content_read as a paired tool-call + tool-result', () => {
+    const output = { content: '<p>surf</p>', blocks: [{ locator: 'abc' }] };
+    const result = agentMessages([
+      { role: 'user', content: 'add fishing para' },
+      virtualRead('r1', TURN, output),
+    ]);
+
+    expect(result).to.have.lengthOf(3);
+    expect(result[0]).to.deep.equal({ role: 'user', content: 'add fishing para' });
+    expect(result[1]).to.deep.equal({
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'r1', toolName: 'content_read', input: { path: '/x' } }],
+    });
+    expect(result[2]).to.deep.equal({
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'r1', toolName: 'content_read', output: { type: 'json', value: output } }],
+    });
+  });
+
+  it('wraps a string tool output as a text part', () => {
+    const result = agentMessages([virtualRead('r1', TURN, 'plain text')]);
+    expect(result[1].content[0].output).to.deep.equal({ type: 'text', value: 'plain text' });
+  });
+
+  it('drops tool I/O from previous turns to keep the payload bounded', () => {
+    const result = agentMessages([
+      virtualRead('old', OTHER_TURN, { content: 'stale' }),
+      { role: 'user', content: 'new question' },
+      virtualRead('new', TURN, { content: 'fresh' }),
+    ]);
+    const readIds = result
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter((p) => p.type === 'tool-call')
+      .map((p) => p.toolCallId);
+    expect(readIds).to.deep.equal(['new']); // 'old' dropped
+  });
+
+  it('drops the virtual twin of an approval tool already represented by a real tool-call', () => {
+    const result = agentMessages([
+      // Real (non-virtual) approval message for content_replace.
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'w1', toolName: 'content_replace', input: {} },
+          { type: 'tool-approval-request', approvalId: 'a1', toolCallId: 'w1' },
+        ],
+      },
+      { role: 'tool', content: [{ type: 'tool-approval-response', approvalId: 'a1', approved: true }] },
+      // Virtual DONE twin for the same call — must NOT be re-sent (would duplicate w1).
+      {
+        role: 'assistant',
+        virtual: true,
+        turnId: TURN,
+        toolResult: { output: { updated: true } },
+        content: [{ type: 'tool-call', toolCallId: 'w1', toolName: 'content_replace', input: {} }],
+      },
+    ]);
+
+    const w1Calls = result
+      .filter((m) => m.role === 'assistant' && Array.isArray(m.content))
+      .flatMap((m) => m.content)
+      .filter((p) => p.type === 'tool-call' && p.toolCallId === 'w1');
+    expect(w1Calls).to.have.lengthOf(1); // exactly one, from the real approval message
+  });
+
+  it('skips a current-turn virtual message that has no stored output', () => {
+    const result = agentMessages([
+      { role: 'assistant', virtual: true, turnId: TURN, content: [{ type: 'tool-call', toolCallId: 'r1', toolName: 'content_read', input: {} }] },
+    ]);
+    expect(result).to.deep.equal([]); // no orphan tool-call emitted
+  });
+});


### PR DESCRIPTION
https://fix-chat-messages--da-nx--adobe.aem.live

https://main--da-live--adobe.aem.live/canvas?nx=fix-chat-messages#/exp-workspace/frescopa/index

Fixes a bug where the agent doesn't see tools that it already used after an approval.

Before:
<img width="401" height="446" alt="Screenshot 2026-06-01 at 11 04 40" src="https://github.com/user-attachments/assets/d38ec200-ca8e-4417-a2af-8899604a3489" />

After:
<img width="429" height="357" alt="Screenshot 2026-06-01 at 11 05 32" src="https://github.com/user-attachments/assets/3670449e-5301-4f51-87cb-7f4806eea87a" />
