### PR TITLE
fix(chat): correct local agent port and add da-agent param support

### DIFF
--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -18,9 +18,15 @@ function affectedFolders(toolName, input) {
   return input.path ? [toParent(input.path)] : [];
 }
 
-const AGENT_URL = new URLSearchParams(window.location.search).get('ref') === 'local'
-  ? 'http://localhost:4200/chat'
-  : 'https://agent.da.live/chat';
+function resolveAgentUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const agent = params.get('da-agent') || params.get('ref');
+  if (agent === 'local') return 'http://localhost:4002/chat';
+  if (agent === 'stage') return 'https://stage-agent.da.live/chat';
+  return 'https://agent.da.live/chat';
+}
+
+const AGENT_URL = resolveAgentUrl();
 
 /**
  * Drop assistant array-content messages whose tool-call IDs have no matching


### PR DESCRIPTION
The chat controller hardcoded localhost:4200 for local agent, but da-agent binds on port 4002 (per wrangler.toml). This caused the chat input to appear disabled whenever ref=local was set.

- read da-agent param first, fall back to ref for backward compat
- map local to localhost:4002 (matching wrangler.toml / ew-devs-cli)
- add stage-agent.da.live for stage environment

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/
