### PR TITLE
feat(nx2): add ewFlags util (moved from da-live)

### DIFF
--- a/nx2/utils/ewFlags.js
+++ b/nx2/utils/ewFlags.js
@@ -1,0 +1,29 @@
+import { fetchDaConfigs } from './daConfig.js';
+
+// Experience Workspace flags live in the `flags` sheet of the DA config docs,
+// keyed `ew.*`. Site-level config overrides org-level (it is fetched last).
+export async function getEWFlags({ org, site }) {
+  try {
+    const configs = await Promise.all(fetchDaConfigs({ org, site }));
+    const flags = {};
+    for (const config of configs) {
+      for (const { key, value } of config?.flags?.data ?? []) {
+        if (key.startsWith('ew.')) flags[key] = value;
+      }
+    }
+    return flags;
+  } catch (e) {
+    if (!(e instanceof TypeError) && !(e instanceof SyntaxError)) throw e;
+  }
+  return {};
+}
+
+export async function isEWEnabled({ org, site }) {
+  const flags = await getEWFlags({ org, site });
+  return flags['ew.enabled'] === 'true';
+}
+
+export async function isEwChatDisabled({ org, site }) {
+  const flags = await getEWFlags({ org, site });
+  return flags['ew.disableChat'] === 'true';
+}

--- a/test/nx2/utils/ewFlags.test.js
+++ b/test/nx2/utils/ewFlags.test.js
@@ -1,0 +1,100 @@
+import { expect } from '@esm-bundle/chai';
+import { getEWFlags, isEWEnabled, isEwChatDisabled } from '../../../nx2/utils/ewFlags.js';
+
+describe('getEWFlags', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  it('returns all ew.* flags merged from org and site configs', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/flag-site1/')
+        ? { flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } }
+        : { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
+    });
+    const flags = await getEWFlags({ org: 'flag-org1', site: 'flag-site1' });
+    expect(flags).to.deep.equal({ 'ew.enabled': 'true', 'ew.canvasDefaultView': 'split' });
+  });
+
+  it('site level flag overrides org level flag', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/flag-site2/')
+        ? { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }
+        : { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
+    });
+    const flags = await getEWFlags({ org: 'flag-org2', site: 'flag-site2' });
+    expect(flags['ew.enabled']).to.equal('false');
+  });
+
+  it('returns empty object when no ew.* flags are present', async () => {
+    window.fetch = async () => ({ ok: true, json: async () => ({ flags: { data: [] } }) });
+    expect(await getEWFlags({ org: 'flag-org3', site: 'flag-site3' })).to.deep.equal({});
+  });
+
+  it('ignores non-ew.* flags', async () => {
+    window.fetch = async () => ({
+      ok: true,
+      json: async () => ({ flags: { data: [{ key: 'other.flag', value: 'true' }] } }),
+    });
+    expect(await getEWFlags({ org: 'flag-org4', site: 'flag-site4' })).to.deep.equal({});
+  });
+});
+
+describe('isEWEnabled', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  it('returns true when ew.enabled flag value is "true"', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/ew-site1/')
+        ? { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }
+        : {}),
+    });
+    expect(await isEWEnabled({ org: 'ew-org1', site: 'ew-site1' })).to.be.true;
+  });
+
+  it('returns false when ew.enabled flag value is "false"', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/ew-site2/')
+        ? { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }
+        : {}),
+    });
+    expect(await isEWEnabled({ org: 'ew-org2', site: 'ew-site2' })).to.be.false;
+  });
+});
+
+describe('isEwChatDisabled', () => {
+  let savedFetch;
+  beforeEach(() => { savedFetch = window.fetch; });
+  afterEach(() => { window.fetch = savedFetch; });
+
+  it('returns true when ew.disableChat is set at org level but not site level', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/dc-site1/')
+        ? { flags: { data: [] } }
+        : { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }),
+    });
+    expect(await isEwChatDisabled({ org: 'dc-org1', site: 'dc-site1' })).to.be.true;
+  });
+
+  it('returns true when ew.disableChat is set at site level but not org level', async () => {
+    window.fetch = async (url) => ({
+      ok: true,
+      json: async () => (url.includes('/dc-site2/')
+        ? { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }
+        : { flags: { data: [] } }),
+    });
+    expect(await isEwChatDisabled({ org: 'dc-org2', site: 'dc-site2' })).to.be.true;
+  });
+
+  it('returns false when ew.disableChat flag is not set at any level', async () => {
+    window.fetch = async () => ({ ok: true, json: async () => ({ flags: { data: [] } }) });
+    expect(await isEwChatDisabled({ org: 'dc-org3', site: 'dc-site3' })).to.be.false;
+  });
+});


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

## What
Adds `nx2/utils/ewFlags.js` — a shared util for reading Experience Workspace
config flags (`ew.*`) from the DA config docs, with `getEWFlags`, `isEWEnabled`,
and `isEwChatDisabled`.

## Why
EW flag logic currently lives in da-live (`blocks/shared/ewFlags.js`). Per the
"pull common features into Nexter" guideline, it belongs in nx2 so any consuming
project can use it. This is the nx2 half of the move; da-live switches to consume
it in adobe/da-live#<PR>.

## Notes
- Reads the `flags` sheet via the existing `daConfig.fetchDaConfigs`; site-level
  config overrides org-level.
- Covered by `test/nx2/utils/ewFlags.test.js` (9 tests).

## Merge order
Merge this **before** the da-live PR, since da-live imports this module at runtime.

Test URLs:
- https://rewflags--da-live--adobe.aem.live//?nx=moveewflags#/exp-workspace/frescopa
