### PR TITLE
ImageLoc: Throttle GLaaS multimodal API calls and avoid status probe storms after failed cancel.

### DIFF
--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -1,6 +1,6 @@
 import makeBatches from '../../../../public/utils/batch.js';
 
-async function throttle(ms = 500) {
+export async function throttle(ms = 500) {
   return new Promise((resolve) => {
     setTimeout(() => { resolve(); }, ms);
   });

--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -211,9 +211,10 @@ export async function updateStatus(service, token, task, newStatus = 'CREATED') 
     }
   }));
 
-  if (!results.some((result) => result.error)) task.status = 'created';
+  const ok = !results.some((result) => result.error);
+  if (ok) task.status = 'created';
 
-  return task;
+  return { task, ok, results };
 }
 
 export async function downloadAsset(service, token, task, path) {

--- a/nx/blocks/loc/connectors/glaas/index.js
+++ b/nx/blocks/loc/connectors/glaas/index.js
@@ -563,6 +563,7 @@ export async function saveItems({
   lang,
   urls,
   saveFn,
+  sendMessage,
 }) {
   normalizeLegacyStructure(lang, urls);
 
@@ -587,6 +588,8 @@ export async function saveItems({
     throw new Error(`No matching tasks found for URLs: ${missingUrls.map((u) => u.suppliedPath).join(', ')}`);
   }
 
+  const logRequest = shouldLogMultimodalRequests() ? logMultimodalRequest : undefined;
+
   const downloadCallback = async (url) => {
     const task = urlToTaskMap.get(url.suppliedPath);
     const glaasPath = getGlaasFilename(url.daBasePath);
@@ -608,6 +611,8 @@ export async function saveItems({
         langCode: code,
         pageAsset,
         htmlAssetName: glaasPath,
+        logRequest,
+        onWarning: sendMessage,
       });
       if (prepared.error) throw new Error(prepared.error);
       text = prepared.text;

--- a/nx/blocks/loc/connectors/glaas/index.js
+++ b/nx/blocks/loc/connectors/glaas/index.js
@@ -654,22 +654,35 @@ export async function cancelTranslation({ service, lang, sendMessage }) {
 
   if (!canCancelLang({ lang })) {
     sendMessage({ text: `Skipping ${lang.name}. No translation information.` });
-    return null;
+    return { ok: true, skipped: true };
   }
 
   const { code } = lang;
   // As a service provider, you need to say what will be canceled
   if (lang.translation?.workflowTasks) {
-    const cancelPromises = Object.values(lang.translation.workflowTasks)
-      .map(async (workflowTask) => {
-        const taskName = workflowTask.name;
-        const taskWorkflow = workflowTask.workflow;
-        sendMessage({ text: `Canceling task ${taskName} for ${lang.name}.` });
-        return updateStatus(service, token, { name: taskName, workflow: taskWorkflow, targetLocales: [code] }, 'CANCELLED');
+    const cancelResults = await Promise.all(
+      Object.values(lang.translation.workflowTasks)
+        .map(async (workflowTask) => {
+          const taskName = workflowTask.name;
+          const taskWorkflow = workflowTask.workflow;
+          sendMessage({ text: `Canceling task ${taskName} for ${lang.name}.` });
+          return updateStatus(
+            service,
+            token,
+            { name: taskName, workflow: taskWorkflow, targetLocales: [code] },
+            'CANCELLED',
+          );
+        }),
+    );
+    const ok = cancelResults.every((result) => result?.ok);
+    if (!ok) {
+      sendMessage({
+        text: `GLaaS did not accept cancel for ${lang.name} (task may not be in a cancelable state).`,
+        type: 'error',
       });
-
-    return Promise.all(cancelPromises);
+    }
+    return { ok };
   }
   sendMessage({ text: `No tasks found to cancel for ${lang.name}.` });
-  return null;
+  return { ok: true };
 }

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -184,17 +184,6 @@ export async function fetchBlobFromSignedUrl(signedURL) {
 
 const CONTENT_DA_LIVE = 'content.da.live';
 
-/** One srcset candidate URL; strips trailing width/density descriptor (e.g. 600w, 2x) only. */
-export function parseSrcsetUrl(part) {
-  const trimmed = part.trim();
-  if (!trimmed) return '';
-  return trimmed.replace(/\s+\d+(?:\.\d+)?[wx]\s*$/i, '').trim();
-}
-
-function collectSrcsetUrls(srcset) {
-  return srcset.split(',').map(parseSrcsetUrl).filter(Boolean);
-}
-
 /** Encode delivery URL for HTML src/srcset (spaces → %20, valid srcset). */
 export function contentDaLiveHrefForAttribute(href) {
   if (!href) return href;
@@ -225,18 +214,13 @@ function isProjectContentDaLiveUrl(href, org, site) {
   }
 }
 
-/** MVP: absolute https://content.da.live/... image URLs only (not relative ./media_ from DNT). */
+/** MVP: absolute https://content.da.live/... image URLs from img[src] only (not relative ./media_ from DNT). */
 export function collectContentDaLiveImageUrls(html, { org, site } = {}) {
   const doc = new DOMParser().parseFromString(html, 'text/html');
   const urls = new Set();
   doc.querySelectorAll('img[src]').forEach((img) => {
     const src = img.getAttribute('src');
     if (isProjectContentDaLiveUrl(src, org, site)) urls.add(new URL(src).href);
-  });
-  doc.querySelectorAll('source[srcset]').forEach((source) => {
-    collectSrcsetUrls(source.getAttribute('srcset') || '').forEach((src) => {
-      if (isProjectContentDaLiveUrl(src, org, site)) urls.add(new URL(src).href);
-    });
   });
   return [...urls];
 }
@@ -258,19 +242,6 @@ export function contentDaLivePathKey(href) {
   }
 }
 
-function replaceSrcsetUrls(srcset, resolveNewUrl) {
-  return srcset.split(',').map((part) => {
-    const trimmed = part.trim();
-    if (!trimmed) return part;
-    const src = parseSrcsetUrl(trimmed);
-    const descriptor = trimmed.slice(src.length).trim();
-    const resolved = resolveNewUrl(src);
-    if (!resolved) return part;
-    const encoded = contentDaLiveHrefForAttribute(resolved);
-    return descriptor ? `${encoded} ${descriptor}` : encoded;
-  }).join(', ');
-}
-
 /** Replace content.da.live image URLs using pathname → new delivery URL map. */
 export function rewriteContentDaLiveImageUrls(html, pathToNewUrl) {
   const doc = new DOMParser().parseFromString(html, 'text/html');
@@ -282,12 +253,14 @@ export function rewriteContentDaLiveImageUrls(html, pathToNewUrl) {
 
   doc.querySelectorAll('img[src]').forEach((img) => {
     const next = resolveNewUrl(img.getAttribute('src'));
-    if (next) img.setAttribute('src', contentDaLiveHrefForAttribute(next));
-  });
-  doc.querySelectorAll('source[srcset]').forEach((source) => {
-    const srcset = source.getAttribute('srcset');
-    if (!srcset) return;
-    source.setAttribute('srcset', replaceSrcsetUrls(srcset, resolveNewUrl));
+    if (!next) return;
+    const encoded = contentDaLiveHrefForAttribute(next);
+    img.setAttribute('src', encoded);
+    const picture = img.closest('picture');
+    if (!picture) return;
+    picture.querySelectorAll('source[srcset]').forEach((source) => {
+      source.setAttribute('srcset', encoded);
+    });
   });
 
   return doc.documentElement?.querySelector('body')?.innerHTML

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -4,30 +4,110 @@ import { daFetch } from '../../../../utils/daFetch.js';
 import { buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl } from './api.js';
 
 const MULTIMODAL_LOG_KEY = 'glaas.multimodal.log';
+/** Documented GLaaS budget is 120/min per client id; target 100 for shared-stage headroom. */
+const GLAAS_API_LIMIT_PER_MINUTE = 100;
+const GLAAS_API_WINDOW_MS = 60_000;
+const GLAAS_API_MIN_INTERVAL_MS = Math.ceil(
+  GLAAS_API_WINDOW_MS / GLAAS_API_LIMIT_PER_MINUTE,
+);
+const IMAGE_FETCH_QUEUE_CONCURRENCY = 5;
 const IMAGE_SAVE_QUEUE_CONCURRENCY = 5;
 const IMAGE_UPLOAD_QUEUE_CONCURRENCY = 3;
+const V2_PROBE_QUEUE_CONCURRENCY = 3;
 const IMAGE_PUSH_INTERVAL_MS = 250;
 const PUT_URL_MAX_RETRIES = 4;
 const PUT_URL_RETRY_WAIT_MS = 1000;
-const PUT_URL_429_DEFAULT_DELAY_MS = 30250;
+const PUT_URL_429_FALLBACK_DELAY_MS = Math.ceil(GLAAS_API_WINDOW_MS / 2) + 250;
 
-let putUrlRateLimitUntil = 0;
+let glaasApiRateLimitUntil = 0;
 
 function delay(ms) {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
-async function awaitPutUrlRateLimitGate() {
-  const waitMs = putUrlRateLimitUntil - Date.now();
+export function createPutUrlRollingLimiter({
+  limitPerWindow = GLAAS_API_LIMIT_PER_MINUTE,
+  windowMs = GLAAS_API_WINDOW_MS,
+  minIntervalMs = GLAAS_API_MIN_INTERVAL_MS,
+} = {}) {
+  let chain = Promise.resolve();
+  let timestamps = [];
+  let lastAcquireAt = 0;
+
+  const prune = (now) => {
+    timestamps = timestamps.filter((t) => now - t < windowMs);
+  };
+
+  return {
+    windowRetryDelayMs(now = Date.now()) {
+      prune(now);
+      if (timestamps.length >= limitPerWindow) {
+        return timestamps[0] + windowMs - now + 250;
+      }
+      return 0;
+    },
+    async acquire() {
+      const previous = chain;
+      let release;
+      chain = new Promise((resolve) => { release = resolve; });
+      await previous;
+      try {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const now = Date.now();
+          prune(now);
+          const waitForWindow = timestamps.length >= limitPerWindow
+            ? timestamps[0] + windowMs - now
+            : 0;
+          const waitForSpacing = Math.max(0, lastAcquireAt + minIntervalMs - now);
+          const waitMs = Math.max(waitForWindow, waitForSpacing);
+          if (waitMs > 0) {
+            await delay(waitMs);
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+          lastAcquireAt = now;
+          timestamps.push(now);
+          return;
+        }
+      } finally {
+        release();
+      }
+    },
+    reset() {
+      chain = Promise.resolve();
+      timestamps = [];
+      lastAcquireAt = 0;
+    },
+  };
+}
+
+const glaasApiLimiter = createPutUrlRollingLimiter();
+
+async function awaitGlaasApiRateLimitGate() {
+  const waitMs = glaasApiRateLimitUntil - Date.now();
   if (waitMs > 0) await delay(waitMs);
 }
 
-function extendPutUrlRateLimitGate(waitMs) {
-  putUrlRateLimitUntil = Math.max(putUrlRateLimitUntil, Date.now() + waitMs);
+async function acquireGlaasApiSlot() {
+  await awaitGlaasApiRateLimitGate();
+  await glaasApiLimiter.acquire();
+}
+
+function extendGlaasApiRateLimitGate(waitMs) {
+  glaasApiRateLimitUntil = Math.max(glaasApiRateLimitUntil, Date.now() + waitMs);
+}
+
+function putUrlReactiveRetryDelayMs({ waitInterval }) {
+  return Math.max(
+    waitInterval,
+    glaasApiLimiter.windowRetryDelayMs() || PUT_URL_429_FALLBACK_DELAY_MS,
+  );
 }
 
 export function resetPutUrlRateLimitGateForTests() {
-  putUrlRateLimitUntil = 0;
+  glaasApiRateLimitUntil = 0;
+  glaasApiLimiter.reset();
 }
 
 function getPutUrlRateLimitHeaders(resp) {
@@ -51,7 +131,7 @@ function putUrl429RetryDelayMs({ resp, waitInterval }) {
   const { retryAfter, xRateLimitRetryAfterSeconds } = getPutUrlRateLimitHeaders(resp);
   const retryIn = getMillisToSleep(retryAfter || xRateLimitRetryAfterSeconds || '');
   if (retryIn > 0) return retryIn + 250;
-  return Math.max(waitInterval, PUT_URL_429_DEFAULT_DELAY_MS);
+  return putUrlReactiveRetryDelayMs({ waitInterval });
 }
 
 async function backoffPutUrl429({
@@ -62,7 +142,7 @@ async function backoffPutUrl429({
   status,
   detail = {},
 }) {
-  extendPutUrlRateLimitGate(waitMs);
+  extendGlaasApiRateLimitGate(waitMs);
   logRequest?.('getPutURL-retry', {
     status,
     attempt: attempt + 1,
@@ -128,7 +208,7 @@ export async function getPutUrlForFile({
   let waitInterval = PUT_URL_RETRY_WAIT_MS;
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
-      await awaitPutUrlRateLimitGate();
+      await acquireGlaasApiSlot();
       const resp = await fetch(url, opts);
       if (resp.status === 429 && attempt < maxRetries) {
         waitInterval *= 2;
@@ -151,7 +231,7 @@ export async function getPutUrlForFile({
       return { putURL: json.putURL, instanceId: json.instanceId, status: resp.status };
     } catch (e) {
       if (attempt < maxRetries) {
-        const waitMs = PUT_URL_429_DEFAULT_DELAY_MS;
+        const waitMs = glaasApiLimiter.windowRetryDelayMs() || PUT_URL_429_FALLBACK_DELAY_MS;
         await backoffPutUrl429({
           waitMs,
           logRequest,
@@ -255,6 +335,7 @@ export async function getV2Asset(service, token, task, assetName) {
   const [product = '', project = ''] = workflow?.split('/') ?? [];
   const opts = getOpts(clientid, token);
   try {
+    await acquireGlaasApiSlot();
     const path = ensureLeadingSlash(assetName);
     const resp = await fetch(`${origin}/api/l10n/v2.0/tasks/${product}/${project}/${taskName}/assets/${lang}${path}`, opts);
     const json = await resp.json();
@@ -407,16 +488,53 @@ export function v2AssetStatusFromProbe(assetName, meta) {
   };
 }
 
+async function runImageQueue({
+  items,
+  processItem,
+  concurrency = IMAGE_SAVE_QUEUE_CONCURRENCY,
+  pushIntervalMs,
+}) {
+  if (!items.length) return { results: [] };
+
+  let firstError;
+  const results = [];
+  const queue = new Queue(async (item) => {
+    if (firstError) return;
+    const result = await processItem(item);
+    if (result?.error) {
+      firstError = result;
+      return;
+    }
+    results.push(result);
+  }, concurrency);
+
+  if (pushIntervalMs) {
+    const pending = [];
+    for (let i = 0; i < items.length; i += 1) {
+      if (i > 0) await delay(pushIntervalMs);
+      pending.push(queue.push(items[i]));
+    }
+    await Promise.all(pending);
+  } else {
+    await Promise.all(items.map((item) => queue.push(item)));
+  }
+
+  if (firstError) return { error: firstError };
+  return { results };
+}
+
 async function probeMultimodalAssetStatuses({
   service, token, task, langCode, assetNames,
 }) {
   const langTask = { ...task, code: langCode };
-  const probes = await Promise.all(
-    assetNames.map(async (assetName) => {
+  const { results: probes } = await runImageQueue({
+    items: assetNames,
+    concurrency: V2_PROBE_QUEUE_CONCURRENCY,
+    processItem: async (assetName) => {
       const meta = await getV2Asset(service, token, langTask, assetName);
       return v2AssetStatusFromProbe(assetName, meta);
-    }),
-  );
+    },
+  });
   return probes;
 }
 
@@ -432,23 +550,23 @@ export async function getMultimodalV2TaskStatus({
     return { status: 404, json: [] };
   }
 
-  const subtasks = await Promise.all(
-    langs.map(async (lang) => {
-      const assets = await probeMultimodalAssetStatuses({
-        service,
-        token,
-        task,
-        langCode: lang.code,
-        assetNames,
-      });
-      const allCompleted = assets.every((asset) => asset.status === 'COMPLETED');
-      return {
-        targetLocale: lang.code,
-        status: allCompleted ? 'COMPLETED' : 'IN_PROGRESS',
-        assets,
-      };
-    }),
-  );
+  const subtasks = [];
+  for (const lang of langs) {
+    // eslint-disable-next-line no-await-in-loop
+    const assets = await probeMultimodalAssetStatuses({
+      service,
+      token,
+      task,
+      langCode: lang.code,
+      assetNames,
+    });
+    const allCompleted = assets.every((asset) => asset.status === 'COMPLETED');
+    subtasks.push({
+      targetLocale: lang.code,
+      status: allCompleted ? 'COMPLETED' : 'IN_PROGRESS',
+      assets,
+    });
+  }
 
   return { status: 200, json: subtasks };
 }
@@ -502,52 +620,7 @@ export function buildMultimodalTextAsset({
   };
 }
 
-async function runImageQueue({
-  items,
-  processItem,
-  concurrency = IMAGE_SAVE_QUEUE_CONCURRENCY,
-  pushIntervalMs,
-}) {
-  if (!items.length) return { results: [] };
-
-  let firstError;
-  const results = [];
-  const queue = new Queue(async (item) => {
-    if (firstError) return;
-    const result = await processItem(item);
-    if (result?.error) {
-      firstError = result;
-      return;
-    }
-    results.push(result);
-  }, concurrency);
-
-  if (pushIntervalMs) {
-    const pending = [];
-    for (let i = 0; i < items.length; i += 1) {
-      if (i > 0) await delay(pushIntervalMs);
-      pending.push(queue.push(items[i]));
-    }
-    await Promise.all(pending);
-  } else {
-    await Promise.all(items.map((item) => queue.push(item)));
-  }
-
-  if (firstError) return { error: firstError };
-  return { results };
-}
-
-async function uploadMultimodalImage({
-  imageIndex,
-  imageUrl,
-  origin,
-  clientid,
-  token,
-  pagePath,
-  pagePreviewUrl,
-  targetLocales,
-  logRequest,
-}) {
+async function fetchMultimodalImage({ imageIndex, imageUrl, logRequest }) {
   const imageAssetName = siteRelativePathFromContentDaLiveUrl(imageUrl);
   const imageSourceUrl = contentDaLiveToDaSourceUrl(imageUrl);
   logRequest?.('fetch-image', { imageIndex, contentDaLiveUrl: imageUrl, daSourceUrl: imageSourceUrl });
@@ -565,12 +638,33 @@ async function uploadMultimodalImage({
     };
   }
 
+  const imageBlob = await imageResp.blob();
+  return {
+    imageIndex,
+    imageUrl,
+    imageAssetName,
+    imageBlob,
+  };
+}
+
+async function uploadFetchedMultimodalImage({
+  imageIndex,
+  imageUrl,
+  imageAssetName,
+  imageBlob,
+  origin,
+  clientid,
+  token,
+  pagePath,
+  pagePreviewUrl,
+  targetLocales,
+  logRequest,
+}) {
   const imagePut = await getPutUrlForFile({
     origin, clientid, token, assetName: imageAssetName, logRequest,
   });
   if (imagePut.error) return { error: imagePut.error, step: `getPutURL-image-${imageIndex}`, ...imagePut };
 
-  const imageBlob = await imageResp.blob();
   const imageUpload = await putAssetToSignedUrl({
     putURL: imagePut.putURL,
     body: imageBlob,
@@ -639,13 +733,23 @@ export async function uploadMultimodalPageAssets({
   if (maxImages != null) imageUrls = imageUrls.slice(0, maxImages);
   logRequest?.('collect-images', { htmlAssetName, org, site, count: imageUrls.length, imageUrls });
 
-  const { error: imageError, results: imageResults } = await runImageQueue({
-    items: imageUrls.map((imageUrl, index) => ({ imageIndex: index + 1, imageUrl })),
-    concurrency: IMAGE_UPLOAD_QUEUE_CONCURRENCY,
-    pushIntervalMs: IMAGE_PUSH_INTERVAL_MS,
-    processItem: ({ imageIndex, imageUrl }) => uploadMultimodalImage({
+  const imageItems = imageUrls.map((imageUrl, index) => ({ imageIndex: index + 1, imageUrl }));
+  const { error: fetchError, results: fetchedImages } = await runImageQueue({
+    items: imageItems,
+    concurrency: IMAGE_FETCH_QUEUE_CONCURRENCY,
+    processItem: ({ imageIndex, imageUrl }) => fetchMultimodalImage({
       imageIndex,
       imageUrl,
+      logRequest,
+    }),
+  });
+  if (fetchError) return fetchError;
+
+  const { error: imageError, results: imageResults } = await runImageQueue({
+    items: fetchedImages,
+    concurrency: IMAGE_UPLOAD_QUEUE_CONCURRENCY,
+    processItem: (fetched) => uploadFetchedMultimodalImage({
+      ...fetched,
       origin,
       clientid,
       token,

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -5,13 +5,29 @@ import { buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl } from './api.
 
 const MULTIMODAL_LOG_KEY = 'glaas.multimodal.log';
 const IMAGE_SAVE_QUEUE_CONCURRENCY = 5;
-const IMAGE_UPLOAD_QUEUE_CONCURRENCY = 5;
+const IMAGE_UPLOAD_QUEUE_CONCURRENCY = 3;
 const IMAGE_PUSH_INTERVAL_MS = 250;
 const PUT_URL_MAX_RETRIES = 4;
 const PUT_URL_RETRY_WAIT_MS = 1000;
+const PUT_URL_429_DEFAULT_DELAY_MS = 30250;
+
+let putUrlRateLimitUntil = 0;
 
 function delay(ms) {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+async function awaitPutUrlRateLimitGate() {
+  const waitMs = putUrlRateLimitUntil - Date.now();
+  if (waitMs > 0) await delay(waitMs);
+}
+
+function extendPutUrlRateLimitGate(waitMs) {
+  putUrlRateLimitUntil = Math.max(putUrlRateLimitUntil, Date.now() + waitMs);
+}
+
+export function resetPutUrlRateLimitGateForTests() {
+  putUrlRateLimitUntil = 0;
 }
 
 function getPutUrlRateLimitHeaders(resp) {
@@ -34,7 +50,27 @@ function getMillisToSleep(retryHeaderString) {
 function putUrl429RetryDelayMs({ resp, waitInterval }) {
   const { retryAfter, xRateLimitRetryAfterSeconds } = getPutUrlRateLimitHeaders(resp);
   const retryIn = getMillisToSleep(retryAfter || xRateLimitRetryAfterSeconds || '');
-  return retryIn > 0 ? retryIn + 250 : waitInterval;
+  if (retryIn > 0) return retryIn + 250;
+  return Math.max(waitInterval, PUT_URL_429_DEFAULT_DELAY_MS);
+}
+
+async function backoffPutUrl429({
+  waitMs,
+  logRequest,
+  attempt,
+  assetName,
+  status,
+  detail = {},
+}) {
+  extendPutUrlRateLimitGate(waitMs);
+  logRequest?.('getPutURL-retry', {
+    status,
+    attempt: attempt + 1,
+    waitMs,
+    assetName,
+    ...detail,
+  });
+  await delay(waitMs);
 }
 
 function putUrlAssetName(assetName) {
@@ -92,18 +128,19 @@ export async function getPutUrlForFile({
   let waitInterval = PUT_URL_RETRY_WAIT_MS;
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
+      await awaitPutUrlRateLimitGate();
       const resp = await fetch(url, opts);
       if (resp.status === 429 && attempt < maxRetries) {
         waitInterval *= 2;
         const waitMs = putUrl429RetryDelayMs({ resp, waitInterval });
-        logRequest?.('getPutURL-retry', {
-          status: 429,
-          attempt: attempt + 1,
+        await backoffPutUrl429({
           waitMs,
+          logRequest,
+          attempt,
           assetName,
-          ...getPutUrlRateLimitHeaders(resp),
+          status: 429,
+          detail: getPutUrlRateLimitHeaders(resp),
         });
-        await delay(waitMs);
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -112,7 +149,20 @@ export async function getPutUrlForFile({
       if (!json.putURL) return { error: 'Missing putURL in response.', status: resp.status, json };
       logRequest?.('getPutURL-response', { status: resp.status, assetName });
       return { putURL: json.putURL, instanceId: json.instanceId, status: resp.status };
-    } catch {
+    } catch (e) {
+      if (attempt < maxRetries) {
+        const waitMs = PUT_URL_429_DEFAULT_DELAY_MS;
+        await backoffPutUrl429({
+          waitMs,
+          logRequest,
+          attempt,
+          assetName,
+          status: 'fetch-error',
+          detail: { error: String(e) },
+        });
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       return { error: 'Error getting put URL for file.' };
     }
   }

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -402,13 +402,29 @@ function isProjectContentDaLiveUrl(href, org, site) {
   }
 }
 
-/** MVP: absolute https://content.da.live/... image URLs from img[src] only (not relative ./media_ from DNT). */
+const GLAAS_MULTIMODAL_IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg']);
+
+function isGlaasMultimodalImageUrl(href) {
+  try {
+    const pathname = decodeURIComponent(new URL(href).pathname);
+    const filename = pathname.split('/').pop() ?? '';
+    const dot = filename.lastIndexOf('.');
+    if (dot === -1) return false;
+    return GLAAS_MULTIMODAL_IMAGE_EXTS.has(filename.slice(dot + 1).toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/** MVP: absolute https://content.da.live/... png/jpeg image URLs from img[src] only. */
 export function collectContentDaLiveImageUrls(html, { org, site } = {}) {
   const doc = new DOMParser().parseFromString(html, 'text/html');
   const urls = new Set();
   doc.querySelectorAll('img[src]').forEach((img) => {
     const src = img.getAttribute('src');
-    if (isProjectContentDaLiveUrl(src, org, site)) urls.add(new URL(src).href);
+    if (isProjectContentDaLiveUrl(src, org, site) && isGlaasMultimodalImageUrl(src)) {
+      urls.add(new URL(src).href);
+    }
   });
   return [...urls];
 }

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -1,7 +1,9 @@
 import { DA_ORIGIN } from '../../../../public/utils/constants.js';
 import { Queue } from '../../../../public/utils/tree.js';
 import { daFetch } from '../../../../utils/daFetch.js';
-import { buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl } from './api.js';
+import {
+  buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl, throttle,
+} from './api.js';
 
 const MULTIMODAL_LOG_KEY = 'glaas.multimodal.log';
 /** Documented GLaaS budget is 120/min per client id; target 100 for shared-stage headroom. */
@@ -18,12 +20,6 @@ const IMAGE_PUSH_INTERVAL_MS = 250;
 const PUT_URL_MAX_RETRIES = 4;
 const PUT_URL_RETRY_WAIT_MS = 1000;
 const PUT_URL_429_FALLBACK_DELAY_MS = Math.ceil(GLAAS_API_WINDOW_MS / 2) + 250;
-
-let glaasApiRateLimitUntil = 0;
-
-function delay(ms) {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
-}
 
 export function createPutUrlRollingLimiter({
   limitPerWindow = GLAAS_API_LIMIT_PER_MINUTE,
@@ -62,7 +58,7 @@ export function createPutUrlRollingLimiter({
           const waitForSpacing = Math.max(0, lastAcquireAt + minIntervalMs - now);
           const waitMs = Math.max(waitForWindow, waitForSpacing);
           if (waitMs > 0) {
-            await delay(waitMs);
+            await throttle(waitMs);
             // eslint-disable-next-line no-continue
             continue;
           }
@@ -84,18 +80,14 @@ export function createPutUrlRollingLimiter({
 
 const glaasApiLimiter = createPutUrlRollingLimiter();
 
-async function awaitGlaasApiRateLimitGate() {
-  const waitMs = glaasApiRateLimitUntil - Date.now();
-  if (waitMs > 0) await delay(waitMs);
-}
-
 async function acquireGlaasApiSlot() {
-  await awaitGlaasApiRateLimitGate();
   await glaasApiLimiter.acquire();
 }
 
-function extendGlaasApiRateLimitGate(waitMs) {
-  glaasApiRateLimitUntil = Math.max(glaasApiRateLimitUntil, Date.now() + waitMs);
+function putUrlOpaqueRetryDelayMs({ waitInterval }) {
+  const windowWait = glaasApiLimiter.windowRetryDelayMs();
+  if (windowWait > 0) return windowWait;
+  return Math.max(waitInterval, PUT_URL_429_FALLBACK_DELAY_MS);
 }
 
 function putUrlReactiveRetryDelayMs({ waitInterval }) {
@@ -106,7 +98,6 @@ function putUrlReactiveRetryDelayMs({ waitInterval }) {
 }
 
 export function resetPutUrlRateLimitGateForTests() {
-  glaasApiRateLimitUntil = 0;
   glaasApiLimiter.reset();
 }
 
@@ -142,7 +133,6 @@ async function backoffPutUrl429({
   status,
   detail = {},
 }) {
-  extendGlaasApiRateLimitGate(waitMs);
   logRequest?.('getPutURL-retry', {
     status,
     attempt: attempt + 1,
@@ -150,7 +140,7 @@ async function backoffPutUrl429({
     assetName,
     ...detail,
   });
-  await delay(waitMs);
+  await throttle(waitMs);
 }
 
 function putUrlAssetName(assetName) {
@@ -231,7 +221,7 @@ export async function getPutUrlForFile({
       return { putURL: json.putURL, instanceId: json.instanceId, status: resp.status };
     } catch (e) {
       if (attempt < maxRetries) {
-        const waitMs = glaasApiLimiter.windowRetryDelayMs() || PUT_URL_429_FALLBACK_DELAY_MS;
+        const waitMs = putUrlOpaqueRetryDelayMs({ waitInterval });
         await backoffPutUrl429({
           waitMs,
           logRequest,
@@ -527,7 +517,7 @@ async function runImageQueue({
   if (pushIntervalMs) {
     const pending = [];
     for (let i = 0; i < items.length; i += 1) {
-      if (i > 0) await delay(pushIntervalMs);
+      if (i > 0) await throttle(pushIntervalMs);
       pending.push(queue.push(items[i]));
     }
     await Promise.all(pending);
@@ -543,15 +533,17 @@ async function probeMultimodalAssetStatuses({
   service, token, task, langCode, assetNames,
 }) {
   const langTask = { ...task, code: langCode };
-  const { results: probes } = await runImageQueue({
+  const queued = await runImageQueue({
     items: assetNames,
     concurrency: V2_PROBE_QUEUE_CONCURRENCY,
     processItem: async (assetName) => {
       const meta = await getV2Asset(service, token, langTask, assetName);
+      if (meta.error) return meta;
       return v2AssetStatusFromProbe(assetName, meta);
     },
   });
-  return probes;
+  if (queued.error) return { error: queued.error };
+  return queued.results ?? [];
 }
 
 /**
@@ -576,6 +568,15 @@ export async function getMultimodalV2TaskStatus({
       langCode: lang.code,
       assetNames,
     });
+    if (assets?.error) {
+      subtasks.push({
+        targetLocale: lang.code,
+        status: 'IN_PROGRESS',
+        assets: [],
+      });
+      // eslint-disable-next-line no-continue
+      continue;
+    }
     const allCompleted = assets.every((asset) => asset.status === 'COMPLETED');
     subtasks.push({
       targetLocale: lang.code,

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -20,6 +20,8 @@ const IMAGE_PUSH_INTERVAL_MS = 250;
 const PUT_URL_MAX_RETRIES = 4;
 const PUT_URL_RETRY_WAIT_MS = 1000;
 const PUT_URL_429_FALLBACK_DELAY_MS = Math.ceil(GLAAS_API_WINDOW_MS / 2) + 250;
+export const MEDIA_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
+export const MEDIA_IMAGE_UPLOAD_MAX_BYTES = 5 * 1024 * 1024;
 
 export function createPutUrlRollingLimiter({
   limitPerWindow = GLAAS_API_LIMIT_PER_MINUTE,
@@ -328,7 +330,12 @@ export async function getV2Asset(service, token, task, assetName) {
     await acquireGlaasApiSlot();
     const path = ensureLeadingSlash(assetName);
     const resp = await fetch(`${origin}/api/l10n/v2.0/tasks/${product}/${project}/${taskName}/assets/${lang}${path}`, opts);
-    const json = await resp.json();
+    let json;
+    try {
+      json = await resp.json();
+    } catch {
+      json = null;
+    }
     return { status: resp.status, json };
   } catch {
     return { error: 'Error getting v2 asset.' };
@@ -837,17 +844,82 @@ export function blobContentTypeForDaSource({ daSourcePath, blob, contentType }) 
   return contentType || blob?.type || 'application/octet-stream';
 }
 
+export function formatMediaImageByteSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export function checkMediaImageSize({ glaasName, mediaPath, sizeBytes, logRequest }) {
+  const exceedsDocumentedLimit = sizeBytes > MEDIA_IMAGE_MAX_BYTES;
+  const exceedsUploadLimit = sizeBytes > MEDIA_IMAGE_UPLOAD_MAX_BYTES;
+  const detail = {
+    glaasName,
+    mediaPath,
+    sizeBytes,
+    sizeFormatted: formatMediaImageByteSize(sizeBytes),
+    maxBytes: MEDIA_IMAGE_UPLOAD_MAX_BYTES,
+    maxFormatted: formatMediaImageByteSize(MEDIA_IMAGE_UPLOAD_MAX_BYTES),
+    documentedMaxBytes: MEDIA_IMAGE_MAX_BYTES,
+    documentedMaxFormatted: formatMediaImageByteSize(MEDIA_IMAGE_MAX_BYTES),
+    exceedsUploadLimit,
+    exceedsDocumentedLimit,
+  };
+  logRequest?.('media-image-size', detail);
+  if (!logRequest) {
+    console.info('[GLaaS multimodal] Media image upload size:', detail);
+  }
+  if (exceedsUploadLimit) {
+    console.warn('[GLaaS multimodal] Image exceeds observed Media Bus upload limit:', detail);
+  } else if (exceedsDocumentedLimit) {
+    console.warn('[GLaaS multimodal] Image exceeds documented Media Bus limit:', detail);
+  }
+  return detail;
+}
+
+function mediaImageSkipWarning({ glaasName, sizeFormatted, maxFormatted }) {
+  return `Skipping oversized image (keeping source URL): ${glaasName} (${sizeFormatted} exceeds ${maxFormatted} upload limit). Compress or resize the source asset.`;
+}
+
+function skippedOversizedMediaUpload({ glaasName, sizeCheck }) {
+  return {
+    skipped: true,
+    reason: 'exceeds_upload_limit',
+    warning: mediaImageSkipWarning({
+      glaasName,
+      sizeFormatted: sizeCheck.sizeFormatted,
+      maxFormatted: sizeCheck.maxFormatted,
+    }),
+    glaasName,
+    ...sizeCheck,
+  };
+}
+
 export async function postImageToDaMedia({
-  org, site, langCode, glaasName, blob, contentType,
+  org, site, langCode, glaasName, blob, contentType, logRequest,
 }) {
   const mediaPath = buildTranslatedMediaPath({ langCode, glaasName });
   const type = blobContentTypeForDaSource({ daSourcePath: mediaPath, blob, contentType });
   const data = blob.type === type ? blob : new Blob([await blob.arrayBuffer()], { type });
+  const sizeCheck = checkMediaImageSize({
+    glaasName,
+    mediaPath,
+    sizeBytes: data.size,
+    logRequest,
+  });
+  if (sizeCheck.exceedsUploadLimit) {
+    return skippedOversizedMediaUpload({ glaasName, sizeCheck });
+  }
   const body = new FormData();
   body.append('data', data, mediaPath.split('/').pop());
   try {
     const resp = await daFetch(`${DA_ORIGIN}/media/${org}/${site}${mediaPath}`, { method: 'POST', body });
-    if (!resp.ok) return { error: 'Error uploading image to media.', status: resp.status };
+    if (!resp.ok) {
+      if (resp.status === 413) {
+        return skippedOversizedMediaUpload({ glaasName, sizeCheck });
+      }
+      return { error: 'Error uploading image to media.', status: resp.status, glaasName, ...sizeCheck };
+    }
     const json = await resp.json();
     const href = json?.uri ?? json?.url;
     if (!href) return { error: 'Missing media URI in response.', status: resp.status, json };
@@ -865,6 +937,7 @@ async function saveMultimodalImageToMedia({
   site,
   langCode,
   image,
+  logRequest,
 }) {
   const downloaded = await downloadMultimodalAssetBlob(service, token, task, image.glaasName);
   if (downloaded.error) return downloaded;
@@ -876,7 +949,25 @@ async function saveMultimodalImageToMedia({
     glaasName: image.glaasName,
     blob: downloaded.blob,
     contentType: downloaded.contentType,
+    logRequest,
   });
+  if (uploaded.skipped) {
+    const detail = {
+      glaasName: image.glaasName,
+      contentDaLiveUrl: image.contentDaLiveUrl,
+      warning: uploaded.warning,
+      sizeFormatted: uploaded.sizeFormatted,
+      maxFormatted: uploaded.maxFormatted,
+    };
+    logRequest?.('media-image-skip', detail);
+    console.warn('[GLaaS multimodal] Skipping oversized image (keeping source URL):', detail);
+    return {
+      skipped: true,
+      glaasName: image.glaasName,
+      contentDaLiveUrl: image.contentDaLiveUrl,
+      warning: uploaded.warning,
+    };
+  }
   if (uploaded.error) return uploaded;
 
   const sourceKey = contentDaLivePathKey(image.contentDaLiveUrl);
@@ -892,8 +983,11 @@ export async function prepareMultimodalPageForSave({
   langCode,
   pageAsset,
   htmlAssetName,
+  logRequest,
+  onWarning,
 }) {
   const pathToNewUrl = new Map();
+  const skippedImages = [];
   const locale = langCode ?? task.code;
 
   const { error: imageError, results: imageEntries } = await runImageQueue({
@@ -907,12 +1001,21 @@ export async function prepareMultimodalPageForSave({
       site,
       langCode: locale,
       image,
+      logRequest,
     }),
   });
   if (imageError) return imageError;
 
-  imageEntries.forEach(({ sourceKey, url }) => {
-    if (sourceKey) pathToNewUrl.set(sourceKey, url);
+  imageEntries.forEach((entry) => {
+    if (entry?.skipped) {
+      skippedImages.push(entry);
+      return;
+    }
+    if (entry?.sourceKey) pathToNewUrl.set(entry.sourceKey, entry.url);
+  });
+
+  skippedImages.forEach(({ warning }) => {
+    onWarning?.({ text: warning, type: 'warning' });
   });
 
   const htmlDownload = await downloadMultimodalAsset(service, token, task, htmlAssetName);
@@ -922,5 +1025,5 @@ export async function prepareMultimodalPageForSave({
     ? rewriteContentDaLiveImageUrls(htmlDownload, pathToNewUrl)
     : htmlDownload;
 
-  return { text };
+  return { text, skippedImages };
 }

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -4,7 +4,38 @@ import { daFetch } from '../../../../utils/daFetch.js';
 import { buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl } from './api.js';
 
 const MULTIMODAL_LOG_KEY = 'glaas.multimodal.log';
-const IMAGE_QUEUE_CONCURRENCY = 5;
+const IMAGE_SAVE_QUEUE_CONCURRENCY = 5;
+const IMAGE_UPLOAD_QUEUE_CONCURRENCY = 5;
+const IMAGE_PUSH_INTERVAL_MS = 250;
+const PUT_URL_MAX_RETRIES = 4;
+const PUT_URL_RETRY_WAIT_MS = 1000;
+
+function delay(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+function getPutUrlRateLimitHeaders(resp) {
+  return {
+    retryAfter: resp.headers.get('retry-after'),
+    xRateLimitRetryAfterSeconds: resp.headers.get('x-rate-limit-retry-after-seconds'),
+  };
+}
+
+function getMillisToSleep(retryHeaderString) {
+  if (typeof retryHeaderString === 'string' && retryHeaderString) {
+    const millisToSleep = Math.round(parseFloat(retryHeaderString) * 1000);
+    if (!Number.isNaN(millisToSleep) && millisToSleep > 0) return millisToSleep;
+    const dateDiff = new Date(retryHeaderString) - Date.now();
+    if (dateDiff > 0) return dateDiff;
+  }
+  return -1;
+}
+
+function putUrl429RetryDelayMs({ resp, waitInterval }) {
+  const { retryAfter, xRateLimitRetryAfterSeconds } = getPutUrlRateLimitHeaders(resp);
+  const retryIn = getMillisToSleep(retryAfter || xRateLimitRetryAfterSeconds || '');
+  return retryIn > 0 ? retryIn + 250 : waitInterval;
+}
 
 function putUrlAssetName(assetName) {
   return assetName.replace(/^\/+/, '').replaceAll('/', '-');
@@ -45,21 +76,47 @@ export function logMultimodalRequest(step, detail) {
   console.info('[GLaaS multimodal]', step, detail);
 }
 
-export async function getPutUrlForFile({ origin, clientid, token, assetName, logRequest }) {
+export async function getPutUrlForFile({
+  origin,
+  clientid,
+  token,
+  assetName,
+  logRequest,
+  maxRetries = PUT_URL_MAX_RETRIES,
+}) {
   const opts = getOpts(clientid, token);
   const pathName = putUrlAssetName(assetName);
   const url = `${origin}/api/l10n/v1.1/asset/getPutURLForFile/${pathName}`;
   logRequest?.('getPutURL', { method: 'GET', url, assetName, wireName: pathName });
-  try {
-    const resp = await fetch(url, opts);
-    const json = await resp.json();
-    if (!resp.ok) return { error: 'Error getting put URL for file.', status: resp.status, json };
-    if (!json.putURL) return { error: 'Missing putURL in response.', status: resp.status, json };
-    logRequest?.('getPutURL-response', { status: resp.status, assetName });
-    return { putURL: json.putURL, instanceId: json.instanceId, status: resp.status };
-  } catch {
-    return { error: 'Error getting put URL for file.' };
+
+  let waitInterval = PUT_URL_RETRY_WAIT_MS;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      const resp = await fetch(url, opts);
+      if (resp.status === 429 && attempt < maxRetries) {
+        waitInterval *= 2;
+        const waitMs = putUrl429RetryDelayMs({ resp, waitInterval });
+        logRequest?.('getPutURL-retry', {
+          status: 429,
+          attempt: attempt + 1,
+          waitMs,
+          assetName,
+          ...getPutUrlRateLimitHeaders(resp),
+        });
+        await delay(waitMs);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const json = await resp.json();
+      if (!resp.ok) return { error: 'Error getting put URL for file.', status: resp.status, json };
+      if (!json.putURL) return { error: 'Missing putURL in response.', status: resp.status, json };
+      logRequest?.('getPutURL-response', { status: resp.status, assetName });
+      return { putURL: json.putURL, instanceId: json.instanceId, status: resp.status };
+    } catch {
+      return { error: 'Error getting put URL for file.' };
+    }
   }
+  return { error: 'Error getting put URL for file.' };
 }
 
 function contentTypeForPutUrl(putURL, contentType) {
@@ -395,7 +452,14 @@ export function buildMultimodalTextAsset({
   };
 }
 
-async function runImageQueue({ items, processItem, concurrency = IMAGE_QUEUE_CONCURRENCY }) {
+async function runImageQueue({
+  items,
+  processItem,
+  concurrency = IMAGE_SAVE_QUEUE_CONCURRENCY,
+  pushIntervalMs,
+}) {
+  if (!items.length) return { results: [] };
+
   let firstError;
   const results = [];
   const queue = new Queue(async (item) => {
@@ -408,7 +472,17 @@ async function runImageQueue({ items, processItem, concurrency = IMAGE_QUEUE_CON
     results.push(result);
   }, concurrency);
 
-  await Promise.all(items.map((item) => queue.push(item)));
+  if (pushIntervalMs) {
+    const pending = [];
+    for (let i = 0; i < items.length; i += 1) {
+      if (i > 0) await delay(pushIntervalMs);
+      pending.push(queue.push(items[i]));
+    }
+    await Promise.all(pending);
+  } else {
+    await Promise.all(items.map((item) => queue.push(item)));
+  }
+
   if (firstError) return { error: firstError };
   return { results };
 }
@@ -517,6 +591,8 @@ export async function uploadMultimodalPageAssets({
 
   const { error: imageError, results: imageResults } = await runImageQueue({
     items: imageUrls.map((imageUrl, index) => ({ imageIndex: index + 1, imageUrl })),
+    concurrency: IMAGE_UPLOAD_QUEUE_CONCURRENCY,
+    pushIntervalMs: IMAGE_PUSH_INTERVAL_MS,
     processItem: ({ imageIndex, imageUrl }) => uploadMultimodalImage({
       imageIndex,
       imageUrl,
@@ -651,6 +727,7 @@ export async function prepareMultimodalPageForSave({
 
   const { error: imageError, results: imageEntries } = await runImageQueue({
     items: pageAsset.images,
+    pushIntervalMs: IMAGE_PUSH_INTERVAL_MS,
     processItem: (image) => saveMultimodalImageToMedia({
       service,
       token,

--- a/nx/blocks/loc/views/translate/index.js
+++ b/nx/blocks/loc/views/translate/index.js
@@ -125,6 +125,7 @@ async function saveLang({
     langIndex,
     urls: urlsToSave,
     saveFn,
+    sendMessage,
   });
 
   const savedCount = saved.filter((url) => url.status === 'success').length;

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -218,14 +218,14 @@ class NxLocTranslate extends LitElement {
 
     const { cancelTranslation } = this._service.connector;
 
-    let cancelAccepted = true;
+    let shouldRefresh = false;
     for (const lang of this._translateLangs) {
       const result = await cancelTranslation({ service: this._service, lang, sendMessage });
-      if (result?.ok === false) cancelAccepted = false;
+      if (result?.ok !== false) shouldRefresh = true;
     }
 
-    if (cancelAccepted) {
-      // Re-fetch status to ensure the service canceled everything.
+    if (shouldRefresh) {
+      // Refresh locales GLaaS accepted; skip when every cancel was rejected.
       await this.handleGetStatus();
     }
   }

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -218,12 +218,16 @@ class NxLocTranslate extends LitElement {
 
     const { cancelTranslation } = this._service.connector;
 
+    let cancelAccepted = true;
     for (const lang of this._translateLangs) {
-      await cancelTranslation({ service: this._service, lang, sendMessage });
+      const result = await cancelTranslation({ service: this._service, lang, sendMessage });
+      if (result?.ok === false) cancelAccepted = false;
     }
 
-    // Re-fetch status to ensure the service canceled everything.
-    this.handleGetStatus();
+    if (cancelAccepted) {
+      // Re-fetch status to ensure the service canceled everything.
+      await this.handleGetStatus();
+    }
   }
 
   async handleCancelLang(lang) {
@@ -231,9 +235,11 @@ class NxLocTranslate extends LitElement {
 
     const { cancelTranslation } = this._service.connector;
 
-    await cancelTranslation({ service: this._service, lang, sendMessage });
+    const result = await cancelTranslation({ service: this._service, lang, sendMessage });
 
-    await this.handleGetStatus();
+    if (result?.ok !== false) {
+      await this.handleGetStatus();
+    }
   }
 
   async handleCopyAll() {

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -10,6 +10,7 @@ import {
   contentDaLiveToDaSourceUrl,
   getMultimodalV2TaskStatus,
   getPutUrlForFile,
+  resetPutUrlRateLimitGateForTests,
   isV2AssetReady,
   v2AssetStatusFromProbe,
 } from '../../../nx/blocks/loc/connectors/glaas/multimodalApi.js';
@@ -17,6 +18,7 @@ import {
 describe('GLaaS multimodal getPutUrlForFile', () => {
   afterEach(() => {
     sinon.restore();
+    resetPutUrlRateLimitGateForTests();
   });
 
   it('retries on 429 using Retry-After before returning putURL', async () => {
@@ -48,6 +50,101 @@ describe('GLaaS multimodal getPutUrlForFile', () => {
 
     expect(result.putURL).to.equal('https://put.example/blob');
     expect(calls).to.equal(2);
+    clock.restore();
+  });
+
+  it('uses default backoff when 429 has no readable rate-limit headers', async () => {
+    const clock = sinon.useFakeTimers();
+    let calls = 0;
+    sinon.stub(window, 'fetch').callsFake(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ putURL: 'https://put.example/blob' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const promise = getPutUrlForFile({
+      origin: 'https://glaas.example',
+      clientid: 'client',
+      token: 'token',
+      assetName: '/drafts/demo/hero.png',
+      maxRetries: 1,
+    });
+    await clock.tickAsync(30250);
+    const result = await promise;
+
+    expect(result.putURL).to.equal('https://put.example/blob');
+    clock.restore();
+  });
+
+  it('retries on opaque fetch failure without a readable 429 response', async () => {
+    const clock = sinon.useFakeTimers();
+    const logRequest = sinon.spy();
+    let calls = 0;
+    sinon.stub(window, 'fetch').callsFake(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ putURL: 'https://put.example/blob' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const promise = getPutUrlForFile({
+      origin: 'https://glaas.example',
+      clientid: 'client',
+      token: 'token',
+      assetName: '/drafts/demo/hero.png',
+      logRequest,
+      maxRetries: 1,
+    });
+    await clock.tickAsync(30250);
+    const result = await promise;
+
+    expect(result.putURL).to.equal('https://put.example/blob');
+    expect(logRequest.calledWith('getPutURL-retry', sinon.match({
+      status: 'fetch-error',
+      waitMs: 30250,
+    }))).to.be.true;
+    clock.restore();
+  });
+
+  it('retries after fetch error following a 429', async () => {
+    const clock = sinon.useFakeTimers();
+    let calls = 0;
+    sinon.stub(window, 'fetch').callsFake(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
+      }
+      if (calls === 2) {
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ putURL: 'https://put.example/blob' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const promise = getPutUrlForFile({
+      origin: 'https://glaas.example',
+      clientid: 'client',
+      token: 'token',
+      assetName: '/drafts/demo/hero.png',
+      maxRetries: 2,
+    });
+    await clock.tickAsync(30250);
+    await clock.tickAsync(30250);
+    const result = await promise;
+
+    expect(result.putURL).to.equal('https://put.example/blob');
+    expect(calls).to.equal(3);
     clock.restore();
   });
 

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -417,6 +417,28 @@ describe('GLaaS multimodal v2 asset status', () => {
     expect(result.json[0].assets.every((asset) => asset.status !== 'COMPLETED')).to.equal(true);
   });
 
+  it('returns IN_PROGRESS without throwing when a v2 probe request fails', async () => {
+    sinon.stub(window, 'fetch').rejects(new TypeError('Failed to fetch'));
+
+    const result = await getMultimodalV2TaskStatus({
+      service: { clientid: 'client', origin: 'https://glaas.example' },
+      token: 'token',
+      task: { name: 'task-1', workflow: 'Product/Project' },
+      langs: [{ code: 'de' }],
+      pageAssets: {
+        '/page': {
+          htmlGlaasName: '/drafts/page.html',
+          images: [{ glaasName: '/media/a.png' }],
+        },
+      },
+    });
+
+    expect(result.status).to.equal(200);
+    expect(result.json[0].targetLocale).to.equal('de');
+    expect(result.json[0].status).to.equal('IN_PROGRESS');
+    expect(result.json[0].assets).to.deep.equal([]);
+  });
+
   afterEach(() => {
     sinon.restore();
   });

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -9,9 +9,70 @@ import {
   countMultimodalTranslatedPages,
   contentDaLiveToDaSourceUrl,
   getMultimodalV2TaskStatus,
+  getPutUrlForFile,
   isV2AssetReady,
   v2AssetStatusFromProbe,
 } from '../../../nx/blocks/loc/connectors/glaas/multimodalApi.js';
+
+describe('GLaaS multimodal getPutUrlForFile', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retries on 429 using Retry-After before returning putURL', async () => {
+    const clock = sinon.useFakeTimers();
+    let calls = 0;
+    sinon.stub(window, 'fetch').callsFake(() => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.resolve(new Response(JSON.stringify({}), {
+          status: 429,
+          headers: { 'Retry-After': '1' },
+        }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ putURL: 'https://put.example/blob' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const promise = getPutUrlForFile({
+      origin: 'https://glaas.example',
+      clientid: 'client',
+      token: 'token',
+      assetName: '/drafts/demo/hero.png',
+      maxRetries: 1,
+    });
+    await clock.tickAsync(1250);
+    const result = await promise;
+
+    expect(result.putURL).to.equal('https://put.example/blob');
+    expect(calls).to.equal(2);
+    clock.restore();
+  });
+
+  it('returns error when 429 persists after retries', async () => {
+    const clock = sinon.useFakeTimers();
+    sinon.stub(window, 'fetch').resolves(new Response(JSON.stringify({}), {
+      status: 429,
+      headers: { 'Retry-After': '1' },
+    }));
+
+    const promise = getPutUrlForFile({
+      origin: 'https://glaas.example',
+      clientid: 'client',
+      token: 'token',
+      assetName: '/drafts/demo/hero.png',
+      maxRetries: 1,
+    });
+    await clock.tickAsync(1250);
+    const result = await promise;
+
+    expect(result.error).to.equal('Error getting put URL for file.');
+    expect(result.status).to.equal(429);
+    clock.restore();
+  });
+});
 
 describe('GLaaS multimodal source preview URL', () => {
   it('normalizes aem.page href for GLaaS (strip trailing /index)', () => {

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -8,6 +8,7 @@ import {
   collectMultimodalAssetNames,
   countMultimodalTranslatedPages,
   contentDaLiveToDaSourceUrl,
+  createPutUrlRollingLimiter,
   getMultimodalV2TaskStatus,
   getPutUrlForFile,
   resetPutUrlRateLimitGateForTests,
@@ -16,158 +17,188 @@ import {
 } from '../../../nx/blocks/loc/connectors/glaas/multimodalApi.js';
 
 describe('GLaaS multimodal getPutUrlForFile', () => {
+  beforeEach(() => {
+    resetPutUrlRateLimitGateForTests();
+  });
+
   afterEach(() => {
+    if (sinon.clock) sinon.clock.restore();
     sinon.restore();
     resetPutUrlRateLimitGateForTests();
   });
 
   it('retries on 429 using Retry-After before returning putURL', async () => {
     const clock = sinon.useFakeTimers();
-    let calls = 0;
-    sinon.stub(window, 'fetch').callsFake(() => {
-      calls += 1;
-      if (calls === 1) {
-        return Promise.resolve(new Response(JSON.stringify({}), {
-          status: 429,
-          headers: { 'Retry-After': '1' },
-        }));
-      }
-      return Promise.resolve(new Response(
-        JSON.stringify({ putURL: 'https://put.example/blob' }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ));
-    });
+    try {
+      let calls = 0;
+      sinon.stub(window, 'fetch').callsFake(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve(new Response(JSON.stringify({}), {
+            status: 429,
+            headers: { 'Retry-After': '1' },
+          }));
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ putURL: 'https://put.example/blob' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      });
 
-    const promise = getPutUrlForFile({
-      origin: 'https://glaas.example',
-      clientid: 'client',
-      token: 'token',
-      assetName: '/drafts/demo/hero.png',
-      maxRetries: 1,
-    });
-    await clock.tickAsync(1250);
-    const result = await promise;
+      const promise = getPutUrlForFile({
+        origin: 'https://glaas.example',
+        clientid: 'client',
+        token: 'token',
+        assetName: '/drafts/demo/hero.png',
+        maxRetries: 1,
+      });
+      await clock.runAllAsync();
+      const result = await promise;
 
-    expect(result.putURL).to.equal('https://put.example/blob');
-    expect(calls).to.equal(2);
-    clock.restore();
+      expect(result.putURL).to.equal('https://put.example/blob');
+      expect(calls).to.equal(2);
+    } finally {
+      clock.restore();
+    }
   });
 
   it('uses default backoff when 429 has no readable rate-limit headers', async () => {
     const clock = sinon.useFakeTimers();
-    let calls = 0;
-    sinon.stub(window, 'fetch').callsFake(() => {
-      calls += 1;
-      if (calls === 1) {
-        return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
-      }
-      return Promise.resolve(new Response(
-        JSON.stringify({ putURL: 'https://put.example/blob' }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ));
-    });
+    try {
+      let calls = 0;
+      sinon.stub(window, 'fetch').callsFake(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ putURL: 'https://put.example/blob' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      });
 
-    const promise = getPutUrlForFile({
-      origin: 'https://glaas.example',
-      clientid: 'client',
-      token: 'token',
-      assetName: '/drafts/demo/hero.png',
-      maxRetries: 1,
-    });
-    await clock.tickAsync(30250);
-    const result = await promise;
+      const promise = getPutUrlForFile({
+        origin: 'https://glaas.example',
+        clientid: 'client',
+        token: 'token',
+        assetName: '/drafts/demo/hero.png',
+        maxRetries: 1,
+      });
+      await clock.runAllAsync();
+      const result = await promise;
 
-    expect(result.putURL).to.equal('https://put.example/blob');
-    clock.restore();
+      expect(result.putURL).to.equal('https://put.example/blob');
+    } finally {
+      clock.restore();
+    }
   });
 
   it('retries on opaque fetch failure without a readable 429 response', async () => {
     const clock = sinon.useFakeTimers();
-    const logRequest = sinon.spy();
-    let calls = 0;
-    sinon.stub(window, 'fetch').callsFake(() => {
-      calls += 1;
-      if (calls === 1) {
-        return Promise.reject(new TypeError('Failed to fetch'));
-      }
-      return Promise.resolve(new Response(
-        JSON.stringify({ putURL: 'https://put.example/blob' }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ));
-    });
+    try {
+      const logRequest = sinon.spy();
+      let calls = 0;
+      sinon.stub(window, 'fetch').callsFake(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.reject(new TypeError('Failed to fetch'));
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ putURL: 'https://put.example/blob' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      });
 
-    const promise = getPutUrlForFile({
-      origin: 'https://glaas.example',
-      clientid: 'client',
-      token: 'token',
-      assetName: '/drafts/demo/hero.png',
-      logRequest,
-      maxRetries: 1,
-    });
-    await clock.tickAsync(30250);
-    const result = await promise;
+      const promise = getPutUrlForFile({
+        origin: 'https://glaas.example',
+        clientid: 'client',
+        token: 'token',
+        assetName: '/drafts/demo/hero.png',
+        logRequest,
+        maxRetries: 1,
+      });
+      await clock.runAllAsync();
+      const result = await promise;
 
-    expect(result.putURL).to.equal('https://put.example/blob');
-    expect(logRequest.calledWith('getPutURL-retry', sinon.match({
-      status: 'fetch-error',
-      waitMs: 30250,
-    }))).to.be.true;
-    clock.restore();
+      expect(result.putURL).to.equal('https://put.example/blob');
+      expect(logRequest.calledWith('getPutURL-retry', sinon.match({
+        status: 'fetch-error',
+        waitMs: 30250,
+      }))).to.be.true;
+    } finally {
+      clock.restore();
+    }
   });
 
   it('retries after fetch error following a 429', async () => {
     const clock = sinon.useFakeTimers();
-    let calls = 0;
-    sinon.stub(window, 'fetch').callsFake(() => {
-      calls += 1;
-      if (calls === 1) {
-        return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
-      }
-      if (calls === 2) {
-        return Promise.reject(new TypeError('Failed to fetch'));
-      }
-      return Promise.resolve(new Response(
-        JSON.stringify({ putURL: 'https://put.example/blob' }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      ));
-    });
+    try {
+      let calls = 0;
+      sinon.stub(window, 'fetch').callsFake(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve(new Response(JSON.stringify({}), { status: 429 }));
+        }
+        if (calls === 2) {
+          return Promise.reject(new TypeError('Failed to fetch'));
+        }
+        return Promise.resolve(new Response(
+          JSON.stringify({ putURL: 'https://put.example/blob' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      });
 
-    const promise = getPutUrlForFile({
-      origin: 'https://glaas.example',
-      clientid: 'client',
-      token: 'token',
-      assetName: '/drafts/demo/hero.png',
-      maxRetries: 2,
-    });
-    await clock.tickAsync(30250);
-    await clock.tickAsync(30250);
-    const result = await promise;
+      const promise = getPutUrlForFile({
+        origin: 'https://glaas.example',
+        clientid: 'client',
+        token: 'token',
+        assetName: '/drafts/demo/hero.png',
+        maxRetries: 2,
+      });
+      await clock.runAllAsync();
+      const result = await promise;
 
-    expect(result.putURL).to.equal('https://put.example/blob');
-    expect(calls).to.equal(3);
-    clock.restore();
+      expect(result.putURL).to.equal('https://put.example/blob');
+      expect(calls).to.equal(3);
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('computes window retry delay when the rolling per-minute budget is exhausted', async () => {
+    const limiter = createPutUrlRollingLimiter({
+      limitPerWindow: 2,
+      windowMs: 60_000,
+      minIntervalMs: 500,
+    });
+    await limiter.acquire();
+    await limiter.acquire();
+    expect(limiter.windowRetryDelayMs()).to.be.above(0);
   });
 
   it('returns error when 429 persists after retries', async () => {
     const clock = sinon.useFakeTimers();
-    sinon.stub(window, 'fetch').resolves(new Response(JSON.stringify({}), {
-      status: 429,
-      headers: { 'Retry-After': '1' },
-    }));
+    try {
+      sinon.stub(window, 'fetch').resolves(new Response(JSON.stringify({}), {
+        status: 429,
+        headers: { 'Retry-After': '1' },
+      }));
 
-    const promise = getPutUrlForFile({
-      origin: 'https://glaas.example',
-      clientid: 'client',
-      token: 'token',
-      assetName: '/drafts/demo/hero.png',
-      maxRetries: 1,
-    });
-    await clock.tickAsync(1250);
-    const result = await promise;
+      const promise = getPutUrlForFile({
+        origin: 'https://glaas.example',
+        clientid: 'client',
+        token: 'token',
+        assetName: '/drafts/demo/hero.png',
+        maxRetries: 1,
+      });
+      await clock.runAllAsync();
+      const result = await promise;
 
-    expect(result.error).to.equal('Error getting put URL for file.');
-    expect(result.status).to.equal(429);
-    clock.restore();
+      expect(result.error).to.equal('Error getting put URL for file.');
+      expect(result.status).to.equal(429);
+    } finally {
+      clock.restore();
+    }
   });
 });
 
@@ -298,6 +329,10 @@ describe('GLaaS multimodal TEXT asset metadata', () => {
 });
 
 describe('GLaaS multimodal v2 asset status', () => {
+  beforeEach(() => {
+    resetPutUrlRateLimitGateForTests();
+  });
+
   it('treats 200 + signedURL as COMPLETED', () => {
     expect(isV2AssetReady({ status: 200, json: { signedURL: 'https://x' } })).to.equal(true);
     expect(isV2AssetReady({ status: 200, json: {} })).to.equal(false);

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -70,6 +70,20 @@ describe('GLaaS multimodal pageAssets', () => {
     expect(collectContentDaLiveImageUrls(html)).to.deep.equal([]);
   });
 
+  it('collects comma-containing filenames from img[src] without srcset fragments', () => {
+    const fullUrl = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/variant=default,%20width=full,%20content=feature%20image.png';
+    const html = `
+      <picture>
+        <source srcset="${fullUrl}">
+        <source srcset="${fullUrl}" media="(min-width: 600px)">
+        <img src="${fullUrl}" loading="lazy">
+      </picture>
+    `;
+    expect(collectContentDaLiveImageUrls(html, { org: 'adobecom', site: 'da-dc' })).to.deep.equal([
+      fullUrl,
+    ]);
+  });
+
   it('returns empty images when page has no content.da.live assets', () => {
     const entry = buildMultimodalPageAssetEntry({
       htmlAssetName: 'drafts/page.html',

--- a/test/loc/glaas/multimodalPageAssets.test.js
+++ b/test/loc/glaas/multimodalPageAssets.test.js
@@ -259,17 +259,43 @@ describe('GLaaS multimodal pageAssets', () => {
     expect(collectContentDaLiveImageUrls(html)).to.deep.equal([]);
   });
 
-  it('collects comma-containing filenames from img[src] without srcset fragments', () => {
-    const fullUrl = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/variant=default,%20width=full,%20content=feature%20image.png';
+  it('collects comma-separated png and jpeg filenames from img[src] only', () => {
+    const commaPng = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/variant=default,%20width=full,%20content=feature%20image.png';
+    const commaJpg = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/breakpoint=small,%20width=full,%20content=hero%20photo.jpg';
+    const commaSvg = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/variant=default,%20width=full,%20content=blur%20bg.svg';
     const html = `
       <picture>
-        <source srcset="${fullUrl}">
-        <source srcset="${fullUrl}" media="(min-width: 600px)">
-        <img src="${fullUrl}" loading="lazy">
+        <source srcset="${commaPng}">
+        <source srcset="${commaPng}" media="(min-width: 600px)">
+        <img src="${commaPng}" loading="lazy">
+      </picture>
+      <img src="${commaJpg}">
+      <picture>
+        <source srcset="${commaSvg}">
+        <source srcset="${commaSvg}" media="(min-width: 600px)">
+        <img src="${commaSvg}" loading="lazy">
       </picture>
     `;
     expect(collectContentDaLiveImageUrls(html, { org: 'adobecom', site: 'da-dc' })).to.deep.equal([
-      fullUrl,
+      commaPng,
+      commaJpg,
+    ]);
+  });
+
+  it('collects only png and jpeg images (GLaaS multimodal format support)', () => {
+    const html = `
+      <img src="https://content.da.live/adobecom/foo/hero.png">
+      <img src="https://content.da.live/adobecom/foo/photo.jpg">
+      <img src="https://content.da.live/adobecom/foo/photo.jpeg">
+      <img src="https://content.da.live/adobecom/foo/blur.svg">
+      <img src="https://content.da.live/adobecom/foo/anim.gif">
+      <img src="https://content.da.live/adobecom/foo/modern.webp">
+      <img src="https://content.da.live/adobecom/foo/next.avif">
+    `;
+    expect(collectContentDaLiveImageUrls(html, { org: 'adobecom', site: 'foo' })).to.deep.equal([
+      'https://content.da.live/adobecom/foo/hero.png',
+      'https://content.da.live/adobecom/foo/photo.jpg',
+      'https://content.da.live/adobecom/foo/photo.jpeg',
     ]);
   });
 

--- a/test/loc/glaas/multimodalSave.test.js
+++ b/test/loc/glaas/multimodalSave.test.js
@@ -4,6 +4,7 @@ import { DA_ORIGIN } from '../../../nx/public/utils/constants.js';
 import {
   blobContentTypeForDaSource,
   buildTranslatedMediaPath,
+  MEDIA_IMAGE_UPLOAD_MAX_BYTES,
   postImageToDaMedia,
   prepareMultimodalPageForSave,
   siteRelativePathFromContentDaLiveUrl,
@@ -67,6 +68,24 @@ describe('GLaaS multimodal save', () => {
       });
       const [url] = fetchStub.firstCall.args;
       expect(url).to.equal(`${DA_ORIGIN}/media/adobecom/da-dc/fr-CA/acrobat/online/test/report.png`);
+    });
+
+    it('postImageToDaMedia skips images above observed upload limit without POST', async () => {
+      const fetchStub = sinon.stub(window, 'fetch');
+      const oversized = new Blob([new Uint8Array(MEDIA_IMAGE_UPLOAD_MAX_BYTES + 1)], { type: 'image/jpeg' });
+      const result = await postImageToDaMedia({
+        org: 'adobecom',
+        site: 'da-dc',
+        langCode: 'de',
+        glaasName: '/hero/large.jpg',
+        blob: oversized,
+        contentType: 'image/jpeg',
+      });
+      expect(fetchStub.called).to.be.false;
+      expect(result.skipped).to.be.true;
+      expect(result.warning).to.include('hero/large.jpg');
+      expect(result.warning).to.include('5.00 MiB');
+      expect(result.warning).to.include('keeping source URL');
     });
   });
 
@@ -147,6 +166,70 @@ describe('GLaaS multimodal save', () => {
     expect(fetchStub.calledWith(expectedMediaPost, sinon.match({ method: 'POST' }))).to.be.true;
     expect(result.text).to.include('main--da-dc--adobecom.aem.page/media_abc.avif');
     expect(result.text).not.to.include(contentDaLiveUrl);
+  });
+
+  it('prepareMultimodalPageForSave skips oversized images and keeps source URLs in html', async () => {
+    const org = 'adobecom';
+    const site = 'da-dc';
+    const imageGlaasName = '/acrobat/shared/hero-large.jpg';
+    const htmlAssetName = '/drafts/page.html';
+    const contentDaLiveUrl = `https://content.da.live/${org}/${site}/acrobat/shared/hero-large.jpg`;
+    const translatedHtml = `<img src="${contentDaLiveUrl}">`;
+    const oversized = new Blob([new Uint8Array(MEDIA_IMAGE_UPLOAD_MAX_BYTES + 1)], { type: 'image/jpeg' });
+    const warnings = [];
+
+    const fetchStub = sinon.stub(window, 'fetch').callsFake((url) => {
+      const href = String(url);
+      if (href.includes('/api/l10n/v2.0/') && href.includes(encodeURI(imageGlaasName))) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ signedURL: 'https://signed.example/image' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      }
+      if (href.includes('/api/l10n/v2.0/') && href.includes(encodeURI(htmlAssetName))) {
+        return Promise.resolve(new Response(
+          JSON.stringify({ signedURL: 'https://signed.example/html' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+      }
+      if (href === 'https://signed.example/image') {
+        return Promise.resolve(new Response(oversized, { status: 200 }));
+      }
+      if (href === 'https://signed.example/html') {
+        return Promise.resolve(new Response(translatedHtml, {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }));
+      }
+      if (href.includes('/media/')) {
+        return Promise.resolve(new Response('', { status: 413 }));
+      }
+      return Promise.resolve(new Response('', { status: 404 }));
+    });
+
+    const result = await prepareMultimodalPageForSave({
+      service: { origin: 'https://glaas.example', clientid: 'client' },
+      token: 'token',
+      task: { name: 'task-1', code: 'de', workflow: 'P/P' },
+      org,
+      site,
+      langCode: 'de',
+      pageAsset: {
+        images: [{ glaasName: imageGlaasName, contentDaLiveUrl }],
+      },
+      htmlAssetName,
+      onWarning: (message) => warnings.push(message),
+    });
+
+    const mediaPosts = fetchStub.getCalls().filter((call) => String(call.args[0]).includes('/media/'));
+    expect(mediaPosts).to.have.length(0);
+    expect(result.text).to.include(contentDaLiveUrl);
+    expect(result.skippedImages).to.have.length(1);
+    expect(result.skippedImages[0].glaasName).to.equal(imageGlaasName);
+    expect(warnings).to.have.length(1);
+    expect(warnings[0].type).to.equal('warning');
+    expect(warnings[0].text).to.include('keeping source URL');
+    expect(warnings[0].text).to.include('hero-large.jpg');
   });
 
   it('rewrites img[src] and mirrors delivery URL onto picture source[srcset]', () => {

--- a/test/loc/glaas/multimodalSave.test.js
+++ b/test/loc/glaas/multimodalSave.test.js
@@ -149,18 +149,41 @@ describe('GLaaS multimodal save', () => {
     expect(result.text).not.to.include(contentDaLiveUrl);
   });
 
-  it('rewrites img and srcset content.da.live URLs to media bus delivery urls', () => {
+  it('rewrites img[src] and mirrors delivery URL onto picture source[srcset]', () => {
+    const deliveryUrl = 'https://main--da-dc--adobecom.aem.page/media_abc.avif';
     const html = `
       <picture>
         <source srcset="https://content.da.live/adobecom/da-dc/acrobat/foo/rect%201.png 1x">
+        <source srcset="https://content.da.live/adobecom/da-dc/acrobat/foo/rect%201.png 1x" media="(min-width: 600px)">
         <img src="https://content.da.live/adobecom/da-dc/acrobat/foo/rect%201.png">
       </picture>
     `;
     const pathToNewUrl = new Map([
-      ['/adobecom/da-dc/acrobat/foo/rect 1.png', 'https://main--da-dc--adobecom.aem.page/media_abc.avif'],
+      ['/adobecom/da-dc/acrobat/foo/rect 1.png', deliveryUrl],
     ]);
     const out = rewriteContentDaLiveImageUrls(html, pathToNewUrl);
-    expect(out).to.include('main--da-dc--adobecom.aem.page/media_abc.avif');
+    expect(out).to.include(`src="${deliveryUrl}"`);
+    expect(out).to.include(`srcset="${deliveryUrl}"`);
     expect(out).not.to.include('content.da.live/adobecom/da-dc/acrobat/foo/rect%201.png');
+  });
+
+  it('rewrites comma-containing filenames without srcset comma splitting', () => {
+    const contentDaLiveUrl = 'https://content.da.live/adobecom/da-dc/drafts/demo/.hero/variant=default,%20width=half%20or%20third,%20content=feature%20image.png';
+    const deliveryUrl = 'https://main--da-dc--adobecom.aem.page/media_hero.avif';
+    const html = `
+      <picture>
+        <source srcset="${contentDaLiveUrl}">
+        <source srcset="${contentDaLiveUrl}" media="(min-width: 600px)">
+        <img src="${contentDaLiveUrl}">
+      </picture>
+    `;
+    const pathToNewUrl = new Map([
+      ['/adobecom/da-dc/drafts/demo/.hero/variant=default, width=half or third, content=feature image.png', deliveryUrl],
+    ]);
+    const out = rewriteContentDaLiveImageUrls(html, pathToNewUrl);
+    expect(out).to.include(`src="${deliveryUrl}"`);
+    expect((out.match(/srcset="/g) ?? []).length).to.equal(2);
+    expect(out).not.to.include('content.da.live');
+    expect(out).not.to.include('variant=default,');
   });
 });


### PR DESCRIPTION
- Share one rolling 100/min limiter across getPutURLForFile and getV2Asset (headroom below documented 120/min)
- Retry getPutURL 429s using Retry-After / X-Rate-Limit-Retry-After-Seconds (+250ms), with window-based fallback
- Split image send into parallel DA fetch (5) then throttled GLaaS upload (3)
- Queue v2 status probes (concurrency 3) and poll locales sequentially instead of firing all assets × langs at once
- Return cancel success from updateStatus; skip handleGetStatus when GLaaS rejects cancel (e.g. Invalid Status 400)
- Harden getPutURL retry tests and reset shared limiter in v2 status tests
