### PR TITLE
fix(form): persist chat open/closed across refresh via nx-browse-chat-open session key

### DIFF
--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -1,5 +1,5 @@
 import { loadStyle, hashChange } from '../../../nx2/utils/utils.js';
-import { openPanel } from '../../../nx2/utils/panel.js';
+import { openPanel, getPanelStore } from '../../../nx2/utils/panel.js';
 import { getEWFlags } from '../../../nx2/utils/ewFlags.js';
 import { getConfig } from '../../../nx2/scripts/nx.js';
 import decorateEditor from './editor.js';
@@ -35,15 +35,41 @@ function ensureNavPath() {
   document.head.append(meta);
 }
 
-function openChatPanel() {
-  return openPanel({
+// Remember the chat's open/closed state per browser session, so a refresh
+// keeps the user's choice. Mirrors da-live's browse panel (same key/value).
+const BROWSE_CHAT_SESSION_KEY = 'nx-browse-chat-open';
+
+function isBrowseChatOpen() {
+  try {
+    return !!sessionStorage.getItem(BROWSE_CHAT_SESSION_KEY);
+  } catch {
+    return false;
+  }
+}
+
+function setBrowseChatOpen(open) {
+  try {
+    if (open) sessionStorage.setItem(BROWSE_CHAT_SESSION_KEY, '1');
+    else sessionStorage.removeItem(BROWSE_CHAT_SESSION_KEY);
+  } catch { /* ignore */ }
+}
+
+async function openChatPanel() {
+  const store = getPanelStore();
+  const width = store.before?.width ?? '400px';
+  const aside = await openPanel({
     position: 'before',
-    width: '400px',
+    width,
     getContent: async () => {
       await import('../../../nx2/blocks/chat/chat.js');
       return document.createElement('nx-chat');
     },
   });
+  if (aside) {
+    setBrowseChatOpen(true);
+    aside.addEventListener('nx-panel-close', () => setBrowseChatOpen(false), { once: true });
+  }
+  return aside;
 }
 
 // A floating toggle at the top-left of the canvas opens the chat panel. The
@@ -80,7 +106,7 @@ async function setupChat(block) {
   if (flags['ew.enabled'] !== 'true') return;
 
   installChatToggle(block);
-  await openChatPanel();
+  if (isBrowseChatOpen()) await openChatPanel();
 }
 
 // Block entry: EW surfaces the form via an `nx-form` content block, which NX

--- a/nx/blocks/form/form.js
+++ b/nx/blocks/form/form.js
@@ -36,21 +36,21 @@ function ensureNavPath() {
 }
 
 // Remember the chat's open/closed state per browser session, so a refresh
-// keeps the user's choice. Mirrors da-live's browse panel (same key/value).
-const BROWSE_CHAT_SESSION_KEY = 'nx-browse-chat-open';
+// keeps the user's choice.
+const CHAT_SESSION_KEY = 'nx-chat-open';
 
-function isBrowseChatOpen() {
+function isChatOpen() {
   try {
-    return !!sessionStorage.getItem(BROWSE_CHAT_SESSION_KEY);
+    return !!sessionStorage.getItem(CHAT_SESSION_KEY);
   } catch {
     return false;
   }
 }
 
-function setBrowseChatOpen(open) {
+function setChatOpen(open) {
   try {
-    if (open) sessionStorage.setItem(BROWSE_CHAT_SESSION_KEY, '1');
-    else sessionStorage.removeItem(BROWSE_CHAT_SESSION_KEY);
+    if (open) sessionStorage.setItem(CHAT_SESSION_KEY, '1');
+    else sessionStorage.removeItem(CHAT_SESSION_KEY);
   } catch { /* ignore */ }
 }
 
@@ -66,8 +66,8 @@ async function openChatPanel() {
     },
   });
   if (aside) {
-    setBrowseChatOpen(true);
-    aside.addEventListener('nx-panel-close', () => setBrowseChatOpen(false), { once: true });
+    setChatOpen(true);
+    aside.addEventListener('nx-panel-close', () => setChatOpen(false), { once: true });
   }
   return aside;
 }
@@ -106,7 +106,7 @@ async function setupChat(block) {
   if (flags['ew.enabled'] !== 'true') return;
 
   installChatToggle(block);
-  if (isBrowseChatOpen()) await openChatPanel();
+  if (isChatOpen()) await openChatPanel();
 }
 
 // Block entry: EW surfaces the form via an `nx-form` content block, which NX


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):



Test URLs:
- https://da.live/form?nx=fix-chat-toggle#/exp-workspace/frescopa/forms/brewing-guide-cold-brewing-101
