### PR TITLE
fix: revert media-library to nx daFetch as nx2 does not support IMS token injection

### DIFF
--- a/nx/blocks/media-library/core/constants.js
+++ b/nx/blocks/media-library/core/constants.js
@@ -182,12 +182,6 @@ export function resolveAemOrigin() {
   return 'https://admin.hlx.page';
 }
 
-export const DA_ADMIN = typeof window !== 'undefined'
-  ? resolveDaOrigin(window.location)
-  : DA_ADMIN_ENVS.prod;
-
-export const HLX_ADMIN = 'https://admin.hlx.page';
-
 export const DA_ETC_ORIGIN = typeof window !== 'undefined'
   ? resolveDaEtcOrigin(window.location)
   : DA_ETC_ENVS.prod;

--- a/nx/blocks/media-library/core/constants.js
+++ b/nx/blocks/media-library/core/constants.js
@@ -182,6 +182,12 @@ export function resolveAemOrigin() {
   return 'https://admin.hlx.page';
 }
 
+export const DA_ADMIN = typeof window !== 'undefined'
+  ? resolveDaOrigin(window.location)
+  : DA_ADMIN_ENVS.prod;
+
+export const HLX_ADMIN = 'https://admin.hlx.page';
+
 export const DA_ETC_ORIGIN = typeof window !== 'undefined'
   ? resolveDaEtcOrigin(window.location)
   : DA_ETC_ENVS.prod;

--- a/nx/blocks/media-library/core/paths.js
+++ b/nx/blocks/media-library/core/paths.js
@@ -1,5 +1,5 @@
-import { source } from '../../../../nx2/utils/api.js';
-import { Paths, Domains, DA_LIVE_EDIT_BASE } from './constants.js';
+import { daFetch } from '../../../utils/daFetch.js';
+import { Paths, Domains, DA_LIVE_EDIT_BASE, DA_ADMIN } from './constants.js';
 import { ErrorCodes, logMediaLibraryError } from './errors.js';
 import { t } from './messages.js';
 import {
@@ -188,10 +188,12 @@ export async function validateSitePath(sitePath) {
 
   if (restPath.length === 0) {
     try {
-      const result = await source.list({ org, site: repo, path: '' });
+      const url = `${DA_ADMIN}/list/${org}/${repo}/`;
+      const resp = await daFetch(url);
 
-      if (result.ok) {
-        const items = result.items || [];
+      if (resp.ok) {
+        const data = await resp.json();
+        const items = Array.isArray(data) ? data : (data.sources || []);
 
         if (!items || items.length === 0) {
           logMediaLibraryError(ErrorCodes.VALIDATION_SITE_NOT_FOUND, { path: `/${org}/${repo}`, status: 404 });
@@ -204,13 +206,13 @@ export async function validateSitePath(sitePath) {
         return { valid: true, org, repo };
       }
 
-      if (result.status === 404) {
+      if (resp.status === 404) {
         logMediaLibraryError(ErrorCodes.VALIDATION_SITE_NOT_FOUND, { path: `/${org}/${repo}`, status: 404 });
         return { valid: false, error: t('VALIDATION_SITE_NOT_FOUND', { path: `/${org}/${repo}` }) };
       }
 
-      if (result.status === 401 || result.status === 403) {
-        logMediaLibraryError(ErrorCodes.DA_READ_DENIED, { path: `/${org}/${repo}`, status: result.status });
+      if (resp.status === 401 || resp.status === 403) {
+        logMediaLibraryError(ErrorCodes.DA_READ_DENIED, { path: `/${org}/${repo}`, status: resp.status });
         return {
           valid: false,
           error: t('VALIDATION_SITE_403'),
@@ -218,7 +220,7 @@ export async function validateSitePath(sitePath) {
         };
       }
 
-      return { valid: false, error: `Validation failed: ${result.status}` };
+      return { valid: false, error: `Validation failed: ${resp.status}` };
     } catch (error) {
       return { valid: false, error: error.message };
     }
@@ -229,13 +231,14 @@ export async function validateSitePath(sitePath) {
   const parentPath = `/${parentParts.join('/')}`;
 
   try {
-    // Extract parent path segments after org/repo for source.list
+    // Extract parent path segments after org/repo for daFetch list
     const parentSegments = restPath.slice(0, -1);
     const parentFilePath = parentSegments.length > 0 ? `/${parentSegments.join('/')}` : '';
-    const result = await source.list({ org, site: repo, path: parentFilePath });
+    const url = `${DA_ADMIN}/list/${org}/${repo}${parentFilePath}`;
+    const resp = await daFetch(url);
 
-    if (!result.ok) {
-      if (result.status === 404) {
+    if (!resp.ok) {
+      if (resp.status === 404) {
         logMediaLibraryError(ErrorCodes.VALIDATION_PATH_NOT_FOUND, {
           path: parentPath,
           status: 404,
@@ -246,10 +249,10 @@ export async function validateSitePath(sitePath) {
         };
       }
 
-      if (result.status === 401 || result.status === 403) {
+      if (resp.status === 401 || resp.status === 403) {
         logMediaLibraryError(
           ErrorCodes.DA_READ_DENIED,
-          { path: parentPath, status: result.status },
+          { path: parentPath, status: resp.status },
         );
         return {
           valid: false,
@@ -258,10 +261,11 @@ export async function validateSitePath(sitePath) {
         };
       }
 
-      return { valid: false, error: `Validation failed: ${result.status}` };
+      return { valid: false, error: `Validation failed: ${resp.status}` };
     }
 
-    const items = result.items || [];
+    const data = await resp.json();
+    const items = Array.isArray(data) ? data : (data.sources || []);
 
     if (!items || items.length === 0) {
       return {

--- a/nx/blocks/media-library/core/paths.js
+++ b/nx/blocks/media-library/core/paths.js
@@ -1,5 +1,6 @@
 import { daFetch } from '../../../utils/daFetch.js';
-import { Paths, Domains, DA_LIVE_EDIT_BASE, DA_ADMIN } from './constants.js';
+import { DA_ADMIN } from '../../../utils/utils.js';
+import { Paths, Domains, DA_LIVE_EDIT_BASE } from './constants.js';
 import { ErrorCodes, logMediaLibraryError } from './errors.js';
 import { t } from './messages.js';
 import {

--- a/nx/blocks/media-library/indexing/admin-api.js
+++ b/nx/blocks/media-library/indexing/admin-api.js
@@ -1,10 +1,11 @@
-import { source, fromPath, daFetch as nx2DaFetch } from '../../../../nx2/utils/api.js';
-import { HLX_ADMIN } from '../../../../nx2/utils/utils.js';
+import { daFetch } from '../../../utils/daFetch.js';
 import { etcFetch } from '../core/urls.js';
 import {
   IndexFiles,
   ExternalMedia,
   DA_ETC_ORIGIN,
+  DA_ADMIN,
+  HLX_ADMIN,
 } from '../core/constants.js';
 import { MediaLibraryError, ErrorCodes, logMediaLibraryError } from '../core/errors.js';
 import { isPerfEnabled } from '../core/params.js';
@@ -42,8 +43,7 @@ function createRateLimiter(initialRate) {
 const aemPageMarkdownLimiter = createRateLimiter(AEM_PAGE_MARKDOWN_RATE);
 
 async function fetchWithAuthRaw(url, opts = {}) {
-  // Use nx2's daFetch which handles IMS internally
-  return nx2DaFetch({ url, opts });
+  return daFetch(url, opts);
 }
 
 export async function createSheet(data, type = 'sheet') {
@@ -177,8 +177,7 @@ export async function fetchPaginated(
 
 export async function loadSheet(path) {
   try {
-    const { org, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
 
     if (resp.ok) {
       const data = await resp.json();
@@ -194,8 +193,7 @@ export async function loadMultiSheet(path, sheetName, options = {}) {
   const { allowMissing = false } = options;
 
   try {
-    const { org, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
 
     if (resp.ok) {
       const data = await resp.json();
@@ -299,15 +297,16 @@ export async function loadIndexChunks(basePath, chunkCount, sheetName, onProgres
 }
 
 export async function saveSheet(data, path) {
-  const body = await createSheet(data);
-  const { org, site, path: filePath } = fromPath(path);
-  return source.save({ org, site, path: filePath, body });
+  const formData = await createSheet(data);
+  return daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'PUT',
+    body: formData,
+  });
 }
 
 export async function loadSheetMeta(path) {
   try {
-    const { org, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
     if (resp.ok) {
       const data = await resp.json();
       const metaData = data.data || data || null;
@@ -324,9 +323,11 @@ export async function loadSheetMeta(path) {
 
 export async function saveSheetMeta(meta, path) {
   const metaArray = Array.isArray(meta) ? meta : [meta];
-  const body = await createSheet(metaArray);
-  const { org, site, path: filePath } = fromPath(path);
-  return source.save({ org, site, path: filePath, body });
+  const formData = await createSheet(metaArray);
+  return daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'PUT',
+    body: formData,
+  });
 }
 
 export async function fetchAuditLog(org, repo, ref = 'main', since = null, limit = 1000) {
@@ -892,11 +893,13 @@ export async function listFolder(path, org, repo) {
   const normalizedPath = contentPath.replace(/^\//, '') || '';
   const listPath = normalizedPath ? `/${normalizedPath}` : '';
 
-  const result = await source.list({ org, site: repo, path: listPath });
-  if (!result.ok) {
+  const url = `${DA_ADMIN}/list/${org}/${repo}${listPath}`;
+  const resp = await daFetch(url);
+  if (!resp.ok) {
     return [];
   }
-  return result.items || [];
+  const data = await resp.json();
+  return Array.isArray(data) ? data : (data.sources || []);
 }
 
 const MEDIA_EXTS = new Set([
@@ -1020,8 +1023,7 @@ export async function checkIndex(folderPath, org, repo) {
 // Loads index meta JSON (lastFetchTime, etc.) from DA.
 export async function loadIndexMeta(path) {
   try {
-    const { org, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
     if (resp.ok) {
       const data = await resp.json();
       return data.data?.[0] || data;
@@ -1036,9 +1038,11 @@ export async function loadIndexMeta(path) {
 
 // Saves index meta to DA source path.
 export async function saveIndexMeta(meta, path) {
-  const body = await createSheet([meta]);
-  const { org, site, path: filePath } = fromPath(path);
-  return source.save({ org, site, path: filePath, body });
+  const formData = await createSheet([meta]);
+  return daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'POST',
+    body: formData,
+  });
 }
 
 function isProtectedSiteAssetUrl(url, org, repo, ref = 'main') {

--- a/nx/blocks/media-library/indexing/admin-api.js
+++ b/nx/blocks/media-library/indexing/admin-api.js
@@ -1,11 +1,10 @@
 import { daFetch } from '../../../utils/daFetch.js';
+import { DA_ADMIN, HLX_ADMIN } from '../../../utils/utils.js';
 import { etcFetch } from '../core/urls.js';
 import {
   IndexFiles,
   ExternalMedia,
   DA_ETC_ORIGIN,
-  DA_ADMIN,
-  HLX_ADMIN,
 } from '../core/constants.js';
 import { MediaLibraryError, ErrorCodes, logMediaLibraryError } from '../core/errors.js';
 import { isPerfEnabled } from '../core/params.js';

--- a/nx/blocks/media-library/indexing/locks.js
+++ b/nx/blocks/media-library/indexing/locks.js
@@ -5,11 +5,11 @@
  * It handles lock creation, refresh (heartbeat), removal, ownership, and checking.
  */
 
-import { source, fromPath } from '../../../../nx2/utils/api.js';
+import { daFetch } from '../../../utils/daFetch.js';
 import { createSheet } from './admin-api.js';
 import { MediaLibraryError, ErrorCodes, logMediaLibraryError } from '../core/errors.js';
 import { t } from '../core/messages.js';
-import { IndexFiles, IndexConfig } from '../core/constants.js';
+import { IndexFiles, IndexConfig, DA_ADMIN } from '../core/constants.js';
 
 const LOCK_OWNER_STORAGE_KEY = 'media-library-lock-owner-id';
 
@@ -24,8 +24,7 @@ export function getIndexLockPath(sitePath) {
 export async function checkIndexLock(sitePath) {
   const path = getIndexLockPath(sitePath);
   try {
-    const { org, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
     if (resp.ok) {
       const data = await resp.json();
       const lockData = data.data?.[0] || data;
@@ -90,9 +89,11 @@ export async function createIndexLock(sitePath) {
     ownerId,
     locked: true,
   }];
-  const body = await createSheet(lockData);
-  const { org, site, path: filePath } = fromPath(path);
-  const resp = await source.save({ org, site, path: filePath, body });
+  const formData = await createSheet(lockData);
+  const resp = await daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'PUT',
+    body: formData,
+  });
   if (!resp.ok) {
     logMediaLibraryError(ErrorCodes.LOCK_CREATE_FAILED, { status: resp.status, path });
     const isDenied = resp.status === 401 || resp.status === 403;
@@ -105,7 +106,7 @@ export async function createIndexLock(sitePath) {
 export async function refreshIndexLock(sitePath, lockData = {}) {
   const path = getIndexLockPath(sitePath);
   const now = Date.now();
-  const body = await createSheet([{
+  const formData = await createSheet([{
     locked: true,
     timestamp: lockData.timestamp || lockData.startedAt || now,
     startedAt: lockData.startedAt || lockData.timestamp || now,
@@ -113,8 +114,10 @@ export async function refreshIndexLock(sitePath, lockData = {}) {
     ownerId: lockData.ownerId || getIndexLockOwnerId(),
     mode: lockData.mode || '',
   }]);
-  const { org, site, path: filePath } = fromPath(path);
-  const resp = await source.save({ org, site, path: filePath, body });
+  const resp = await daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'PUT',
+    body: formData,
+  });
   if (!resp.ok) {
     logMediaLibraryError(ErrorCodes.LOCK_CREATE_FAILED, { status: resp.status, path });
     const isDenied = resp.status === 401 || resp.status === 403;
@@ -126,8 +129,9 @@ export async function refreshIndexLock(sitePath, lockData = {}) {
 
 export async function removeIndexLock(sitePath) {
   const path = getIndexLockPath(sitePath);
-  const { org, site, path: filePath } = fromPath(path);
-  const resp = await source.delete({ org, site, path: filePath });
+  const resp = await daFetch(`${DA_ADMIN}/source${path}`, {
+    method: 'DELETE',
+  });
   if (!resp.ok) {
     if (resp.status === 404) return resp;
     logMediaLibraryError(ErrorCodes.LOCK_REMOVE_FAILED, { status: resp.status, path });

--- a/nx/blocks/media-library/indexing/locks.js
+++ b/nx/blocks/media-library/indexing/locks.js
@@ -6,10 +6,11 @@
  */
 
 import { daFetch } from '../../../utils/daFetch.js';
+import { DA_ADMIN } from '../../../utils/utils.js';
 import { createSheet } from './admin-api.js';
 import { MediaLibraryError, ErrorCodes, logMediaLibraryError } from '../core/errors.js';
 import { t } from '../core/messages.js';
-import { IndexFiles, IndexConfig, DA_ADMIN } from '../core/constants.js';
+import { IndexFiles, IndexConfig } from '../core/constants.js';
 
 const LOCK_OWNER_STORAGE_KEY = 'media-library-lock-owner-id';
 

--- a/nx/blocks/media-library/media-library.css
+++ b/nx/blocks/media-library/media-library.css
@@ -247,6 +247,10 @@ nx-media-sidebar {
   position: relative;
 }
 
+.content:has(nx-media-grid[pluginmode]) {
+  height: 100%;
+}
+
 .media-content {
   grid-area: main;
   overflow: hidden;

--- a/nx/blocks/media-library/media-library.css
+++ b/nx/blocks/media-library/media-library.css
@@ -3,7 +3,7 @@
   width: 100%;
   max-width: 100%;
   margin: 0;
-  height: 100vh;
+  height: 100%;
   overflow: hidden;
   color-scheme: light dark;
 
@@ -25,7 +25,7 @@
     "sidebar topbar" auto
     "sidebar main" 1fr
     / auto 1fr;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   max-width: 100%;
   background: var(--s2-gray-50);

--- a/nx/blocks/media-library/media-library.js
+++ b/nx/blocks/media-library/media-library.js
@@ -920,6 +920,7 @@ class NxMediaLibrary extends LitElement {
       || this._appState.isProgressiveLoading
       || this._appState.isLoadingData);
 
+    const pluginMode = isMediaLibraryPluginMode();
     return html`
       <nx-media-grid
         .mediaData=${displayData}
@@ -927,6 +928,7 @@ class NxMediaLibrary extends LitElement {
         .repo=${this.repo}
         .usePreviewDaLive=${this.siteAuthInfo?.requiresAuth || false}
         .resultsBusy=${resultsBusy}
+        .pluginMode=${pluginMode}
         @mediaClick=${this.handleMediaClick}
         @mediaCopy=${this.handleMediaCopy}
       ></nx-media-grid>

--- a/nx/blocks/media-library/ui/data.js
+++ b/nx/blocks/media-library/ui/data.js
@@ -11,6 +11,7 @@
  */
 
 import { daFetch } from '../../../utils/daFetch.js';
+import { DA_ADMIN } from '../../../utils/utils.js';
 import {
   loadIndexChunks,
   loadSheetMeta,
@@ -24,7 +25,6 @@ import { isIndexedExternalMediaEntry } from '../core/media.js';
 import {
   IndexFiles,
   SheetNames,
-  DA_ADMIN,
 } from '../core/constants.js';
 
 function getOrgRepoFromSitePath(sitePath) {

--- a/nx/blocks/media-library/ui/data.js
+++ b/nx/blocks/media-library/ui/data.js
@@ -10,7 +10,7 @@
  * NO indexing logic - only reads already-published index data.
  */
 
-import { source, fromPath } from '../../../../nx2/utils/api.js';
+import { daFetch } from '../../../utils/daFetch.js';
 import {
   loadIndexChunks,
   loadSheetMeta,
@@ -24,6 +24,7 @@ import { isIndexedExternalMediaEntry } from '../core/media.js';
 import {
   IndexFiles,
   SheetNames,
+  DA_ADMIN,
 } from '../core/constants.js';
 
 function getOrgRepoFromSitePath(sitePath) {
@@ -82,8 +83,7 @@ export async function loadMediaSheet(sitePath, onProgressiveChunk) {
       }
     }
 
-    const { org: pathOrg, site, path: filePath } = fromPath(path);
-    const resp = await source.get({ org: pathOrg, site, path: filePath });
+    const resp = await daFetch(`${DA_ADMIN}/source${path}`);
 
     if (resp.ok) {
       const data = await resp.json();

--- a/nx/blocks/media-library/ui/views/grid/grid.css
+++ b/nx/blocks/media-library/ui/views/grid/grid.css
@@ -1,4 +1,9 @@
 /* Grid component styles - inherits CSS variables from parent */
+:host {
+  display: block;
+  height: 100%;
+}
+
 svg.icon {
   width: 20px;
   height: 20px;
@@ -123,6 +128,10 @@ svg.icon {
 .media-main:focus-visible {
   outline: 2px solid var(--s2-blue-500);
   outline-offset: -2px;
+}
+
+:host([pluginmode]) .media-main {
+  height: 100%;
 }
 
 .media-main > * {

--- a/nx/blocks/media-library/ui/views/grid/grid.css
+++ b/nx/blocks/media-library/ui/views/grid/grid.css
@@ -47,7 +47,7 @@ svg.icon {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - 200px);
+  height: calc(100vh - var(--ml-chrome-height, 130px) - 70px);
   text-align: center;
   color: var(--s2-gray-700);
 }
@@ -70,7 +70,7 @@ svg.icon {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - 200px);
+  height: calc(100vh - var(--ml-chrome-height, 130px) - 70px);
   text-align: center;
   color: var(--s2-gray-700);
 }
@@ -111,7 +111,7 @@ svg.icon {
 }
 
 .media-main {
-  height: calc(100vh - 130px);
+  height: calc(100vh - var(--ml-chrome-height, 130px));
   overflow-y: auto;
   position: relative;
   contain: layout;

--- a/nx/blocks/media-library/ui/views/grid/grid.css
+++ b/nx/blocks/media-library/ui/views/grid/grid.css
@@ -47,7 +47,7 @@ svg.icon {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - var(--ml-chrome-height, 130px) - 70px);
+  height: calc(100vh - 200px);
   text-align: center;
   color: var(--s2-gray-700);
 }
@@ -70,7 +70,7 @@ svg.icon {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: calc(100vh - var(--ml-chrome-height, 130px) - 70px);
+  height: calc(100vh - 200px);
   text-align: center;
   color: var(--s2-gray-700);
 }
@@ -111,7 +111,7 @@ svg.icon {
 }
 
 .media-main {
-  height: calc(100vh - var(--ml-chrome-height, 130px));
+  height: calc(100vh - 130px);
   overflow-y: auto;
   position: relative;
   contain: layout;

--- a/nx/blocks/media-library/ui/views/grid/grid.js
+++ b/nx/blocks/media-library/ui/views/grid/grid.js
@@ -49,6 +49,7 @@ class NxMediaGrid extends LitElement {
     repo: { type: String },
     usePreviewDaLive: { type: Boolean },
     resultsBusy: { type: Boolean },
+    pluginMode: { type: Boolean },
   };
 
   constructor() {

--- a/nx/blocks/media-library/ui/views/grid/grid.js
+++ b/nx/blocks/media-library/ui/views/grid/grid.js
@@ -49,7 +49,7 @@ class NxMediaGrid extends LitElement {
     repo: { type: String },
     usePreviewDaLive: { type: Boolean },
     resultsBusy: { type: Boolean },
-    pluginMode: { type: Boolean },
+    pluginMode: { type: Boolean, reflect: true },
   };
 
   constructor() {


### PR DESCRIPTION


Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--da-live--adobe.aem.live/apps/media-library#/kmurugulla/brightpath
- After: https://main--da-live--adobe.aem.live/apps/media-library?nx=medialib-plugin#/kmurugulla/brightpath

Note - In the plugin i am loading media-library.js from da.live so that i can reuse the same code for both app and plugin. when i switch app to nx2 way of daFetch that uses ims from nx2 , loading the media-library.js was not able to load assets as the ims token obtained in the plugin was not being injected , hence cause CORS issues with nx2 way of getting IMS token 

Error caused in Plugin 
"Access to XMLHttpRequest at '[https://adobeid-na1.services.adobe.com/ims/check/v6/token?jslVersion=v2-v0.56.0-3-gd881755'](https://adobeid-na1.services.adobe.com/ims/check/v6/token?jslVersion=v2-v0.56.0-3-gd881755%27) from origin 'https://main--da-blog-tools--aemsites.aem.live/' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource."

PR for Plugin is - https://github.com/adobe-rnd/aem-apps/pull/13 ( which is in draft mode as its loading media-library from this branch , once this PR approved and merged into main, will switch to load from da.live) 

To register plugin on any site , please add the following to Library 
  | title            | path                                          | experience        |
  | ---------------- | --------------------------------------------- | ----------------- |
  | `Media Library`  | `https://medialib--aem-apps--adobe-rnd.aem.page/tools/plugins/media-library/media-library.html` | `fullsize-dialog` |