### PR TITLE
feat(feedback): auto-select chat history checkbox for AI Assistant category

### DIFF
--- a/nx2/blocks/feedback/feedback-dialog.js
+++ b/nx2/blocks/feedback/feedback-dialog.js
@@ -29,11 +29,13 @@ class NxFeedbackDialog extends LitElement {
     _submitting: { state: true },
     _submitError: { state: true },
     _category: { state: true },
+    _linkChatSession: { state: true },
   };
 
   constructor() {
     super();
     this._category = CATEGORIES[0].value;
+    this._linkChatSession = false;
   }
 
   connectedCallback() {
@@ -49,10 +51,13 @@ class NxFeedbackDialog extends LitElement {
 
   get _message() { return this.shadowRoot.getElementById('feedback-message'); }
 
-  get _linkChatSession() { return this.shadowRoot.getElementById('feedback-include-chat'); }
-
   _onCategoryChange({ detail: { value } }) {
     this._category = value;
+    if (value === 'assistant') this._linkChatSession = true;
+  }
+
+  _onLinkChatSessionChange({ target: { checked } }) {
+    this._linkChatSession = checked;
   }
 
   _handleClose(e) {
@@ -103,7 +108,7 @@ class NxFeedbackDialog extends LitElement {
     const categoryOption = CATEGORIES.find((c) => c.value === this._category);
     const categoryLabel = categoryOption?.label ?? this._category;
 
-    const linkChatSession = this._linkChatSession.checked;
+    const linkChatSession = this._linkChatSession;
     const context = this._getContext();
     const sessionId = linkChatSession ? await this._getChatSessionId(context) : null;
 
@@ -161,7 +166,7 @@ class NxFeedbackDialog extends LitElement {
             ${this._messageError ? html`<p class="da-input-error-msg">Please describe your feedback before submitting.</p>` : nothing}
           </div>
           <label class="da-checkbox">
-            <input id="feedback-include-chat" type="checkbox" />
+            <input id="feedback-include-chat" type="checkbox" .checked=${this._linkChatSession} @change=${this._onLinkChatSessionChange} />
             Include assistant chat history?
           </label>
           <p class="feedback-intro"><span>Your name, email and current page will be shared with the team.</span></p>

--- a/nx2/test/unit/nx/blocks/feedback/feedback-dialog.test.js
+++ b/nx2/test/unit/nx/blocks/feedback/feedback-dialog.test.js
@@ -1,0 +1,70 @@
+import { expect } from '@esm-bundle/chai';
+import { setConfig } from '../../../../../scripts/nx.js';
+import { resetMockIms } from '../../../../mocks/ims.js';
+
+// feedback-dialog.js pulls in picker.js, which reads getConfig() at import
+// time, so setConfig() must resolve before feedback-dialog.js is ever
+// imported — same pattern used in feedback.test.js and profile.test.js.
+await setConfig({ hostnames: [] });
+await import('../../../../../blocks/feedback/feedback-dialog.js');
+
+async function createDialog() {
+  const el = document.createElement('nx-feedback-dialog');
+  el.label = 'Submit an idea';
+  el.kind = 'idea';
+  document.body.append(el);
+  await el.updateComplete;
+  return el;
+}
+
+function selectCategory(el, value) {
+  const picker = el.shadowRoot.querySelector('nx-picker');
+  picker.dispatchEvent(new CustomEvent('change', { detail: { value }, bubbles: true, composed: true }));
+}
+
+describe('nx-feedback-dialog checkbox auto-select', () => {
+  afterEach(() => {
+    resetMockIms();
+    document.querySelectorAll('nx-feedback-dialog').forEach((el) => el.remove());
+  });
+
+  it('is unchecked by default (general category)', async () => {
+    const el = await createDialog();
+    const checkbox = el.shadowRoot.getElementById('feedback-include-chat');
+    expect(checkbox.checked).to.be.false;
+  });
+
+  it('auto-checks the checkbox when the category is switched to AI Assistant', async () => {
+    const el = await createDialog();
+    selectCategory(el, 'assistant');
+    await el.updateComplete;
+
+    const checkbox = el.shadowRoot.getElementById('feedback-include-chat');
+    expect(checkbox.checked).to.be.true;
+  });
+
+  it('does not uncheck the checkbox when switching away from AI Assistant', async () => {
+    const el = await createDialog();
+    selectCategory(el, 'assistant');
+    await el.updateComplete;
+
+    selectCategory(el, 'ui');
+    await el.updateComplete;
+
+    const checkbox = el.shadowRoot.getElementById('feedback-include-chat');
+    expect(checkbox.checked).to.be.true;
+  });
+
+  it('does not re-check the checkbox if the user manually unchecked it while on AI Assistant', async () => {
+    const el = await createDialog();
+    selectCategory(el, 'assistant');
+    await el.updateComplete;
+
+    const checkbox = el.shadowRoot.getElementById('feedback-include-chat');
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+
+    expect(checkbox.checked).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-checks the "Include assistant chat history?" checkbox in the feedback dialog when the user selects the "AI Assistant" category.
- Switching to a different category afterward does not uncheck it.
- If the user manually unchecks it while on "AI Assistant", it is not forced back on.

## Changes
- `nx2/blocks/feedback/feedback-dialog.js`: `_linkChatSession` is now a reactive state property bound to the checkbox instead of being read from the DOM only at submit time. `_onCategoryChange` sets it to `true` when the category is `assistant`.
- `nx2/test/unit/nx/blocks/feedback/feedback-dialog.test.js`: new tests covering default state, auto-check on selection, persistence across category switches, and respecting manual unchecks.

## Testing
- `npx wtr --config ./nx2/test/wtr.config.mjs` — new tests pass, lint clean.