### PR TITLE
feat(nx2): port sandbox org-check to nx2

### DIFF
--- a/nx2/blocks/shared/toast/toast.css
+++ b/nx2/blocks/shared/toast/toast.css
@@ -33,7 +33,7 @@
 
   &.toast-warning {
     border-color: var(--s2-orange-800);
-    background: var(--s2-orange-900);
+    background: var(--s2-orange-700);
     color: var(--s2-gray-25);
   }
 }

--- a/nx2/blocks/shared/toast/toast.css
+++ b/nx2/blocks/shared/toast/toast.css
@@ -30,6 +30,12 @@
     background: var(--s2-red-900);
     color: var(--s2-gray-25);
   }
+
+  &.toast-warning {
+    border-color: var(--s2-orange-800);
+    background: var(--s2-orange-900);
+    color: var(--s2-gray-25);
+  }
 }
 
 .text {
@@ -40,6 +46,19 @@
   line-height: var(--s2-component-m-medium-line-height, 1.4);
   overflow-wrap: anywhere;
   white-space: pre-line;
+}
+
+.cta {
+  flex-shrink: 0;
+  color: inherit;
+  font-size: var(--s2-component-m-medium-font-size, 14px);
+  font-weight: bold;
+  text-decoration: underline;
+  white-space: nowrap;
+
+  &:hover {
+    opacity: 0.85;
+  }
 }
 
 .close {

--- a/nx2/blocks/shared/toast/toast.css
+++ b/nx2/blocks/shared/toast/toast.css
@@ -1,7 +1,7 @@
 :host {
   display: block;
   box-sizing: border-box;
-  max-width: min(22rem, calc(100vw - 2 * var(--s2-spacing-300)));
+  max-width: min(var(--nx-toast-max-width, 22rem), calc(100vw - 2 * var(--s2-spacing-300)));
   margin: 0;
   padding: 0;
   border: 0;

--- a/nx2/blocks/shared/toast/toast.js
+++ b/nx2/blocks/shared/toast/toast.js
@@ -4,6 +4,7 @@ import { loadHrefSvg } from '../../../utils/svg.js';
 
 export const VARIANT_SUCCESS = 'success';
 export const VARIANT_ERROR = 'error';
+export const VARIANT_WARNING = 'warning';
 
 const CLOSE_ICON_URL = new URL('../../../img/icons/S2_Icon_Close_20_N.svg', import.meta.url).href;
 
@@ -37,6 +38,7 @@ class NxToast extends LitElement {
   static properties = {
     message: { type: String, attribute: false },
     variant: { type: String, attribute: false },
+    cta: { attribute: false },
     _closeIcon: { state: true },
   };
 
@@ -48,8 +50,10 @@ class NxToast extends LitElement {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [styles];
     this.style.pointerEvents = 'auto';
-    const ms = Math.max(6000, Number(this.duration) || 6000);
-    this._timerId = window.setTimeout(this.dismiss, ms);
+    if (this.duration !== null) {
+      const ms = Math.max(6000, Number(this.duration) || 6000);
+      this._timerId = window.setTimeout(this.dismiss, ms);
+    }
     this._loadIcon();
   }
 
@@ -75,12 +79,15 @@ class NxToast extends LitElement {
     const text = this.message?.trim();
     if (!text) return nothing;
     const isError = this.variant === VARIANT_ERROR;
+    const isWarning = this.variant === VARIANT_WARNING;
+    let variantClass = VARIANT_SUCCESS;
+    if (isError) variantClass = VARIANT_ERROR;
+    else if (isWarning) variantClass = VARIANT_WARNING;
+    const role = isError || isWarning ? 'alert' : 'status';
     return html`
-      <div
-        class="toast toast-${isError ? VARIANT_ERROR : VARIANT_SUCCESS}"
-        role=${isError ? 'alert' : 'status'}
-      >
+      <div class="toast toast-${variantClass}" role=${role}>
         <p class="text">${text}</p>
+        ${this.cta?.href ? html`<a class="cta" href=${this.cta.href}>${this.cta.text}</a>` : nothing}
         <button
           type="button"
           class="close"
@@ -92,13 +99,14 @@ class NxToast extends LitElement {
   }
 }
 
-export function showToast({ text, variant = VARIANT_SUCCESS, timeout = 6000 } = {}) {
+export function showToast({ text, variant = VARIANT_SUCCESS, cta, timeout = 6000 } = {}) {
   const messageText = text?.trim();
   if (!messageText) return;
   const toast = document.createElement('nx-toast');
   toast.message = messageText;
-  toast.variant = variant === VARIANT_ERROR ? VARIANT_ERROR : VARIANT_SUCCESS;
-  toast.duration = timeout;
+  toast.variant = [VARIANT_ERROR, VARIANT_WARNING].includes(variant) ? variant : VARIANT_SUCCESS;
+  toast.cta = cta;
+  toast.duration = timeout; // null = indefinite (no auto-dismiss)
   ensureHost().append(toast);
 }
 

--- a/nx2/blocks/shared/toast/toast.js
+++ b/nx2/blocks/shared/toast/toast.js
@@ -99,7 +99,7 @@ class NxToast extends LitElement {
   }
 }
 
-export function showToast({ text, variant = VARIANT_SUCCESS, cta, timeout = 6000 } = {}) {
+export function showToast({ text, variant = VARIANT_SUCCESS, cta, timeout = 6000, maxWidth } = {}) {
   const messageText = text?.trim();
   if (!messageText) return;
   const toast = document.createElement('nx-toast');
@@ -107,6 +107,7 @@ export function showToast({ text, variant = VARIANT_SUCCESS, cta, timeout = 6000
   toast.variant = [VARIANT_ERROR, VARIANT_WARNING].includes(variant) ? variant : VARIANT_SUCCESS;
   toast.cta = cta;
   toast.duration = timeout; // null = indefinite (no auto-dismiss)
+  if (maxWidth) toast.style.setProperty('--nx-toast-max-width', maxWidth);
   ensureHost().append(toast);
 }
 

--- a/nx2/blocks/shared/toast/toast.js
+++ b/nx2/blocks/shared/toast/toast.js
@@ -80,9 +80,7 @@ class NxToast extends LitElement {
     if (!text) return nothing;
     const isError = this.variant === VARIANT_ERROR;
     const isWarning = this.variant === VARIANT_WARNING;
-    let variantClass = VARIANT_SUCCESS;
-    if (isError) variantClass = VARIANT_ERROR;
-    else if (isWarning) variantClass = VARIANT_WARNING;
+    const variantClass = isError || isWarning ? this.variant : VARIANT_SUCCESS;
     const role = isError || isWarning ? 'alert' : 'status';
     return html`
       <div class="toast toast-${variantClass}" role=${role}>

--- a/nx2/scripts/nx.js
+++ b/nx2/scripts/nx.js
@@ -325,6 +325,7 @@ export async function loadArea({ area } = { area: document }) {
 
       if (!isSession) loadSession();
       import('../utils/favicon.js');
+      import('../utils/org-check.js');
     }
   }
 

--- a/nx2/utils/org-check.js
+++ b/nx2/utils/org-check.js
@@ -1,0 +1,39 @@
+import { DA_ADMIN } from './utils.js';
+import { daFetch } from './api.js';
+import { showToast, VARIANT_ERROR } from '../blocks/shared/toast/toast.js';
+
+const DEF_SANDBOX = 'aem-sandbox';
+const SANDBOX_MSG = 'You are viewing a sandbox organization. Some features may be unavailable.';
+
+async function getIsSandbox(org) {
+  const confResp = await daFetch({ url: `${DA_ADMIN}/config/${org}/` });
+  const { status } = confResp;
+
+  if (status === 403 || status === 401) return false;
+
+  if (status === 200) {
+    const json = await confResp.json();
+    if (json.permissions) return false;
+  }
+
+  const listResp = await daFetch({ url: `${DA_ADMIN}/list/${org}` });
+  const listJson = await listResp.json();
+  return listJson.length > 0;
+}
+
+async function orgCheck() {
+  const { pathname, hash } = window.location;
+  if (pathname.startsWith('/app')) return;
+  if (!hash) return;
+  const hashVal = hash.replace('#', '');
+  if (!hashVal.startsWith('/')) return;
+  const [org] = hashVal.substring(1).split('/');
+  if (!org || org === DEF_SANDBOX) return;
+  const isSandbox = await getIsSandbox(org);
+  if (!isSandbox) return;
+
+  showToast({ text: SANDBOX_MSG, variant: VARIANT_ERROR });
+}
+
+orgCheck();
+window.addEventListener('hashchange', orgCheck);

--- a/nx2/utils/org-check.js
+++ b/nx2/utils/org-check.js
@@ -1,9 +1,24 @@
 import { DA_ADMIN } from './utils.js';
 import { daFetch } from './api.js';
-import { showToast, VARIANT_ERROR } from '../blocks/shared/toast/toast.js';
+import { showToast, VARIANT_WARNING } from '../blocks/shared/toast/toast.js';
 
 const DEF_SANDBOX = 'aem-sandbox';
-const SANDBOX_MSG = 'You are viewing a sandbox organization. Some features may be unavailable.';
+const SANDBOX_FRAGMENT = '/fragments/toasts/sandbox';
+
+async function getSandboxContent() {
+  const resp = await fetch(`${SANDBOX_FRAGMENT}.plain.html`);
+  if (!resp.ok) return null;
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const link = doc.body.querySelector('a');
+  const cta = link ? {
+    text: link.textContent.trim(),
+    href: `${new URL(link.href).pathname}${window.location.search}${window.location.hash}`,
+  } : null;
+  link?.remove();
+  const text = doc.body.textContent.trim();
+  return text ? { text, cta } : null;
+}
 
 async function getIsSandbox(org) {
   const confResp = await daFetch({ url: `${DA_ADMIN}/config/${org}/` });
@@ -32,7 +47,9 @@ async function orgCheck() {
   const isSandbox = await getIsSandbox(org);
   if (!isSandbox) return;
 
-  showToast({ text: SANDBOX_MSG, variant: VARIANT_ERROR });
+  const content = await getSandboxContent();
+  if (!content) return;
+  showToast({ text: content.text, cta: content.cta, variant: VARIANT_WARNING, timeout: null });
 }
 
 orgCheck();

--- a/nx2/utils/org-check.js
+++ b/nx2/utils/org-check.js
@@ -49,7 +49,7 @@ async function orgCheck() {
 
   const content = await getSandboxContent();
   if (!content) return;
-  showToast({ text: content.text, cta: content.cta, variant: VARIANT_WARNING, timeout: null });
+  showToast({ text: content.text, cta: content.cta, variant: VARIANT_WARNING, timeout: null, maxWidth: '42rem' });
 }
 
 orgCheck();

--- a/test/nx2/blocks/shared/toast/toast.test.js
+++ b/test/nx2/blocks/shared/toast/toast.test.js
@@ -1,0 +1,102 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  showToast,
+  VARIANT_SUCCESS,
+  VARIANT_ERROR,
+  VARIANT_WARNING,
+} from '../../../../../nx2/blocks/shared/toast/toast.js';
+
+const HOST_SELECTOR = '#nx-toast-host';
+const getHost = () => document.querySelector(HOST_SELECTOR);
+const getToast = () => document.querySelector('nx-toast');
+
+async function toastFor(opts) {
+  showToast(opts);
+  const toast = getToast();
+  await toast.updateComplete;
+  return toast;
+}
+
+describe('showToast', () => {
+  afterEach(() => {
+    getHost()?.remove();
+  });
+
+  it('creates the host region and appends an nx-toast', async () => {
+    const toast = await toastFor({ text: 'Saved' });
+    const host = getHost();
+    expect(host).to.exist;
+    expect(host.getAttribute('role')).to.equal('region');
+    expect(host.getAttribute('aria-label')).to.equal('Notifications');
+    expect(toast).to.exist;
+    expect(toast.message).to.equal('Saved');
+  });
+
+  it('is a no-op when text is missing, empty, or whitespace-only', () => {
+    showToast({ text: '' });
+    showToast({ text: '   ' });
+    showToast({});
+    expect(getToast()).to.be.null;
+  });
+
+  it('trims surrounding whitespace from the text', async () => {
+    const toast = await toastFor({ text: '  Saved  ' });
+    expect(toast.message).to.equal('Saved');
+    expect(toast.shadowRoot.querySelector('.text').textContent).to.equal('Saved');
+  });
+
+  it('defaults to the success variant', async () => {
+    const toast = await toastFor({ text: 'Saved' });
+    const inner = toast.shadowRoot.querySelector('.toast');
+    expect(inner.classList.contains(`toast-${VARIANT_SUCCESS}`)).to.be.true;
+    expect(inner.getAttribute('role')).to.equal('status');
+  });
+
+  it('applies the error variant class and role="alert"', async () => {
+    const toast = await toastFor({ text: 'Boom', variant: VARIANT_ERROR });
+    const inner = toast.shadowRoot.querySelector('.toast');
+    expect(inner.classList.contains(`toast-${VARIANT_ERROR}`)).to.be.true;
+    expect(inner.getAttribute('role')).to.equal('alert');
+  });
+
+  it('applies the warning variant class and role="alert"', async () => {
+    const toast = await toastFor({ text: 'Careful', variant: VARIANT_WARNING });
+    const inner = toast.shadowRoot.querySelector('.toast');
+    expect(inner.classList.contains(`toast-${VARIANT_WARNING}`)).to.be.true;
+    expect(inner.getAttribute('role')).to.equal('alert');
+  });
+
+  it('falls back to the success variant for unknown values', async () => {
+    const toast = await toastFor({ text: 'Saved', variant: 'bogus' });
+    expect(toast.variant).to.equal(VARIANT_SUCCESS);
+    const inner = toast.shadowRoot.querySelector('.toast');
+    expect(inner.classList.contains(`toast-${VARIANT_SUCCESS}`)).to.be.true;
+  });
+
+  it('renders a CTA link when cta.href and cta.text are provided', async () => {
+    const toast = await toastFor({
+      text: 'Saved',
+      cta: { href: '/next', text: 'View' },
+    });
+    const cta = toast.shadowRoot.querySelector('a.cta');
+    expect(cta).to.exist;
+    expect(cta.getAttribute('href')).to.equal('/next');
+    expect(cta.textContent).to.equal('View');
+  });
+
+  it('does not render a CTA when omitted', async () => {
+    const toast = await toastFor({ text: 'Saved' });
+    expect(toast.shadowRoot.querySelector('a.cta')).to.be.null;
+  });
+
+  it('dismisses the toast when the close button is clicked', async () => {
+    const toast = await toastFor({ text: 'Saved' });
+    toast.shadowRoot.querySelector('button.close').click();
+    expect(getToast()).to.be.null;
+  });
+
+  it('sets --nx-toast-max-width as an inline style when maxWidth is passed', async () => {
+    const toast = await toastFor({ text: 'Saved', maxWidth: '320px' });
+    expect(toast.style.getPropertyValue('--nx-toast-max-width')).to.equal('320px');
+  });
+});


### PR DESCRIPTION
* Adds back the sandbox org warning
* Uses toast from nx2

Fix #539 

https://da.live/#/da-sites/nexter
- After: https://main--da-live--adobe.aem.live/?nx=feat-nx2-org-check#/da-sites/nexter
