### PR TITLE
fix: open panel from extensions

### DIFF
--- a/nx/utils/sdk.js
+++ b/nx/utils/sdk.js
@@ -30,6 +30,10 @@ function setPrompt(text, { autoSend = false } = {}) {
   port2.postMessage({ action: 'setPrompt', details: { text, autoSend } });
 }
 
+function showPanel(name) {
+  port2.postMessage({ action: 'showPanel', details: name });
+}
+
 function getSelection() {
   return new Promise((resolve, reject) => {
     const listener = (e) => {
@@ -76,6 +80,7 @@ const DA_SDK = (() => new Promise((resolve) => {
         closeLibrary,
         getSelection,
         setPrompt,
+        showPanel,
       };
 
       resolve({ ...e.data, actions });


### PR DESCRIPTION
Required for supporting https://github.com/adobe/da-live/pull/987 and providing the capability within extensions
