### PR TITLE
feat(ew): move chat's AI disclaimer outside its bordered body

### DIFF
--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -76,6 +76,29 @@
   }
 }
 
+:host([styled-as-panel]) {
+  padding-top: 0;
+}
+
+.chat-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  align-items: center;
+  gap: var(--s2-spacing-300);
+  box-sizing: border-box;
+}
+
+:host([styled-as-panel]) .chat-body {
+  border: 1px solid var(--s2-gray-100);
+  border-radius: var(--s2-corner-radius-800);
+  background: light-dark(#fff, #000);
+  overflow: hidden;
+  padding: var(--s2-spacing-200) 0;
+}
+
 .chat-header {
   display: flex;
   align-items: center;
@@ -627,12 +650,14 @@
 }
 
 .chat-disclaimer {
+  flex-shrink: 0;
   max-width: 720px;
   width: calc(100% - 2 * var(--s2-spacing-200));
   margin: 0;
   font-size: var(--s2-body-size-xs);
-  color: var(--s2-gray-700);
+  color: var(--s2-gray-600);
   line-height: 1.5;
+  text-align: center;
   box-sizing: border-box;
 
   a {

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -33,6 +33,7 @@ class NxChat extends LitElement {
     thinking: { type: Boolean },
     connected: { type: Boolean },
     toolCards: { type: Object },
+    styled: { type: Boolean, reflect: true, attribute: 'styled-as-panel' },
     _prompts: { state: true },
     _items: { state: true },
     _dragging: { state: true },
@@ -502,89 +503,91 @@ class NxChat extends LitElement {
           .onSend=${(p) => this._sendPrompt(p)}
         ></nx-prompts>
       </nx-popover>
-      <div class="chat-header">
-        <button
-          type="button"
-          class="chat-header-btn clear-btn"
-          aria-label="Clear chat"
-          ?hidden=${!this.messages?.length}
-          @click=${() => this.clear()}
-        >${icon('clear')}<span>Clear</span></button>
-        <button
-          type="button"
-          class="chat-header-btn"
-          aria-label="Close chat panel"
-          @click=${this._closePanel}
-        >${icon('close')}</button>
-      </div>
-      <div class="chat-scroll-container">
-        <div class="chat-messages-container" role="log" aria-live="polite">
-          ${!this.messages?.length && !this.thinking
-        ? html`<nx-chat-welcome
-              .prompts=${prompts}
-              .onSend=${(p) => this._sendPrompt(p)}
-              @nx-show-prompts=${this._openPrompts}
-            ></nx-chat-welcome>`
-        : nothing}
-        ${this.messages?.map((msg) => renderMessage(msg, this.toolCards))}
-        ${this.thinking && !this.messages?.at(-1)?.streaming ? html`<div class="chat-thinking">Thinking...</div>` : nothing}
+      <div class="chat-body">
+        <div class="chat-header">
+          <button
+            type="button"
+            class="chat-header-btn clear-btn"
+            aria-label="Clear chat"
+            ?hidden=${!this.messages?.length}
+            @click=${() => this.clear()}
+          >${icon('clear')}<span>Clear</span></button>
+          <button
+            type="button"
+            class="chat-header-btn"
+            aria-label="Close chat panel"
+            @click=${this._closePanel}
+          >${icon('close')}</button>
         </div>
-      </div>
-      <div class="chat-form-wrap">
-        <nx-menu
-          class="slash-menu"
-          .ignoreFocus=${true}
-          .scoped=${true}
-          @select=${({ detail }) => this._onSlashSelect(detail.id)}
-          @mousedown=${(e) => e.preventDefault()}
-        ></nx-menu>
-        ${renderApprovalCard(this._pendingApproval(), this._controller.approveToolCall)}
-        <form class="chat-form" autocomplete="off" @submit=${this._submit}
-          @dragenter=${this._onDragEnter}
-          @dragleave=${this._onDragLeave}
-          @dragover=${this._onDragOver}
-          @drop=${this._onDrop}
-        >
-        <input
-          class="chat-file-input"
-          type="file"
-          accept="image/*,text/markdown,.md,application/pdf,.pdf"
-          multiple
-          hidden
-          @change=${this._onFileInputChange}
-        />
-        ${this._dragging ? html`
-          <div class="chat-drop-zone" aria-hidden="true">
-            <span class="chat-drop-title">Drop a file to add context</span>
-            <span class="chat-drop-hint">Supports PDF, images, and documents</span>
-          </div>` : nothing}
-        ${this._items?.length ? html`
-          <nx-chat-pills
-            .items=${this._items}
-            @nx-pill-remove=${this._handlePillRemove}
-            @nx-pill-pin=${this._handlePillPin}
-            @nx-pill-activate=${this._handlePillActivate}
-          ></nx-chat-pills>` : nothing}
-        <textarea
-          name="chat-input"
-          class="chat-input"
-          placeholder="Ask anything, or type / for skills..."
-          ?disabled=${this.thinking || !this.connected}
-          @input=${this._handleInput}
-          @keydown=${this._handleKeydown}
-          @blur=${this._handleBlur}
-        ></textarea>
-        <div class="chat-actions" ?data-thinking=${this.thinking} ?data-has-items=${!!this._items?.length}>
-          <nx-menu .items=${ADD_MENU_ITEMS} placement="above" @select=${this._handleMenuSelect}>
-            <button slot="trigger" class="chat-add" type="button" aria-label="Add" @click=${this._onAddClick}>
-              <span class="icon-add">${icon('add')}</span>
-              <span class="icon-up">${icon('up')}</span>
-            </button>
-          </nx-menu>
-          <button class="chat-stop action-btn" type="button" aria-label="Stop" @click=${this._submit}>${icon('stop')}</button>
-          <button class="chat-send action-btn" type="submit" aria-label="Send">${icon('send')}</button>
+        <div class="chat-scroll-container">
+          <div class="chat-messages-container" role="log" aria-live="polite">
+            ${!this.messages?.length && !this.thinking
+          ? html`<nx-chat-welcome
+                .prompts=${prompts}
+                .onSend=${(p) => this._sendPrompt(p)}
+                @nx-show-prompts=${this._openPrompts}
+              ></nx-chat-welcome>`
+          : nothing}
+          ${this.messages?.map((msg) => renderMessage(msg, this.toolCards))}
+          ${this.thinking && !this.messages?.at(-1)?.streaming ? html`<div class="chat-thinking">Thinking...</div>` : nothing}
+          </div>
         </div>
-        </form>
+        <div class="chat-form-wrap">
+          <nx-menu
+            class="slash-menu"
+            .ignoreFocus=${true}
+            .scoped=${true}
+            @select=${({ detail }) => this._onSlashSelect(detail.id)}
+            @mousedown=${(e) => e.preventDefault()}
+          ></nx-menu>
+          ${renderApprovalCard(this._pendingApproval(), this._controller.approveToolCall)}
+          <form class="chat-form" autocomplete="off" @submit=${this._submit}
+            @dragenter=${this._onDragEnter}
+            @dragleave=${this._onDragLeave}
+            @dragover=${this._onDragOver}
+            @drop=${this._onDrop}
+          >
+          <input
+            class="chat-file-input"
+            type="file"
+            accept="image/*,text/markdown,.md,application/pdf,.pdf"
+            multiple
+            hidden
+            @change=${this._onFileInputChange}
+          />
+          ${this._dragging ? html`
+            <div class="chat-drop-zone" aria-hidden="true">
+              <span class="chat-drop-title">Drop a file to add context</span>
+              <span class="chat-drop-hint">Supports PDF, images, and documents</span>
+            </div>` : nothing}
+          ${this._items?.length ? html`
+            <nx-chat-pills
+              .items=${this._items}
+              @nx-pill-remove=${this._handlePillRemove}
+              @nx-pill-pin=${this._handlePillPin}
+              @nx-pill-activate=${this._handlePillActivate}
+            ></nx-chat-pills>` : nothing}
+          <textarea
+            name="chat-input"
+            class="chat-input"
+            placeholder="Ask anything, or type / for skills..."
+            ?disabled=${this.thinking || !this.connected}
+            @input=${this._handleInput}
+            @keydown=${this._handleKeydown}
+            @blur=${this._handleBlur}
+          ></textarea>
+          <div class="chat-actions" ?data-thinking=${this.thinking} ?data-has-items=${!!this._items?.length}>
+            <nx-menu .items=${ADD_MENU_ITEMS} placement="above" @select=${this._handleMenuSelect}>
+              <button slot="trigger" class="chat-add" type="button" aria-label="Add" @click=${this._onAddClick}>
+                <span class="icon-add">${icon('add')}</span>
+                <span class="icon-up">${icon('up')}</span>
+              </button>
+            </nx-menu>
+            <button class="chat-stop action-btn" type="button" aria-label="Stop" @click=${this._submit}>${icon('stop')}</button>
+            <button class="chat-send action-btn" type="submit" aria-label="Send">${icon('send')}</button>
+          </div>
+          </form>
+        </div>
       </div>
       <p class="chat-disclaimer">
         Responses are generated using AI, and may be inaccurate. Check before using.

--- a/nx2/styles/styles.css
+++ b/nx2/styles/styles.css
@@ -560,6 +560,16 @@ html:has(meta[content="edge-delivery"]) {
             left: -12px;
           }
         }
+
+        &:has([styled-as-panel]) .panel-wrapper {
+          border-radius: 0;
+          background: none;
+        }
+
+        &:has([styled-as-panel]) .panel-shell {
+          border: none;
+          overflow: visible;
+        }
       }
 
       footer {


### PR DESCRIPTION
Adds an optional `styled` property to nx-chat, reflected as the `styled-as-panel` attribute. When set, nx-chat wraps its header, messages, and input in a bordered/rounded/backgrounded `.chat-body`, and renders the AI disclaimer below it, outside that border — all within its own shadow DOM. styles.css removes the outer panel's own background, border, and border-radius whenever it contains an element with the `styled-as-panel` attribute, so the two don't stack. panel.js is unchanged: it has no knowledge of chat or any specific consumer, just a generic `:has([styled-as-panel])` check.

