### PR TITLE
feat(chat): pass registered MCP servers to da-agent

### DIFF
--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -373,8 +373,7 @@ export default class ChatController {
         sessionId: this._sessionId,
         ...(this._requestedSkills?.length ? { requestedSkills: this._requestedSkills } : {}),
         ...(this._pendingAttachments?.length ? { attachments: this._pendingAttachments } : {}),
-        ...(this._mcpServers && Object.keys(this._mcpServers).length ? { mcpServers: this._mcpServers } : {}),
-        ...(this._mcpServerHeaders && Object.keys(this._mcpServerHeaders).length ? { mcpServerHeaders: this._mcpServerHeaders } : {}),
+        ...this._mcpPayload(),
       }),
       signal: this._abortController.signal,
     });
@@ -398,6 +397,15 @@ export default class ChatController {
   setMcpConfig(mcpServers, mcpServerHeaders) {
     this._mcpServers = mcpServers;
     this._mcpServerHeaders = mcpServerHeaders;
+  }
+
+  _mcpPayload() {
+    const s = this._mcpServers;
+    const h = this._mcpServerHeaders;
+    return {
+      ...(s && Object.keys(s).length ? { mcpServers: s } : {}),
+      ...(h && Object.keys(h).length ? { mcpServerHeaders: h } : {}),
+    };
   }
 
   async sendMessage(message, context = [], { requestedSkills = [], attachments = [] } = {}) {

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -373,6 +373,8 @@ export default class ChatController {
         sessionId: this._sessionId,
         ...(this._requestedSkills?.length ? { requestedSkills: this._requestedSkills } : {}),
         ...(this._pendingAttachments?.length ? { attachments: this._pendingAttachments } : {}),
+        ...(this._mcpServers && Object.keys(this._mcpServers).length ? { mcpServers: this._mcpServers } : {}),
+        ...(this._mcpServerHeaders && Object.keys(this._mcpServerHeaders).length ? { mcpServerHeaders: this._mcpServerHeaders } : {}),
       }),
       signal: this._abortController.signal,
     });
@@ -393,10 +395,14 @@ export default class ChatController {
     });
   }
 
+  setMcpConfig(mcpServers, mcpServerHeaders) {
+    this._mcpServers = mcpServers;
+    this._mcpServerHeaders = mcpServerHeaders;
+  }
+
   async sendMessage(message, context = [], { requestedSkills = [], attachments = [] } = {}) {
     if (this._thinking || !this._connected) return;
 
-    // New turn id; an approval round-trip keeps it, so this turn's reads stay replayable.
     this._currentTurnId = crypto.randomUUID();
     this._requestedSkills = requestedSkills;
     const selectionContext = context

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -96,9 +96,10 @@ class NxChat extends LitElement {
     const key = `${org}/${site}`;
     if (this._configKey === key) return;
     this._configKey = key;
-    const { prompts, skills } = await loadSiteConfig(org, site);
+    const { prompts, skills, mcpServers, mcpServerHeaders } = await loadSiteConfig(org, site);
     this._prompts = prompts ?? [];
     this._skills = skills ?? [];
+    this._controller?.setMcpConfig(mcpServers ?? {}, mcpServerHeaders ?? {});
     if (this._slashCtx) this._syncSlashMenu(this._slashCtx);
   }
 

--- a/nx2/blocks/chat/utils/api.js
+++ b/nx2/blocks/chat/utils/api.js
@@ -1,30 +1,35 @@
-import { daFetch } from '../../../utils/api.js';
-import { DA_ADMIN } from '../../../utils/utils.js';
+import { fetchDaConfigs } from '../../../utils/daConfig.js';
 
 export async function loadSiteConfig(org, site) {
   try {
-    const resp = await daFetch({ url: `${DA_ADMIN}/config/${org}/${site}` });
-    if (!resp.ok) return {};
-    const json = await resp.json();
-    const prompts = (json?.prompts?.data ?? []).filter((p) => p.title && p.prompt);
-    const rows = json?.skills?.data ?? [];
+    const configs = fetchDaConfigs({ org, site });
+    const siteJson = await configs[configs.length - 1];
+    if (!siteJson || siteJson.error) return {};
+
+    const prompts = (siteJson?.prompts?.data ?? [])
+      .filter((p) => p.title && p.prompt);
+    const rows = siteJson?.skills?.data ?? [];
     const skills = rows
-      .filter((row) => String(row.status ?? '').trim().toLowerCase() !== 'draft')
-      .map((row) => String(row.key ?? row.id ?? '').trim().replace(/\.md$/i, ''))
+      .filter((r) => {
+        const s = String(r.status ?? '').trim().toLowerCase();
+        return s !== 'draft';
+      })
+      .map((r) => String(r.key ?? r.id ?? '').trim()
+        .replace(/\.md$/i, ''))
       .filter(Boolean);
 
     const mcpServers = {};
     const mcpServerHeaders = {};
-    (json?.['mcp-servers']?.data ?? []).forEach((row) => {
+    (siteJson?.['mcp-servers']?.data ?? []).forEach((row) => {
       const key = String(row?.key ?? '').trim();
       const url = row?.url || row?.value;
-      const status = String(row?.status ?? '').trim().toLowerCase();
-      const enabled = String(row?.enabled ?? 'true').trim().toLowerCase();
-      if (!key || !url || status === 'draft' || enabled === 'false') return;
+      const st = String(row?.status ?? '').trim().toLowerCase();
+      const en = String(row?.enabled ?? 'true').trim().toLowerCase();
+      if (!key || !url || st === 'draft' || en === 'false') return;
       mcpServers[key] = url;
-      const hName = String(row?.authHeaderName ?? '').trim();
-      const hValue = String(row?.authHeaderValue ?? '').trim();
-      if (hName && hValue) mcpServerHeaders[key] = { [hName]: hValue };
+      const hN = String(row?.authHeaderName ?? '').trim();
+      const hV = String(row?.authHeaderValue ?? '').trim();
+      if (hN && hV) mcpServerHeaders[key] = { [hN]: hV };
     });
 
     return { prompts, skills, mcpServers, mcpServerHeaders };

--- a/nx2/blocks/chat/utils/api.js
+++ b/nx2/blocks/chat/utils/api.js
@@ -12,7 +12,22 @@ export async function loadSiteConfig(org, site) {
       .filter((row) => String(row.status ?? '').trim().toLowerCase() !== 'draft')
       .map((row) => String(row.key ?? row.id ?? '').trim().replace(/\.md$/i, ''))
       .filter(Boolean);
-    return { prompts, skills };
+
+    const mcpServers = {};
+    const mcpServerHeaders = {};
+    (json?.['mcp-servers']?.data ?? []).forEach((row) => {
+      const key = String(row?.key ?? '').trim();
+      const url = row?.url || row?.value;
+      const status = String(row?.status ?? '').trim().toLowerCase();
+      const enabled = String(row?.enabled ?? 'true').trim().toLowerCase();
+      if (!key || !url || status === 'draft' || enabled === 'false') return;
+      mcpServers[key] = url;
+      const hName = String(row?.authHeaderName ?? '').trim();
+      const hValue = String(row?.authHeaderValue ?? '').trim();
+      if (hName && hValue) mcpServerHeaders[key] = { [hName]: hValue };
+    });
+
+    return { prompts, skills, mcpServers, mcpServerHeaders };
   } catch {
     return {};
   }


### PR DESCRIPTION
## Summary

- Custom MCP servers registered in the Skills Editor config sheet (`mcp-servers`) were never forwarded to `da-agent` during chat. The agent had no visibility into user-configured MCPs.
- `loadSiteConfig()` now parses the `mcp-servers` sheet into `mcpServers` (key-to-URL map) and `mcpServerHeaders` (key-to-auth-headers map), filtering out draft and disabled entries.
- `ChatController` exposes `setMcpConfig()` and includes both maps in every POST to `/chat`, matching da-agent's existing `ChatRequestSchema` fields.

## Test plan

- [ ] Register a custom MCP in the Skills Editor (e.g. a test SSE endpoint)
- [ ] Open chat, send a message -- verify the POST body includes `mcpServers` and `mcpServerHeaders`
- [ ] Agent should discover and list the MCP's tools
- [ ] Disable the MCP in Skills Editor, reload -- verify it's no longer sent
- [ ] Draft-status MCPs should not be forwarded
- [ ] Sites with no MCPs registered -- no `mcpServers` key in POST body (no regression)
