### PR TITLE
fix: resolve sl-input custom element registry collision

### DIFF
--- a/nx/blocks/shared/path/path.js
+++ b/nx/blocks/shared/path/path.js
@@ -1,11 +1,6 @@
 import { html, LitElement, nothing } from 'da-lit';
 import { loadStyle } from '../../../../nx2/utils/utils.js';
 
-// `nx-path` renders `sl-input` / `sl-button` but does not register them itself.
-// Consumers must import their desired `sl/components.js` flavor (nx or nx2)
-// before importing this module, otherwise a second `customElements.define`
-// for the same tag names will throw (NotSupportedError).
-
 const style = await loadStyle(import.meta.url);
 
 const DEFAULT_ERROR = 'Not a valid path. Please use /org/site.';

--- a/nx/blocks/shared/path/path.js
+++ b/nx/blocks/shared/path/path.js
@@ -1,7 +1,10 @@
 import { html, LitElement, nothing } from 'da-lit';
 import { loadStyle } from '../../../../nx2/utils/utils.js';
 
-import '../../../../nx2/public/sl/components.js';
+// `nx-path` renders `sl-input` / `sl-button` but does not register them itself.
+// Consumers must import their desired `sl/components.js` flavor (nx or nx2)
+// before importing this module, otherwise a second `customElements.define`
+// for the same tag names will throw (NotSupportedError).
 
 const style = await loadStyle(import.meta.url);
 


### PR DESCRIPTION
## Problem

`nx/blocks/scheduler/scheduler.js` (and `secure-org.js`) throw:

```
NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry':
the name "sl-input" has already been used with this registry
```

Test:
- https://da.live/apps/schema?nx=schednx2fix
- https://da.live/apps/scheduler?nx=schednx2fix