### PR TITLE
chore: minor css improvements

### DIFF
--- a/nx2/blocks/shared/dialog/dialog.css
+++ b/nx2/blocks/shared/dialog/dialog.css
@@ -53,7 +53,6 @@ dialog {
 .heading {
   flex-shrink: 0;
   padding-bottom: var(--s2-spacing-200);
-  border-bottom: 1px solid var(--s2-gray-200);
 }
 
 .title {
@@ -81,4 +80,5 @@ dialog {
   flex-flow: row wrap;
   justify-content: flex-end;
   gap: var(--s2-spacing-100);
+  padding-top: var(--s2-spacing-200);
 }

--- a/nx2/blocks/shared/menu/menu.css
+++ b/nx2/blocks/shared/menu/menu.css
@@ -29,7 +29,7 @@
   background: none;
   color: var(--s2-gray-900);
   font-family: inherit;
-  font-size: var(--s2-body-size-xs);
+  font-size: var(--nx-menu-font-size, var(--s2-body-size-xs));
   line-height: var(--s2-component-s-regular-line-height);
   cursor: pointer;
   box-sizing: border-box;


### PR DESCRIPTION
- Remove title border-bottom from dialogs to align with s2 https://react-spectrum.adobe.com/Dialog
- Add spacing above footer dialog
- Make menu font size configurable

https://da.live/canvas?nx=ewdlg#/exp-workspace/frescopa/index

<img width="508" height="374" alt="Screenshot 2026-07-01 at 17 18 31" src="https://github.com/user-attachments/assets/cd4fc766-94b4-4cf4-a8c9-de58efd330ff" />
