### PR TITLE
Add ASO constants workflow and keywords (updated) columns.

### DIFF
--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -1,5 +1,15 @@
 import makeBatches from '../../../../public/utils/batch.js';
 
+export const GLAAS_DEBUG_LOG_KEY = 'glaas.log';
+
+export function shouldLogGLaaSRequests() {
+  try {
+    return localStorage.getItem(GLAAS_DEBUG_LOG_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
 export async function throttle(ms = 500) {
   return new Promise((resolve) => {
     setTimeout(() => { resolve(); }, ms);
@@ -129,7 +139,8 @@ async function readGlaasResponse(resp) {
 function logGlaasAddAssetsRequest({
   url, workflow, taskName, targetLocales, fileDetails, assetMetadata, daBasePath,
 }) {
-  // eslint-disable-next-line no-console -- intentional upload debug
+  if (!shouldLogGLaaSRequests()) return;
+  // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
   console.info('[GLaaS addAssets] request', {
     daBasePath,
     url,
@@ -146,13 +157,14 @@ function logGlaasAddAssetsRequest({
       ...(assetMetadata.languageContext && { languageContext: assetMetadata.languageContext }),
     },
   });
-  // eslint-disable-next-line no-console -- copy-paste wire payload for GLaaS team
+  // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
   console.info('[GLaaS addAssets] _asset_metadata_\n', JSON.stringify(assetMetadata, null, 2));
 }
 
 function logGlaasAddAssetsResponse({
   daBasePath, ok, status, statusText, body, json,
 }) {
+  if (!shouldLogGLaaSRequests()) return;
   const label = ok ? '[GLaaS addAssets] success' : '[GLaaS addAssets] error';
   const detail = {
     daBasePath,
@@ -246,11 +258,13 @@ export async function addAssets({
         }
         return { status: response.status };
       } catch (error) {
-        // eslint-disable-next-line no-console -- intentional upload debug
-        console.error('[GLaaS addAssets] error', {
-          daBasePath: item.daBasePath,
-          message: error?.message ?? String(error),
-        });
+        if (shouldLogGLaaSRequests()) {
+          // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
+          console.error('[GLaaS addAssets] error', {
+            daBasePath: item.daBasePath,
+            message: error?.message ?? String(error),
+          });
+        }
         return { error: 'There was an error uploading' };
       }
     }));
@@ -258,15 +272,17 @@ export async function addAssets({
     task.error += results.filter((result) => (result.error)).length;
     updateLangTask(task, task.langs);
   }
-  // eslint-disable-next-line no-console -- intentional upload debug
-  console.info('[GLaaS addAssets] batch complete', {
-    taskName: name,
-    workflow,
-    targetLocales,
-    sent: task.sent,
-    error: task.error,
-    status: task.error === 0 ? 'uploaded' : 'uploading-with-errors',
-  });
+  if (shouldLogGLaaSRequests()) {
+    // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
+    console.info('[GLaaS addAssets] batch complete', {
+      taskName: name,
+      workflow,
+      targetLocales,
+      sent: task.sent,
+      error: task.error,
+      status: task.error === 0 ? 'uploaded' : 'uploading-with-errors',
+    });
+  }
   if (task.error === 0) task.status = 'uploaded';
 }
 

--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -109,6 +109,67 @@ export function glaasSourcePreviewUrl(aemHref) {
   return aemHref.replace(/\/index$/, '/');
 }
 
+async function readGlaasResponse(resp) {
+  const { status, statusText } = resp;
+  let body = '';
+  try {
+    body = await resp.text();
+  } catch (error) {
+    body = `[response read error: ${error?.message ?? error}]`;
+  }
+  let json;
+  try {
+    json = body ? JSON.parse(body) : undefined;
+  } catch {
+    json = undefined;
+  }
+  return { status, statusText, body, json };
+}
+
+function logGlaasAddAssetsRequest({
+  url, workflow, taskName, targetLocales, fileDetails, assetMetadata, daBasePath,
+}) {
+  // eslint-disable-next-line no-console -- intentional upload debug
+  console.info('[GLaaS addAssets] request', {
+    daBasePath,
+    url,
+    workflow,
+    taskName,
+    targetLocales,
+    fileDetails,
+    assetMetadata: {
+      assetName: assetMetadata.assetName,
+      assetType: assetMetadata.assetType,
+      targetLocales: assetMetadata.targetLocales,
+      'source-preview-url': assetMetadata.metadata?.['source-preview-url'],
+      ...(assetMetadata.langMetadata && { langMetadata: assetMetadata.langMetadata }),
+      ...(assetMetadata.languageContext && { languageContext: assetMetadata.languageContext }),
+    },
+  });
+  // eslint-disable-next-line no-console -- copy-paste wire payload for GLaaS team
+  console.info('[GLaaS addAssets] _asset_metadata_\n', JSON.stringify(assetMetadata, null, 2));
+}
+
+function logGlaasAddAssetsResponse({
+  daBasePath, ok, status, statusText, body, json,
+}) {
+  const label = ok ? '[GLaaS addAssets] success' : '[GLaaS addAssets] error';
+  const detail = {
+    daBasePath,
+    status,
+    statusText,
+    ...(json && { json }),
+    ...(!json && body && { body }),
+  };
+  if (ok) {
+    // eslint-disable-next-line no-console -- intentional upload debug
+    console.info(label, detail);
+  } else {
+    // eslint-disable-next-line no-console -- intentional upload debug
+    console.error(label, detail);
+  }
+}
+
 export async function addAssets({
   origin,
   clientid,
@@ -158,28 +219,38 @@ export async function addAssets({
       const opts = getOpts(clientid, token, body, null, 'POST');
       // Add fileDetails parameter for GLaaS v1.2
       const url = `${origin}/api/l10n/v1.2/tasks/${workflow}/${name}/assets?targetLanguages=${targetLocales.join(',')}&fileDetails=${encodeURIComponent(JSON.stringify(fileDetails))}`;
-      // eslint-disable-next-line no-console -- intentional upload debug
-      console.info('[GLaaS addAssets]', {
+      logGlaasAddAssetsRequest({
         url,
         workflow,
         taskName: name,
         targetLocales,
         fileDetails,
-        assetMetadata: {
-          assetName: assetMetadata.assetName,
-          assetType: assetMetadata.assetType,
-          targetLocales: assetMetadata.targetLocales,
-          'source-preview-url': assetMetadata.metadata?.['source-preview-url'],
-          ...(assetMetadata.langMetadata && { langMetadata: assetMetadata.langMetadata }),
-          ...(assetMetadata.languageContext && { languageContext: assetMetadata.languageContext }),
-        },
+        assetMetadata,
+        daBasePath: item.daBasePath,
       });
 
       try {
         const resp = await fetch(url, opts);
-        if (!resp.ok) throw new Error(resp.status);
-        return { status: resp.status };
-      } catch {
+        const response = await readGlaasResponse(resp);
+        logGlaasAddAssetsResponse({
+          daBasePath: item.daBasePath,
+          ok: resp.ok,
+          ...response,
+        });
+        if (!resp.ok) {
+          return {
+            error: 'There was an error uploading',
+            status: response.status,
+            glaasBody: response.body,
+          };
+        }
+        return { status: response.status };
+      } catch (error) {
+        // eslint-disable-next-line no-console -- intentional upload debug
+        console.error('[GLaaS addAssets] error', {
+          daBasePath: item.daBasePath,
+          message: error?.message ?? String(error),
+        });
         return { error: 'There was an error uploading' };
       }
     }));
@@ -187,6 +258,15 @@ export async function addAssets({
     task.error += results.filter((result) => (result.error)).length;
     updateLangTask(task, task.langs);
   }
+  // eslint-disable-next-line no-console -- intentional upload debug
+  console.info('[GLaaS addAssets] batch complete', {
+    taskName: name,
+    workflow,
+    targetLocales,
+    sent: task.sent,
+    error: task.error,
+    status: task.error === 0 ? 'uploaded' : 'uploading-with-errors',
+  });
   if (task.error === 0) task.status = 'uploaded';
 }
 

--- a/nx/blocks/loc/connectors/glaas/index.js
+++ b/nx/blocks/loc/connectors/glaas/index.js
@@ -1,7 +1,7 @@
 import { Queue } from '../../../../public/utils/tree.js';
 import {
   checkSession, createTask, addAssets, updateStatus, getTask, downloadAsset,
-  prepareTargetPreview, getGlaasFilename,
+  prepareTargetPreview, getGlaasFilename, shouldLogGLaaSRequests,
 } from './api.js';
 import {
   createMultimodalTask,
@@ -10,7 +10,6 @@ import {
   getMultimodalV2TaskStatus,
   prepareMultimodalPageForSave,
   logMultimodalRequest,
-  shouldLogMultimodalRequests,
 } from './multimodalApi.js';
 import { getGlaasToken, connectToGlaas } from './auth.js';
 import { addDnt, removeDnt } from './dnt.js';
@@ -219,7 +218,7 @@ async function sendMultimodalTask(service, suppliedTask, urls, actions, { org, s
     updateLangTask(task, task.langs);
     await saveState();
 
-    const logRequest = shouldLogMultimodalRequests() ? logMultimodalRequest : undefined;
+    const logRequest = shouldLogGLaaSRequests() ? logMultimodalRequest : undefined;
     logRequest?.('translate-all-send', {
       taskName: task.name,
       workflow: task.workflow,
@@ -588,7 +587,7 @@ export async function saveItems({
     throw new Error(`No matching tasks found for URLs: ${missingUrls.map((u) => u.suppliedPath).join(', ')}`);
   }
 
-  const logRequest = shouldLogMultimodalRequests() ? logMultimodalRequest : undefined;
+  const logRequest = shouldLogGLaaSRequests() ? logMultimodalRequest : undefined;
 
   const downloadCallback = async (url) => {
     const task = urlToTaskMap.get(url.suppliedPath);

--- a/nx/blocks/loc/connectors/glaas/multimodalApi.js
+++ b/nx/blocks/loc/connectors/glaas/multimodalApi.js
@@ -2,10 +2,25 @@ import { DA_ORIGIN } from '../../../../public/utils/constants.js';
 import { Queue } from '../../../../public/utils/tree.js';
 import { daFetch } from '../../../../utils/daFetch.js';
 import {
-  buildGlaasCreateMetadata, getOpts, glaasSourcePreviewUrl, throttle,
+  buildGlaasCreateMetadata,
+  getOpts,
+  glaasSourcePreviewUrl,
+  shouldLogGLaaSRequests,
+  throttle,
 } from './api.js';
 
-const MULTIMODAL_LOG_KEY = 'glaas.multimodal.log';
+export { shouldLogGLaaSRequests } from './api.js';
+
+function logMultimodalDebug(logRequest, step, detail, { level = 'info' } = {}) {
+  if (logRequest) {
+    logRequest(step, detail);
+    return;
+  }
+  if (!shouldLogGLaaSRequests()) return;
+  const fn = level === 'warn' ? console.warn : console.info;
+  // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
+  fn('[GLaaS multimodal]', step, detail);
+}
 /** Documented GLaaS budget is 120/min per client id; target 100 for shared-stage headroom. */
 const GLAAS_API_LIMIT_PER_MINUTE = 100;
 const GLAAS_API_WINDOW_MS = 60_000;
@@ -171,17 +186,8 @@ export function buildTranslatedMediaPath({ langCode, glaasName }) {
   return `/${locale}${base}`;
 }
 
-export function shouldLogMultimodalRequests() {
-  try {
-    return localStorage.getItem(MULTIMODAL_LOG_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
 export function logMultimodalRequest(step, detail) {
-  // eslint-disable-next-line no-console -- dev multimodal handoff
-  console.info('[GLaaS multimodal]', step, detail);
+  logMultimodalDebug(undefined, step, detail);
 }
 
 export async function getPutUrlForFile({
@@ -299,10 +305,7 @@ export async function createMultimodalTask({
 
   const url = `${origin}/api/l10n/v2.0/tasks/${product}/${project}/create`;
   logRequest?.('v2-create', { method: 'POST', url, body });
-  if (logRequest) {
-    // eslint-disable-next-line no-console -- dev handoff
-    console.info('[GLaaS multimodal] v2-create-body-json\n', JSON.stringify(body, null, 2));
-  }
+  logMultimodalDebug(logRequest, 'v2-create-body-json\n', JSON.stringify(body, null, 2));
   const opts = getOpts(clientid, token, JSON.stringify(body), 'application/json', 'POST');
   try {
     const resp = await fetch(url, opts);
@@ -865,14 +868,21 @@ export function checkMediaImageSize({ glaasName, mediaPath, sizeBytes, logReques
     exceedsUploadLimit,
     exceedsDocumentedLimit,
   };
-  logRequest?.('media-image-size', detail);
-  if (!logRequest) {
-    console.info('[GLaaS multimodal] Media image upload size:', detail);
-  }
+  logMultimodalDebug(logRequest, 'media-image-size', detail);
   if (exceedsUploadLimit) {
-    console.warn('[GLaaS multimodal] Image exceeds observed Media Bus upload limit:', detail);
+    logMultimodalDebug(
+      logRequest,
+      'Image exceeds observed Media Bus upload limit',
+      detail,
+      { level: 'warn' },
+    );
   } else if (exceedsDocumentedLimit) {
-    console.warn('[GLaaS multimodal] Image exceeds documented Media Bus limit:', detail);
+    logMultimodalDebug(
+      logRequest,
+      'Image exceeds documented Media Bus limit',
+      detail,
+      { level: 'warn' },
+    );
   }
   return detail;
 }
@@ -959,8 +969,12 @@ async function saveMultimodalImageToMedia({
       sizeFormatted: uploaded.sizeFormatted,
       maxFormatted: uploaded.maxFormatted,
     };
-    logRequest?.('media-image-skip', detail);
-    console.warn('[GLaaS multimodal] Skipping oversized image (keeping source URL):', detail);
+    logMultimodalDebug(
+      logRequest,
+      'Skipping oversized image (keeping source URL)',
+      detail,
+      { level: 'warn' },
+    );
     return {
       skipped: true,
       glaasName: image.glaasName,

--- a/nx/blocks/loc/connectors/glaas/translationMetadata.js
+++ b/nx/blocks/loc/connectors/glaas/translationMetadata.js
@@ -107,32 +107,84 @@ export function needsKeywordsMetadata(parsedSchema) {
   return Object.values(parsedSchema).some(hasKeywords);
 }
 
-export async function fetchKeywordsFile(org, site, pagePath) {
-  // Remove .html extension if present and add -keywords.json
+const CONSTANT_SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const CONSTANT_TOKEN_PATTERN = /\{\{([a-z0-9]+(-[a-z0-9]+)*)\}\}/g;
+
+function metadataPathForPage(pagePath, suffix) {
   const cleanPath = pagePath.replace(/\.html$/, '');
-  const keywordsPath = `${cleanPath}-keywords.json`;
-  // Try primary path
-  let url = `${DA_ORIGIN}/source/${org}/${site}${keywordsPath}`;
+  return `${cleanPath}${suffix}`;
+}
+
+async function fetchMetadataFile(org, site, pagePath, suffix, readBody) {
+  const metadataPath = metadataPathForPage(pagePath, suffix);
+  let url = `${DA_ORIGIN}/source/${org}/${site}${metadataPath}`;
   try {
-    const resp = await daFetch(url);
+    let resp = await daFetch(url);
     if (resp.ok) {
-      return resp.json();
+      return readBody(resp);
     }
-    // If 404 and path contains /langstore/, try fallback
-    if (resp.status === 404 && keywordsPath.includes('/langstore/')) {
-      const fallbackPath = keywordsPath.replace(/\/langstore\/[^/]+\//, '/');
+    if (resp.status === 404 && metadataPath.includes('/langstore/')) {
+      const fallbackPath = metadataPath.replace(/\/langstore\/[^/]+\//, '/');
       url = `${DA_ORIGIN}/source/${org}/${site}${fallbackPath}`;
-      const fallbackResp = await daFetch(url);
-      if (fallbackResp.ok) {
-        return fallbackResp.json();
+      resp = await daFetch(url);
+      if (resp.ok) {
+        return readBody(resp);
       }
     }
     return null;
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('Error fetching keywords file:', error);
+    console.error('Error fetching page metadata file:', suffix, error);
     return null;
   }
+}
+
+export async function fetchKeywordsFile(org, site, pagePath) {
+  return fetchMetadataFile(org, site, pagePath, '-keywords.json', (resp) => resp.json());
+}
+
+export async function fetchConstantsFile(org, site, pagePath) {
+  return fetchMetadataFile(org, site, pagePath, '-constants.html', (resp) => resp.text());
+}
+
+function collectConstantSlugsFromText(text) {
+  if (!text || typeof text !== 'string') return [];
+  const slugs = new Set();
+  const pattern = new RegExp(CONSTANT_TOKEN_PATTERN.source, CONSTANT_TOKEN_PATTERN.flags);
+  let match = pattern.exec(text);
+  while (match) {
+    const slug = match[1];
+    if (CONSTANT_SLUG_PATTERN.test(slug)) slugs.add(slug);
+    match = pattern.exec(text);
+  }
+  return [...slugs].sort();
+}
+
+function slugFromConstantsBlock(block) {
+  if (!block) return null;
+  const slugClasses = [...block.classList].filter((className) => className !== 'aso-constants');
+  if (slugClasses.length !== 1) return null;
+  const slug = slugClasses[0];
+  return CONSTANT_SLUG_PATTERN.test(slug) ? slug : null;
+}
+
+function constantsRowsFromHtml(html) {
+  if (!html || typeof html !== 'string') return [];
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const byLanguage = new Map();
+  doc.querySelectorAll('div.aso-constants').forEach((block) => {
+    const slug = slugFromConstantsBlock(block);
+    if (!slug) return;
+    Array.from(block.children).forEach((row) => {
+      if (row.tagName !== 'DIV' || row.children.length < 2) return;
+      const language = row.children[0].textContent.trim();
+      const value = row.children[1].innerHTML.trim();
+      if (!language || !value) return;
+      if (!byLanguage.has(language)) byLanguage.set(language, {});
+      byLanguage.get(language)[slug] = value;
+    });
+  });
+  return [...byLanguage.entries()].map(([language, slugs]) => ({ language, slugs }));
 }
 
 /**
@@ -171,16 +223,8 @@ function isExactMatch(div, fieldName) {
   return false;
 }
 
-export function annotateHTML(htmlContent, parsedSchema) {
-  if (!htmlContent) {
-    return htmlContent;
-  }
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlContent, 'text/html');
-  unwrapSoleParagraphs(doc);
-  if (!parsedSchema || Object.keys(parsedSchema).length === 0) {
-    return doc.body.innerHTML;
-  }
+function forEachMetadataField(doc, parsedSchema, visitField) {
+  if (!parsedSchema || Object.keys(parsedSchema).length === 0) return;
   Object.entries(parsedSchema).forEach(([blockId, block]) => {
     const { selector, fields } = block;
     const blockElements = doc.querySelectorAll(selector);
@@ -194,26 +238,67 @@ export function annotateHTML(htmlContent, parsedSchema) {
         }
         const field = fields.find((f) => isExactMatch(labelDiv, f.fieldName));
         if (!field) return;
-        const { fieldName, fieldKey, charCount, keywordsInjection } = field;
-        if (charCount) {
-          contentDiv.setAttribute('its-storage-size', charCount);
-        }
-        const keywordsValue = String(keywordsInjection);
-        const locNoteValue = `block-name=${blockId}_${blockIndex + 1}_${fieldKey}|fieldName=${fieldName}|apply-keywords=${keywordsValue}`;
-        contentDiv.setAttribute('its-loc-note', locNoteValue);
-        contentDiv.setAttribute('its-loc-note-type', 'description');
+        visitField({
+          blockId,
+          blockIndex: blockIndex + 1,
+          field,
+          contentDiv,
+        });
       });
     });
+  });
+}
+
+function fieldConstantSlugs(pageHtml, parsedSchema) {
+  if (!pageHtml || !parsedSchema) return [];
+  const doc = new DOMParser().parseFromString(pageHtml, 'text/html');
+  const fieldsWithSlugs = [];
+  forEachMetadataField(doc, parsedSchema, ({ blockId, blockIndex, field, contentDiv }) => {
+    const slugs = collectConstantSlugsFromText(contentDiv.innerHTML);
+    if (slugs.length === 0) return;
+    fieldsWithSlugs.push({
+      blockId,
+      blockIndex,
+      fieldKey: field.fieldKey,
+      slugs,
+    });
+  });
+  return fieldsWithSlugs;
+}
+
+export function annotateHTML(htmlContent, parsedSchema) {
+  if (!htmlContent) {
+    return htmlContent;
+  }
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlContent, 'text/html');
+  unwrapSoleParagraphs(doc);
+  forEachMetadataField(doc, parsedSchema, ({
+    blockId, blockIndex, field, contentDiv,
+  }) => {
+    const { fieldName, fieldKey, charCount, keywordsInjection } = field;
+    if (charCount) {
+      contentDiv.setAttribute('its-storage-size', charCount);
+    }
+    const keywordsValue = String(keywordsInjection);
+    const locNoteValue = `block-name=${blockId}_${blockIndex}_${fieldKey}|fieldName=${fieldName}|apply-keywords=${keywordsValue}`;
+    contentDiv.setAttribute('its-loc-note', locNoteValue);
+    contentDiv.setAttribute('its-loc-note-type', 'description');
   });
 
   return doc.body.innerHTML;
 }
 
-export function buildLanguageMetadata(keywordsData, langs) {
-  if (!keywordsData || !langs) return {};
+export function buildLanguageMetadata(keywordsData, langs, {
+  constantsHtml,
+  pageHtml,
+  parsedSchema,
+} = {}) {
+  if (!langs) return {};
   const targetLangCodes = new Set(langs.map((lang) => lang.code));
   const langCodeByName = new Map();
-  const getLangCode = (languageName) => {
+  const langCodeForName = (languageName) => {
+    if (!languageName) return null;
     const normalizedName = languageName.toLowerCase();
     let code = langCodeByName.get(normalizedName);
     if (code === undefined) {
@@ -223,33 +308,55 @@ export function buildLanguageMetadata(keywordsData, langs) {
     return code;
   };
   const langMetadata = {};
-  Object.entries(keywordsData).forEach(([key, blockData]) => {
-    if (key.startsWith(':') || !blockData?.data) return;
-    // Parse the key: "aso-app (apple, listing) (1)" -> blockId + index
-    const indexMatch = key.match(/\((\d+)\)$/);
-    if (!indexMatch) return;
-    const index = indexMatch[1];
-    const blockKeyWithoutIndex = key.replace(/\s*\(\d+\)$/, '').trim();
-    const { id: blockId } = processSchemaKey(blockKeyWithoutIndex);
-    // Process each language entry
-    blockData.data.forEach((entry) => {
-      const languageName = entry.language;
-      if (!languageName) return;
-      const langCode = getLangCode(languageName);
-      if (!langCode || !targetLangCodes.has(langCode)) return;
-      if (!langMetadata[langCode]) {
-        langMetadata[langCode] = {};
-      }
-      Object.keys(entry).forEach((fieldName) => {
-        if (fieldName === 'language') return;
-        const keywordValue = entry[fieldName];
-        if (!keywordValue || !keywordValue.trim()) return;
-        const fieldKey = fieldNameToKey(fieldName);
-        const metadataKey = `keywords|${blockId}_${index}_${fieldKey}`;
-        langMetadata[langCode][metadataKey] = keywordValue;
+
+  if (keywordsData) {
+    Object.entries(keywordsData).forEach(([key, blockData]) => {
+      if (key.startsWith(':') || !blockData?.data) return;
+      const indexMatch = key.match(/\((\d+)\)$/);
+      if (!indexMatch) return;
+      const index = indexMatch[1];
+      const blockKeyWithoutIndex = key.replace(/\s*\(\d+\)$/, '').trim();
+      const { id: blockId } = processSchemaKey(blockKeyWithoutIndex);
+      blockData.data.forEach((entry) => {
+        const languageName = entry.language;
+        if (!languageName) return;
+        const langCode = langCodeForName(languageName);
+        if (!langCode || !targetLangCodes.has(langCode)) return;
+        if (!langMetadata[langCode]) {
+          langMetadata[langCode] = {};
+        }
+        Object.keys(entry).forEach((fieldName) => {
+          if (fieldName === 'language') return;
+          const keywordValue = entry[fieldName];
+          if (!keywordValue || !keywordValue.trim()) return;
+          const fieldKey = fieldNameToKey(fieldName);
+          const metadataKey = `keywords|${blockId}_${index}_${fieldKey}`;
+          langMetadata[langCode][metadataKey] = keywordValue;
+        });
       });
     });
-  });
+  }
+
+  if (constantsHtml && pageHtml && parsedSchema) {
+    const fieldsWithSlugs = fieldConstantSlugs(pageHtml, parsedSchema);
+    if (fieldsWithSlugs.length > 0) {
+      constantsRowsFromHtml(constantsHtml).forEach(({ language, slugs }) => {
+        const langCode = langCodeForName(language);
+        if (!langCode || !targetLangCodes.has(langCode)) return;
+        fieldsWithSlugs.forEach(({ blockId, blockIndex, fieldKey, slugs: fieldSlugs }) => {
+          const placeholders = fieldSlugs.reduce((acc, slug) => {
+            const value = slugs[slug];
+            if (value) acc[slug] = value;
+            return acc;
+          }, {});
+          if (Object.keys(placeholders).length === 0) return;
+          if (!langMetadata[langCode]) langMetadata[langCode] = {};
+          const metadataKey = `placeholders|${blockId}_${blockIndex}_${fieldKey}`;
+          langMetadata[langCode][metadataKey] = placeholders;
+        });
+      });
+    }
+  }
 
   return langMetadata;
 }
@@ -374,7 +481,21 @@ export function addSeoGlossary(urls, langs) {
 }
 
 /**
- * Add translation metadata to URLs (HTML annotation + keywords + SEO glossary languageContext)
+ * Logs langMetadata in the shape sent to GLaaS (copy from browser console for handoff).
+ * @param {string} pagePath
+ * @param {object} langMetadata
+ */
+export function logGlaasLangMetadata(pagePath, langMetadata) {
+  if (!langMetadata || Object.keys(langMetadata).length === 0) return;
+  // eslint-disable-next-line no-console -- reference payload for GLaaS team
+  console.info(
+    `[GLaaS langMetadata] ${pagePath}\n`,
+    JSON.stringify({ langMetadata }, null, 2),
+  );
+}
+
+/**
+ * Add translation metadata to URLs (HTML annotation + keywords + placeholders + SEO glossary)
  * Modifies url.content, url.translationMetadata, and url.languageContext in place
  * @param {string} org - Organization name
  * @param {string} site - Site name
@@ -382,7 +503,6 @@ export function addSeoGlossary(urls, langs) {
  * @param {Array} urls - Array of URL objects with .content and .suppliedPath
  */
 export async function addTranslationMetadata(org, site, langs, urls) {
-  // Block schema flow (HTML annotation + per-page keywords)
   const blockSchema = await fetchBlockSchema(org, site);
   if (blockSchema) {
     const hasKeywords = needsKeywordsMetadata(blockSchema);
@@ -390,17 +510,26 @@ export async function addTranslationMetadata(org, site, langs, urls) {
       if (url.content && typeof url.content === 'string') {
         url.content = annotateHTML(url.content, blockSchema);
       }
-      if (!hasKeywords) return;
-      const keywordsData = await fetchKeywordsFile(org, site, url.suppliedPath);
-      if (!keywordsData) return;
-      const langMetadata = buildLanguageMetadata(keywordsData, langs);
-      if (langMetadata && Object.keys(langMetadata).length > 0) {
-        url.translationMetadata = langMetadata;
+
+      const needsConstants = fieldConstantSlugs(url.content, blockSchema).length > 0;
+      const [keywordsData, constantsHtml] = await Promise.all([
+        hasKeywords ? fetchKeywordsFile(org, site, url.suppliedPath) : null,
+        needsConstants ? fetchConstantsFile(org, site, url.suppliedPath) : null,
+      ]);
+
+      const translationMetadata = buildLanguageMetadata(keywordsData, langs, {
+        constantsHtml,
+        pageHtml: url.content,
+        parsedSchema: blockSchema,
+      });
+
+      if (Object.keys(translationMetadata).length > 0) {
+        url.translationMetadata = translationMetadata;
+        logGlaasLangMetadata(url.suppliedPath, translationMetadata);
       }
     }));
   }
 
-  // SEO glossary: if /.da/seo/glossary.json exists, add languageContext for GLaaS
   await loadSeoGlossary(org, site);
   addSeoGlossary(urls, langs);
 }

--- a/nx/blocks/loc/connectors/glaas/translationMetadata.js
+++ b/nx/blocks/loc/connectors/glaas/translationMetadata.js
@@ -1,5 +1,6 @@
 import { DA_ORIGIN } from '../../../../public/utils/constants.js';
 import { daFetch } from '../../../../utils/daFetch.js';
+import { shouldLogGLaaSRequests } from './api.js';
 
 const BLOCK_SCHEMA_PATH = '/.da/block-schema.json';
 const SEO_GLOSSARY_PATH = '/.da/seo/glossary.json';
@@ -249,11 +250,10 @@ function forEachMetadataField(doc, parsedSchema, visitField) {
   });
 }
 
-function fieldConstantSlugs(pageHtml, parsedSchema) {
-  if (!pageHtml || !parsedSchema) return [];
-  const doc = new DOMParser().parseFromString(pageHtml, 'text/html');
+function fieldConstantSlugs(pageDoc, parsedSchema) {
+  if (!pageDoc || !parsedSchema) return [];
   const fieldsWithSlugs = [];
-  forEachMetadataField(doc, parsedSchema, ({ blockId, blockIndex, field, contentDiv }) => {
+  forEachMetadataField(pageDoc, parsedSchema, ({ blockId, blockIndex, field, contentDiv }) => {
     const slugs = collectConstantSlugsFromText(contentDiv.innerHTML);
     if (slugs.length === 0) return;
     fieldsWithSlugs.push({
@@ -266,12 +266,11 @@ function fieldConstantSlugs(pageHtml, parsedSchema) {
   return fieldsWithSlugs;
 }
 
-export function annotateHTML(htmlContent, parsedSchema) {
+function annotateHTML(htmlContent, parsedSchema) {
   if (!htmlContent) {
     return htmlContent;
   }
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlContent, 'text/html');
+  const doc = new DOMParser().parseFromString(htmlContent, 'text/html');
   unwrapSoleParagraphs(doc);
   forEachMetadataField(doc, parsedSchema, ({
     blockId, blockIndex, field, contentDiv,
@@ -286,7 +285,7 @@ export function annotateHTML(htmlContent, parsedSchema) {
     contentDiv.setAttribute('its-loc-note-type', 'description');
   });
 
-  return doc.body.innerHTML;
+  return doc;
 }
 
 function normalizeColumnKey(key) {
@@ -340,8 +339,10 @@ export function normalizeKeywordsFile(json) {
   if (!json || !isSingleSheetKeywords(json)) return json;
   const sheetName = typeof json[':sheetname'] === 'string' ? json[':sheetname'].trim() : '';
   if (!sheetName) {
-    // eslint-disable-next-line no-console
-    console.warn('[keywords] Single-sheet keywords file is missing :sheetname; skipping keyword metadata.');
+    if (shouldLogGLaaSRequests()) {
+      // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
+      console.warn('[keywords] Single-sheet keywords file is missing :sheetname; skipping keyword metadata.');
+    }
     return null;
   }
   const { data, total, offset, limit, ':colWidths': colWidths } = json;
@@ -354,9 +355,10 @@ export function normalizeKeywordsFile(json) {
   };
 }
 
-export function buildLanguageMetadata(keywordsData, langs, {
+function buildLanguageMetadata(keywordsData, langs, {
   constantsHtml,
-  pageHtml,
+  pageDoc,
+  fieldsWithSlugs: providedFieldsWithSlugs,
   parsedSchema,
 } = {}) {
   if (!langs) return {};
@@ -406,26 +408,25 @@ export function buildLanguageMetadata(keywordsData, langs, {
     });
   }
 
-  if (constantsHtml && pageHtml && parsedSchema) {
-    const fieldsWithSlugs = fieldConstantSlugs(pageHtml, parsedSchema);
-    if (fieldsWithSlugs.length > 0) {
-      const neededSlugs = [...new Set(fieldsWithSlugs.flatMap(({ slugs }) => slugs))];
-      constantsRowsFromHtml(constantsHtml, neededSlugs).forEach(({ language, slugs }) => {
-        const langCode = langCodeForName(language);
-        if (!langCode || !targetLangCodes.has(langCode)) return;
-        fieldsWithSlugs.forEach(({ blockId, blockIndex, fieldKey, slugs: fieldSlugs }) => {
-          const placeholders = fieldSlugs.reduce((acc, slug) => {
-            const value = slugs[slug];
-            if (value) acc[slug] = value;
-            return acc;
-          }, {});
-          if (Object.keys(placeholders).length === 0) return;
-          if (!langMetadata[langCode]) langMetadata[langCode] = {};
-          const metadataKey = `placeholders|${blockId}_${blockIndex}_${fieldKey}`;
-          langMetadata[langCode][metadataKey] = placeholders;
-        });
+  const fieldsWithSlugs = providedFieldsWithSlugs
+    ?? (pageDoc && parsedSchema ? fieldConstantSlugs(pageDoc, parsedSchema) : []);
+  if (constantsHtml && fieldsWithSlugs.length > 0) {
+    const neededSlugs = [...new Set(fieldsWithSlugs.flatMap(({ slugs }) => slugs))];
+    constantsRowsFromHtml(constantsHtml, neededSlugs).forEach(({ language, slugs }) => {
+      const langCode = langCodeForName(language);
+      if (!langCode || !targetLangCodes.has(langCode)) return;
+      fieldsWithSlugs.forEach(({ blockId, blockIndex, fieldKey, slugs: fieldSlugs }) => {
+        const placeholders = fieldSlugs.reduce((acc, slug) => {
+          const value = slugs[slug];
+          if (value) acc[slug] = value;
+          return acc;
+        }, {});
+        if (Object.keys(placeholders).length === 0) return;
+        if (!langMetadata[langCode]) langMetadata[langCode] = {};
+        const metadataKey = `placeholders|${blockId}_${blockIndex}_${fieldKey}`;
+        langMetadata[langCode][metadataKey] = placeholders;
       });
-    }
+    });
   }
 
   return langMetadata;
@@ -550,14 +551,9 @@ export function addSeoGlossary(urls, langs) {
   });
 }
 
-/**
- * Logs langMetadata in the shape sent to GLaaS (copy from browser console for handoff).
- * @param {string} pagePath
- * @param {object} langMetadata
- */
-export function logGlaasLangMetadata(pagePath, langMetadata) {
-  if (!langMetadata || Object.keys(langMetadata).length === 0) return;
-  // eslint-disable-next-line no-console -- reference payload for GLaaS team
+function logGlaasLangMetadata(pagePath, langMetadata) {
+  if (!shouldLogGLaaSRequests()) return;
+  // eslint-disable-next-line no-console -- dev GLaaS handoff (glaas.log)
   console.info(
     `[GLaaS langMetadata] ${pagePath}\n`,
     JSON.stringify({ langMetadata }, null, 2),
@@ -577,11 +573,15 @@ export async function addTranslationMetadata(org, site, langs, urls) {
   if (blockSchema) {
     const hasKeywords = needsKeywordsMetadata(blockSchema);
     await Promise.all(urls.map(async (url) => {
+      let pageDoc = null;
+      let fieldsWithSlugs = [];
       if (url.content && typeof url.content === 'string') {
-        url.content = annotateHTML(url.content, blockSchema);
+        pageDoc = annotateHTML(url.content, blockSchema);
+        url.content = pageDoc.body.innerHTML;
+        fieldsWithSlugs = fieldConstantSlugs(pageDoc, blockSchema);
       }
 
-      const needsConstants = fieldConstantSlugs(url.content, blockSchema).length > 0;
+      const needsConstants = fieldsWithSlugs.length > 0;
       const [keywordsData, constantsHtml] = await Promise.all([
         hasKeywords ? fetchKeywordsFile(org, site, url.suppliedPath) : null,
         needsConstants ? fetchConstantsFile(org, site, url.suppliedPath) : null,
@@ -589,7 +589,7 @@ export async function addTranslationMetadata(org, site, langs, urls) {
 
       const translationMetadata = buildLanguageMetadata(keywordsData, langs, {
         constantsHtml,
-        pageHtml: url.content,
+        fieldsWithSlugs,
         parsedSchema: blockSchema,
       });
 

--- a/nx/blocks/loc/connectors/glaas/translationMetadata.js
+++ b/nx/blocks/loc/connectors/glaas/translationMetadata.js
@@ -332,6 +332,28 @@ function buildKeywordMetadataValue(keywordValue, updatedCell) {
   return { value, updated };
 }
 
+function isSingleSheetKeywords(json) {
+  return json?.[':type'] === 'sheet' && Array.isArray(json.data);
+}
+
+export function normalizeKeywordsFile(json) {
+  if (!json || !isSingleSheetKeywords(json)) return json;
+  const sheetName = typeof json[':sheetname'] === 'string' ? json[':sheetname'].trim() : '';
+  if (!sheetName) {
+    // eslint-disable-next-line no-console
+    console.warn('[keywords] Single-sheet keywords file is missing :sheetname; skipping keyword metadata.');
+    return null;
+  }
+  const { data, total, offset, limit, ':colWidths': colWidths } = json;
+  const sheet = { total, offset, limit, data };
+  if (colWidths) sheet[':colWidths'] = colWidths;
+  return {
+    ':type': 'multi-sheet',
+    ':names': [sheetName],
+    [sheetName]: sheet,
+  };
+}
+
 export function buildLanguageMetadata(keywordsData, langs, {
   constantsHtml,
   pageHtml,
@@ -352,8 +374,9 @@ export function buildLanguageMetadata(keywordsData, langs, {
   };
   const langMetadata = {};
 
-  if (keywordsData) {
-    Object.entries(keywordsData).forEach(([key, blockData]) => {
+  const normalizedKeywords = normalizeKeywordsFile(keywordsData);
+  if (normalizedKeywords) {
+    Object.entries(normalizedKeywords).forEach(([key, blockData]) => {
       if (key.startsWith(':') || !blockData?.data) return;
       const indexMatch = key.match(/\((\d+)\)$/);
       if (!indexMatch) return;

--- a/nx/blocks/loc/connectors/glaas/translationMetadata.js
+++ b/nx/blocks/loc/connectors/glaas/translationMetadata.js
@@ -160,21 +160,18 @@ function collectConstantSlugsFromText(text) {
   return [...slugs].sort();
 }
 
-function slugFromConstantsBlock(block) {
-  if (!block) return null;
-  const slugClasses = [...block.classList].filter((className) => className !== 'aso-constants');
-  if (slugClasses.length !== 1) return null;
-  const slug = slugClasses[0];
-  return CONSTANT_SLUG_PATTERN.test(slug) ? slug : null;
+function getConstantsBlockBySlug(doc, slug) {
+  if (!doc || !slug || !CONSTANT_SLUG_PATTERN.test(slug)) return null;
+  return doc.querySelector(`main > div > div.${CSS.escape(slug)}`);
 }
 
-function constantsRowsFromHtml(html) {
-  if (!html || typeof html !== 'string') return [];
+function constantsRowsFromHtml(html, slugs = []) {
+  if (!html || typeof html !== 'string' || slugs.length === 0) return [];
   const doc = new DOMParser().parseFromString(html, 'text/html');
   const byLanguage = new Map();
-  doc.querySelectorAll('div.aso-constants').forEach((block) => {
-    const slug = slugFromConstantsBlock(block);
-    if (!slug) return;
+  slugs.forEach((slug) => {
+    const block = getConstantsBlockBySlug(doc, slug);
+    if (!block) return;
     Array.from(block.children).forEach((row) => {
       if (row.tagName !== 'DIV' || row.children.length < 2) return;
       const language = row.children[0].textContent.trim();
@@ -184,7 +181,10 @@ function constantsRowsFromHtml(html) {
       byLanguage.get(language)[slug] = value;
     });
   });
-  return [...byLanguage.entries()].map(([language, slugs]) => ({ language, slugs }));
+  return [...byLanguage.entries()].map(([language, slugValues]) => ({
+    language,
+    slugs: slugValues,
+  }));
 }
 
 /**
@@ -409,7 +409,8 @@ export function buildLanguageMetadata(keywordsData, langs, {
   if (constantsHtml && pageHtml && parsedSchema) {
     const fieldsWithSlugs = fieldConstantSlugs(pageHtml, parsedSchema);
     if (fieldsWithSlugs.length > 0) {
-      constantsRowsFromHtml(constantsHtml).forEach(({ language, slugs }) => {
+      const neededSlugs = [...new Set(fieldsWithSlugs.flatMap(({ slugs }) => slugs))];
+      constantsRowsFromHtml(constantsHtml, neededSlugs).forEach(({ language, slugs }) => {
         const langCode = langCodeForName(language);
         if (!langCode || !targetLangCodes.has(langCode)) return;
         fieldsWithSlugs.forEach(({ blockId, blockIndex, fieldKey, slugs: fieldSlugs }) => {

--- a/nx/blocks/loc/connectors/glaas/translationMetadata.js
+++ b/nx/blocks/loc/connectors/glaas/translationMetadata.js
@@ -289,6 +289,49 @@ export function annotateHTML(htmlContent, parsedSchema) {
   return doc.body.innerHTML;
 }
 
+function normalizeColumnKey(key) {
+  return typeof key === 'string' ? key.trim() : '';
+}
+
+export function isUpdatedColumn(key) {
+  return normalizeColumnKey(key).endsWith(' (updated)');
+}
+
+export function parseUpdatedFlag(cell) {
+  const val = normalizeColumnKey(cell).toLowerCase();
+  if (!val) return false;
+  return val === 'yes' || val === 'true';
+}
+
+function updatedColumnName(fieldName) {
+  return `${normalizeColumnKey(fieldName)} (updated)`;
+}
+
+function normalizedEntryLookup(entry) {
+  const lookup = new Map();
+  Object.entries(entry).forEach(([key, value]) => {
+    lookup.set(normalizeColumnKey(key), value);
+  });
+  return lookup;
+}
+
+function keywordFieldNamesFromEntry(entry) {
+  const names = new Set();
+  Object.keys(entry).forEach((key) => {
+    const normalized = normalizeColumnKey(key);
+    if (normalized === 'language' || isUpdatedColumn(normalized)) return;
+    names.add(normalized);
+  });
+  return [...names];
+}
+
+function buildKeywordMetadataValue(keywordValue, updatedCell) {
+  const updated = parseUpdatedFlag(updatedCell);
+  const value = typeof keywordValue === 'string' ? keywordValue.trim() : '';
+  if (!value && !updated) return null;
+  return { value, updated };
+}
+
 export function buildLanguageMetadata(keywordsData, langs, {
   constantsHtml,
   pageHtml,
@@ -322,16 +365,19 @@ export function buildLanguageMetadata(keywordsData, langs, {
         if (!languageName) return;
         const langCode = langCodeForName(languageName);
         if (!langCode || !targetLangCodes.has(langCode)) return;
-        if (!langMetadata[langCode]) {
-          langMetadata[langCode] = {};
-        }
-        Object.keys(entry).forEach((fieldName) => {
-          if (fieldName === 'language') return;
-          const keywordValue = entry[fieldName];
-          if (!keywordValue || !keywordValue.trim()) return;
+        const rowLookup = normalizedEntryLookup(entry);
+        keywordFieldNamesFromEntry(entry).forEach((fieldName) => {
+          const keywordMetadata = buildKeywordMetadataValue(
+            rowLookup.get(fieldName),
+            rowLookup.get(updatedColumnName(fieldName)),
+          );
+          if (!keywordMetadata) return;
+          if (!langMetadata[langCode]) {
+            langMetadata[langCode] = {};
+          }
           const fieldKey = fieldNameToKey(fieldName);
           const metadataKey = `keywords|${blockId}_${index}_${fieldKey}`;
-          langMetadata[langCode][metadataKey] = keywordValue;
+          langMetadata[langCode][metadataKey] = keywordMetadata;
         });
       });
     });

--- a/test/loc/glaas/mocks/page-constants.html
+++ b/test/loc/glaas/mocks/page-constants.html
@@ -1,7 +1,7 @@
 <body>
 <main>
   <div>
-    <div class="aso-constants legal-terms">
+    <div class="legal-terms">
       <div>
         <div><p>English</p></div>
         <div><p>[Optional access permissions]</p><p>Camera: Scan pages</p></div>

--- a/test/loc/glaas/mocks/page-constants.html
+++ b/test/loc/glaas/mocks/page-constants.html
@@ -1,0 +1,20 @@
+<body>
+<main>
+  <div>
+    <div class="aso-constants legal-terms">
+      <div>
+        <div><p>English</p></div>
+        <div><p>[Optional access permissions]</p><p>Camera: Scan pages</p></div>
+      </div>
+      <div>
+        <div><p>Japanese</p></div>
+        <div><p>[オプションのアクセス権]</p><p>カメラ: ページをスキャン</p></div>
+      </div>
+      <div>
+        <div><p>French</p></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+</main>
+</body>

--- a/test/loc/glaas/mocks/page-keywords.json
+++ b/test/loc/glaas/mocks/page-keywords.json
@@ -8,17 +8,23 @@
       {
         "language": "English",
         "Subtitle": "ai art generator, ai create, ai image generator, ai image, ai design, ai video, ai photo, ai video editing, ai artist, ai tool, animation, video, content, video effects, sound effects, backgrounds, video animation, image creator, generate, creator, producer, designer, content creator, graphic design, movie maker, text to image, editing tools, text to video, editing app, edit images, edit videos",
-        "Description": "create stunning images with ai, generate professional content, edit photos and videos, design graphics, produce animations, make movies, transform text to visuals"
+        "Subtitle (updated)": "",
+        "Description": "create stunning images with ai, generate professional content, edit photos and videos, design graphics, produce animations, make movies, transform text to visuals",
+        "Description (updated)": ""
       },
       {
         "language": "French",
         "Subtitle": "générateur d'art ia, créer ia, générateur d'image ia, image ia, design ia, vidéo ia, photo ia, montage vidéo ia, artiste ia, outil ia, animation, vidéo, contenu, effets vidéo, effets sonores, arrière-plans, animation vidéo, créateur d'images, générer, créateur, producteur, designer, créateur de contenu, design graphique, créateur de films, texte en image, outils de montage, texte en vidéo, application de montage, modifier des images, modifier des vidéos",
-        "Description": "créez des images époustouflantes avec l'ia, générez du contenu professionnel, modifiez des photos et des vidéos, concevez des graphiques, produisez des animations, créez des films, transformez du texte en visuels"
+        "Subtitle (updated)": "yes",
+        "Description": "créez des images époustouflantes avec l'ia, générez du contenu professionnel, modifiez des photos et des vidéos, concevez des graphiques, produisez des animations, créez des films, transformez du texte en visuels",
+        "Description (updated)": "yes"
       },
       {
         "language": "Japanese",
         "Subtitle": "ai アートジェネレーター, ai 作成, ai 画像ジェネレーター, ai 画像, ai デザイン, ai ビデオ, ai 写真, ai ビデオ編集, ai アーティスト, ai ツール, アニメーション, ビデオ, コンテンツ, ビデオエフェクト, サウンドエフェクト, 背景, ビデオアニメーション, 画像クリエーター, 生成, クリエーター, プロデューサー, デザイナー, コンテンツクリエーター, グラフィックデザイン, 映画メーカー, テキストから画像, 編集ツール, テキストからビデオ, 編集アプリ, 画像編集, ビデオ編集",
-        "Description": "ai で素晴らしい画像を作成, プロフェッショナルなコンテンツを生成, 写真とビデオを編集, グラフィックをデザイン, アニメーションを制作, 映画を作成, テキストをビジュアルに変換"
+        "Subtitle (updated)": "yes",
+        "Description": "ai で素晴らしい画像を作成, プロフェッショナルなコンテンツを生成, 写真とビデオを編集, グラフィックをデザイン, アニメーションを制作, 映画を作成, テキストをビジュアルに変換",
+        "Description (updated)": "yes"
       }
     ]
   },
@@ -30,14 +36,17 @@
       {
         "language": "English",
         "Subtitle": "photo editor pro, professional editing, edit photos, photo tools, image editing, photo filters, retouch photos, photo enhancement, creative editing, photo studio",
-        "Description": "professional photo editing tools, advanced filters and effects, retouch and enhance images, creative photo studio"
+        "Subtitle (updated)": "",
+        "Description": "professional photo editing tools, advanced filters and effects, retouch and enhance images, creative photo studio",
+        "Description (updated)": ""
       },
       {
         "language": "French",
         "Subtitle": "éditeur de photos pro, montage professionnel, modifier des photos, outils photo, édition d'image, filtres photo, retoucher des photos, amélioration photo, montage créatif, studio photo",
-        "Description": "outils d'édition photo professionnels, filtres et effets avancés, retoucher et améliorer les images, studio photo créatif"
+        "Subtitle (updated)": "yes",
+        "Description": "outils d'édition photo professionnels, filtres et effets avancés, retoucher et améliorer les images, studio photo créatif",
+        "Description (updated)": "yes"
       }
     ]
   }
 }
-

--- a/test/loc/glaas/translationMetadata.test.js
+++ b/test/loc/glaas/translationMetadata.test.js
@@ -11,6 +11,8 @@ import {
   buildLanguageMetadata,
   loadSeoGlossary,
   addSeoGlossary,
+  isUpdatedColumn,
+  parseUpdatedFlag,
 } from '../../../nx/blocks/loc/connectors/glaas/translationMetadata.js';
 
 const mockRes = ({ payload, status = 404, ok = false } = {}) => new Promise((resolve) => {
@@ -749,8 +751,14 @@ describe('translationMetadata', () => {
 
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_subtitle');
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_description');
-      expect(result.fr['keywords|aso-app_apple_listing_1_subtitle']).to.equal(expectedSubtitle);
-      expect(result.fr['keywords|aso-app_apple_listing_1_description']).to.equal(expectedDescription);
+      expect(result.fr['keywords|aso-app_apple_listing_1_subtitle']).to.deep.equal({
+        value: expectedSubtitle,
+        updated: true,
+      });
+      expect(result.fr['keywords|aso-app_apple_listing_1_description']).to.deep.equal({
+        value: expectedDescription,
+        updated: true,
+      });
     });
 
     it('should handle multiple blocks', () => {
@@ -766,8 +774,14 @@ describe('translationMetadata', () => {
 
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_subtitle');
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_2_subtitle');
-      expect(result.fr['keywords|aso-app_apple_listing_2_subtitle']).to.equal(expectedBlock2Subtitle);
-      expect(result.fr['keywords|aso-app_apple_listing_2_description']).to.equal(expectedBlock2Description);
+      expect(result.fr['keywords|aso-app_apple_listing_2_subtitle']).to.deep.equal({
+        value: expectedBlock2Subtitle,
+        updated: true,
+      });
+      expect(result.fr['keywords|aso-app_apple_listing_2_description']).to.deep.equal({
+        value: expectedBlock2Description,
+        updated: true,
+      });
     });
 
     it('should return empty object if keywordsData is null', () => {
@@ -811,6 +825,93 @@ describe('translationMetadata', () => {
       const keys = Object.keys(result.fr || {});
       const hasLanguageKey = keys.some((key) => key.includes('language'));
       expect(hasLanguageKey).to.be.false;
+    });
+
+    it('should send keywords with updated false when flag is empty or no', () => {
+      const keywords = {
+        'aso-app (google, listing) (1)': {
+          data: [{
+            language: 'French',
+            'Short Description': 'keyword text',
+            'Short Description (updated)': 'no',
+            Description: 'other keyword',
+            'Description (updated)': '',
+          }],
+        },
+      };
+      const result = buildLanguageMetadata(keywords, [{ name: 'French', code: 'fr' }]);
+      expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
+        value: 'keyword text',
+        updated: false,
+      });
+      expect(result.fr['keywords|aso-app_google_listing_1_description']).to.deep.equal({
+        value: 'other keyword',
+        updated: false,
+      });
+    });
+
+    it('should send empty value when updated is yes and keywords were deleted', () => {
+      const keywords = {
+        'aso-app (google, listing) (1)': {
+          data: [{
+            language: 'Japanese',
+            'Short Description': '',
+            'Short Description (updated)': 'yes',
+          }],
+        },
+      };
+      const result = buildLanguageMetadata(keywords, [{ name: 'Japanese', code: 'ja' }]);
+      expect(result.ja['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
+        value: '',
+        updated: true,
+      });
+    });
+
+    it('should trim keyword value before send', () => {
+      const keywords = {
+        'aso-app (google, listing) (1)': {
+          data: [{
+            language: 'French',
+            'Short Description': '  keyword text  ',
+            'Short Description (updated)': ' yes ',
+          }],
+        },
+      };
+      const result = buildLanguageMetadata(keywords, [{ name: 'French', code: 'fr' }]);
+      expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
+        value: 'keyword text',
+        updated: true,
+      });
+    });
+
+    it('should send legacy keywords with updated false when column is missing', () => {
+      const legacyKeywords = {
+        'aso-app (google, listing) (1)': {
+          data: [{
+            language: 'French',
+            'Short Description': 'legacy keyword',
+          }],
+        },
+      };
+      const result = buildLanguageMetadata(legacyKeywords, [{ name: 'French', code: 'fr' }]);
+      expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
+        value: 'legacy keyword',
+        updated: false,
+      });
+    });
+
+    describe('updated column helpers', () => {
+      it('should detect updated columns with surrounding whitespace', () => {
+        expect(isUpdatedColumn(' Short Description (updated) ')).to.be.true;
+        expect(isUpdatedColumn('Short Description')).to.be.false;
+      });
+
+      it('should parse updated flag case-insensitively with trim', () => {
+        expect(parseUpdatedFlag(' YES ')).to.be.true;
+        expect(parseUpdatedFlag('True')).to.be.true;
+        expect(parseUpdatedFlag('')).to.be.false;
+        expect(parseUpdatedFlag('no')).to.be.false;
+      });
     });
 
     describe('placeholders from constants metadata file', () => {
@@ -868,6 +969,7 @@ describe('translationMetadata', () => {
               data: [{
                 language: 'Japanese',
                 Description: 'keyword string',
+                'Description (updated)': 'yes',
               }],
             },
           },
@@ -877,7 +979,10 @@ describe('translationMetadata', () => {
 
         expect(result).to.deep.equal({
           ja: {
-            'keywords|aso-app_apple_listing_1_description': 'keyword string',
+            'keywords|aso-app_apple_listing_1_description': {
+              value: 'keyword string',
+              updated: true,
+            },
             'placeholders|aso-app_apple_listing_1_description': {
               'legal-terms': '<p>[オプションのアクセス権]</p><p>カメラ: ページをスキャン</p>',
             },

--- a/test/loc/glaas/translationMetadata.test.js
+++ b/test/loc/glaas/translationMetadata.test.js
@@ -6,15 +6,19 @@ import {
   fieldNameToKey,
   languageNameToCode,
   parseBlockSchema,
-  annotateHTML,
   needsKeywordsMetadata,
-  buildLanguageMetadata,
   normalizeKeywordsFile,
+  fetchBlockSchema,
   loadSeoGlossary,
   addSeoGlossary,
+  addTranslationMetadata,
   isUpdatedColumn,
   parseUpdatedFlag,
 } from '../../../nx/blocks/loc/connectors/glaas/translationMetadata.js';
+
+const TM_TEST_ORG = 'test-org';
+const TM_TEST_SITE = 'test-site';
+const TM_PAGE_PATH = '/content/page';
 
 const mockRes = ({ payload, status = 404, ok = false } = {}) => new Promise((resolve) => {
   resolve({
@@ -25,6 +29,72 @@ const mockRes = ({ payload, status = 404, ok = false } = {}) => new Promise((res
     headers: { get: () => null },
   });
 });
+
+function schemaKeyFromBlock({ selector }) {
+  const parts = selector.replace(/^\./, '').split('.');
+  const [blockType, ...classes] = parts;
+  if (classes.length === 0) return blockType;
+  return `${blockType} (${[...classes].sort().join(', ')})`;
+}
+
+function blockSchemaJsonFromParsed(parsedSchema) {
+  if (!parsedSchema || Object.keys(parsedSchema).length === 0) {
+    return { ':version': 1 };
+  }
+  const schemaData = { ':version': 1 };
+  Object.values(parsedSchema).forEach((block) => {
+    schemaData[schemaKeyFromBlock(block)] = {
+      data: block.fields.map((field) => ({
+        'field name': field.fieldName,
+        'character count': field.charCount || '',
+        'keywords injection': field.keywordsInjection ? 'yes' : '',
+      })),
+    };
+  });
+  return schemaData;
+}
+
+async function runTranslationMetadata({
+  html,
+  langs = [{ name: 'French', code: 'fr' }],
+  blockSchemaJson,
+  blockSchema404 = false,
+  keywordsData,
+  constantsHtml,
+  suppliedPath = TM_PAGE_PATH,
+}) {
+  window.fetch = sinon.stub().callsFake((input) => {
+    const urlStr = String(typeof input === 'string' ? input : input.url);
+
+    if (urlStr.includes('/.da/block-schema.json')) {
+      if (blockSchema404) return mockRes({ status: 404, ok: false });
+      return mockRes({
+        payload: blockSchemaJson ?? { ':version': 1 },
+        status: 200,
+        ok: true,
+      });
+    }
+    if (urlStr.includes('-keywords.json')) {
+      if (keywordsData === undefined) return mockRes({ status: 404, ok: false });
+      return mockRes({ payload: keywordsData, status: 200, ok: true });
+    }
+    if (urlStr.includes('-constants.html')) {
+      if (!constantsHtml) return mockRes({ status: 404, ok: false });
+      return mockRes({ payload: constantsHtml, status: 200, ok: true });
+    }
+    if (urlStr.includes('/.da/seo/glossary.json')) {
+      return mockRes({ status: 404, ok: false });
+    }
+    return mockRes({ status: 404, ok: false });
+  });
+
+  await fetchBlockSchema(TM_TEST_ORG, TM_TEST_SITE, { reset: true });
+  await loadSeoGlossary(TM_TEST_ORG, TM_TEST_SITE, { reset: true });
+
+  const urls = [{ suppliedPath, content: html }];
+  await addTranslationMetadata(TM_TEST_ORG, TM_TEST_SITE, langs, urls);
+  return urls[0];
+}
 
 describe('translationMetadata', () => {
   describe('processSchemaKey', () => {
@@ -303,7 +373,8 @@ describe('translationMetadata', () => {
     });
   });
 
-  describe('annotateHTML', () => {
+  describe('annotateHTML (via addTranslationMetadata)', () => {
+    const originalFetch = window.fetch;
     const parsedSchema = {
       'aso-app_apple_listing': {
         selector: '.aso-app.apple.listing',
@@ -318,7 +389,19 @@ describe('translationMetadata', () => {
       },
     };
 
-    it('should add attributes to HTML elements', () => {
+    afterEach(() => {
+      window.fetch = originalFetch;
+    });
+
+    async function annotateUrl(html, schema = parsedSchema, { blockSchema404 = false } = {}) {
+      return runTranslationMetadata({
+        html,
+        blockSchemaJson: blockSchema404 ? undefined : blockSchemaJsonFromParsed(schema),
+        blockSchema404,
+      });
+    }
+
+    it('should add attributes to HTML elements', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -328,31 +411,31 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
       expect(result).to.include('its-storage-size="30"');
       expect(result).to.include('its-loc-note="block-name=aso-app_apple_listing_1_subtitle|fieldName=Subtitle|apply-keywords=true"');
       expect(result).to.include('its-loc-note-type="description"');
     });
 
-    it('should return unchanged HTML if parsedSchema is empty', () => {
+    it('should return unchanged HTML if parsedSchema is empty', async () => {
       const html = '<div>Test</div>';
-      const result = annotateHTML(html, {});
+      const { content: result } = await annotateUrl(html, {});
       expect(result).to.equal(html);
     });
 
-    it('should return unchanged HTML if htmlContent is empty', () => {
-      const result = annotateHTML('', parsedSchema);
+    it('should return unchanged HTML if htmlContent is empty', async () => {
+      const { content: result } = await annotateUrl('');
       expect(result).to.equal('');
     });
 
-    it('should return unchanged HTML if parsedSchema is null', () => {
+    it('should return unchanged HTML if block schema is unavailable', async () => {
       const html = '<div>Test</div>';
-      const result = annotateHTML(html, null);
+      const { content: result } = await annotateUrl(html, null, { blockSchema404: true });
       expect(result).to.equal(html);
     });
 
-    it('should handle multiple blocks of the same type with correct indexing', () => {
+    it('should handle multiple blocks of the same type with correct indexing', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -368,13 +451,13 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
       expect(result).to.include('block-name=aso-app_apple_listing_1_subtitle');
       expect(result).to.include('block-name=aso-app_apple_listing_2_subtitle');
     });
 
-    it('should handle multiple fields in a block', () => {
+    it('should handle multiple fields in a block', async () => {
       const schemaWithMultipleFields = {
         'aso-app_apple_listing': {
           selector: '.aso-app.apple.listing',
@@ -408,7 +491,7 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, schemaWithMultipleFields);
+      const { content: result } = await annotateUrl(html, schemaWithMultipleFields);
 
       expect(result).to.include('block-name=aso-app_apple_listing_1_subtitle');
       expect(result).to.include('block-name=aso-app_apple_listing_1_description');
@@ -416,7 +499,7 @@ describe('translationMetadata', () => {
       expect(result).to.include('its-storage-size="4000"');
     });
 
-    it('should handle field without charCount (keywords only)', () => {
+    it('should handle field without charCount (keywords only)', async () => {
       const schemaKeywordsOnly = {
         'aso-app_apple_listing': {
           selector: '.aso-app.apple.listing',
@@ -440,13 +523,13 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, schemaKeywordsOnly);
+      const { content: result } = await annotateUrl(html, schemaKeywordsOnly);
 
       expect(result).to.not.include('its-storage-size');
       expect(result).to.include('its-loc-note="block-name=aso-app_apple_listing_1_subtitle|fieldName=Subtitle|apply-keywords=true"');
     });
 
-    it('should skip field if field name div not found in HTML', () => {
+    it('should skip field if field name div not found in HTML', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -456,13 +539,13 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
       expect(result).to.not.include('its-storage-size');
       expect(result).to.not.include('its-loc-note');
     });
 
-    it('should skip field if next sibling is not a div', () => {
+    it('should skip field if next sibling is not a div', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -472,13 +555,13 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
       expect(result).to.not.include('its-storage-size');
       expect(result).to.not.include('its-loc-note');
     });
 
-    it('should unwrap single <p> tag from label div', () => {
+    it('should unwrap single <p> tag from label div', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -488,16 +571,14 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
-      // Should unwrap <p> tag
       expect(result).to.include('<div>Subtitle</div>');
       expect(result).to.not.include('<p>Subtitle</p>');
-      // Should still add attributes
       expect(result).to.include('its-storage-size="30"');
     });
 
-    it('should unwrap single <p> tag from content div', () => {
+    it('should unwrap single <p> tag from content div', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -507,15 +588,14 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
-      // Should unwrap <p> tag
       expect(result).to.include('<div its-storage-size="30"');
       expect(result).to.include('>Adobe Firefly</div>');
       expect(result).to.not.include('<p>Adobe Firefly</p>');
     });
 
-    it('should not unwrap multiple <p> tags', () => {
+    it('should not unwrap multiple <p> tags', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -525,14 +605,13 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
-      // Should keep multiple <p> tags
       expect(result).to.include('<p>Line 1</p>');
       expect(result).to.include('<p>Line 2</p>');
     });
 
-    it('should unwrap <p> tags even without schema', () => {
+    it('should unwrap <p> tags when schema has no matching fields', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -542,18 +621,15 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, null);
+      const { content: result } = await annotateUrl(html, {});
 
-      // Should unwrap <p> tags even without schema
       expect(result).to.include('<div>Label</div>');
       expect(result).to.include('<div>Content</div>');
       expect(result).to.not.include('<p>Label</p>');
       expect(result).to.not.include('<p>Content</p>');
     });
 
-    it('should be resilient to wrapped content - attributes work even with <p> tags', () => {
-      // This test simulates what would happen if unwrapping was skipped
-      // The isExactMatch function should still work with <p> wrapped labels
+    it('should be resilient to wrapped content - attributes work even with <p> tags', async () => {
       const htmlWithPTags = `
         <div class="aso-app listing apple">
           <div>
@@ -563,18 +639,14 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(htmlWithPTags, parsedSchema);
+      const { content: result } = await annotateUrl(htmlWithPTags);
 
-      // Even though input has <p> tags, attributes should be added
-      // (after unwrapping, of course, but isExactMatch handles both cases)
       expect(result).to.include('its-storage-size="30"');
       expect(result).to.include('block-name=aso-app_apple_listing_1_subtitle');
       expect(result).to.include('apply-keywords=true');
     });
 
-    it('should NOT match label divs with nested elements (prevents false positives)', () => {
-      // Tests that we reject <div><p>Field <strong>Name</strong></p></div>
-      // and <div>Field <span>Name</span></div> as label matches
+    it('should NOT match label divs with nested elements (prevents false positives)', async () => {
       const htmlWithNestedElements = `
         <div class="aso-app listing apple">
           <div>
@@ -592,12 +664,11 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(htmlWithNestedElements, parsedSchema);
+      const { content: result } = await annotateUrl(htmlWithNestedElements);
 
       const parser = new DOMParser();
       const doc = parser.parseFromString(result, 'text/html');
 
-      // First two rows should NOT have attributes (nested elements in label)
       const rows = doc.querySelectorAll('.aso-app.listing.apple > div');
       const contentA = rows[0].querySelector(':scope > div:nth-child(2)');
       const contentB = rows[1].querySelector(':scope > div:nth-child(2)');
@@ -607,13 +678,12 @@ describe('translationMetadata', () => {
       expect(contentB.hasAttribute('its-storage-size')).to.be.false;
       expect(contentB.hasAttribute('its-loc-note')).to.be.false;
 
-      // Third row SHOULD have attributes (valid label)
       const validContent = rows[2].querySelector(':scope > div:nth-child(2)');
       expect(validContent.getAttribute('its-storage-size')).to.equal('30');
       expect(validContent.getAttribute('its-loc-note')).to.include('subtitle');
     });
 
-    it('should add attributes to content div (column 2), not label div (column 1)', () => {
+    it('should add attributes to content div (column 2), not label div (column 1)', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -623,7 +693,7 @@ describe('translationMetadata', () => {
         </div>
       `;
 
-      const result = annotateHTML(html, parsedSchema);
+      const { content: result } = await annotateUrl(html);
 
       const parser = new DOMParser();
       const doc = parser.parseFromString(result, 'text/html');
@@ -633,11 +703,9 @@ describe('translationMetadata', () => {
       const labelDiv = row.querySelector(':scope > div:nth-child(1)');
       const contentDiv = row.querySelector(':scope > div:nth-child(2)');
 
-      // Label div should NOT have ITS attributes
       expect(labelDiv.hasAttribute('its-storage-size')).to.be.false;
       expect(labelDiv.hasAttribute('its-loc-note')).to.be.false;
 
-      // Content div SHOULD have ITS attributes
       expect(contentDiv.hasAttribute('its-storage-size')).to.be.true;
       expect(contentDiv.getAttribute('its-storage-size')).to.equal('30');
       expect(contentDiv.hasAttribute('its-loc-note')).to.be.true;
@@ -645,9 +713,7 @@ describe('translationMetadata', () => {
       expect(contentDiv.hasAttribute('its-loc-note-type')).to.be.true;
     });
 
-    it('should handle empty content divs correctly', () => {
-      // Ensures attributes are added to content div (column 2), not row container
-      // Tests with both empty and non-empty content divs
+    it('should handle empty content divs correctly', async () => {
       const html = `
         <div class="aso-app listing apple">
           <div>
@@ -681,7 +747,7 @@ describe('translationMetadata', () => {
         },
       };
 
-      const result = annotateHTML(html, schemaWithDescription);
+      const { content: result } = await annotateUrl(html, schemaWithDescription);
 
       const parser = new DOMParser();
       const doc = parser.parseFromString(result, 'text/html');
@@ -689,7 +755,6 @@ describe('translationMetadata', () => {
       const block = doc.querySelector('.aso-app.listing.apple');
       const rows = block.querySelectorAll(':scope > div');
 
-      // First row (Subtitle with empty content)
       const row1 = rows[0];
       expect(row1.hasAttribute('its-storage-size')).to.be.false;
       expect(row1.hasAttribute('its-loc-note')).to.be.false;
@@ -698,7 +763,6 @@ describe('translationMetadata', () => {
       expect(row1Content.hasAttribute('its-storage-size')).to.be.true;
       expect(row1Content.getAttribute('its-storage-size')).to.equal('30');
 
-      // Second row (Description with content)
       const row2 = rows[1];
       expect(row2.hasAttribute('its-storage-size')).to.be.false;
       expect(row2.hasAttribute('its-loc-note')).to.be.false;
@@ -709,32 +773,79 @@ describe('translationMetadata', () => {
     });
   });
 
-  describe('buildLanguageMetadata', () => {
+  describe('buildLanguageMetadata (via addTranslationMetadata)', () => {
     let mockKeywords;
     const languageMapping = [
       { name: 'English', code: 'en' },
       { name: 'French', code: 'fr' },
       { name: 'Japanese', code: 'ja' },
     ];
+    const originalFetch = window.fetch;
+
+    const keywordsBlockSchemaJson = blockSchemaJsonFromParsed({
+      'aso-app_apple_listing': {
+        selector: '.aso-app.apple.listing',
+        fields: [{
+          fieldName: 'Subtitle',
+          fieldKey: 'subtitle',
+          charCount: '30',
+          keywordsInjection: true,
+        }],
+      },
+    });
+
+    const googleKeywordsBlockSchemaJson = blockSchemaJsonFromParsed({
+      'aso-app_google_listing': {
+        selector: '.aso-app.google.listing',
+        fields: [{
+          fieldName: 'Short Description',
+          fieldKey: 'short-description',
+          charCount: '80',
+          keywordsInjection: true,
+        }],
+      },
+    });
+
+    afterEach(() => {
+      window.fetch = originalFetch;
+    });
+
+    async function metadataUrl({
+      html = '<div></div>',
+      langs,
+      blockSchemaJson = keywordsBlockSchemaJson,
+      keywordsData,
+      constantsHtml,
+    }) {
+      return runTranslationMetadata({
+        html,
+        langs,
+        blockSchemaJson,
+        keywordsData,
+        constantsHtml,
+      });
+    }
 
     before(async () => {
       mockKeywords = JSON.parse(await readFile({ path: './mocks/page-keywords.json' }));
     });
 
-    it('should build language metadata for target languages only', () => {
-      // Only pass French and Japanese (exclude English)
+    it('should build language metadata for target languages only', async () => {
       const frenchAndJapanese = [
         { name: 'French', code: 'fr' },
         { name: 'Japanese', code: 'ja' },
       ];
-      const result = buildLanguageMetadata(mockKeywords, frenchAndJapanese);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: frenchAndJapanese,
+        keywordsData: mockKeywords,
+      });
 
       expect(result).to.have.property('fr');
       expect(result).to.have.property('ja');
       expect(result).to.not.have.property('en');
     });
 
-    it('should create correct metadata keys with block ID, index, and field', () => {
+    it('should create correct metadata keys with block ID, index, and field', async () => {
       const frenchOnly = [{ name: 'French', code: 'fr' }];
       const expectedSubtitle = 'générateur d\'art ia, créer ia, générateur d\'image ia, '
         + 'image ia, design ia, vidéo ia, photo ia, montage vidéo ia, artiste ia, outil ia, '
@@ -748,7 +859,10 @@ describe('translationMetadata', () => {
         + 'concevez des graphiques, produisez des animations, créez des films, '
         + 'transformez du texte en visuels';
 
-      const result = buildLanguageMetadata(mockKeywords, frenchOnly);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: frenchOnly,
+        keywordsData: mockKeywords,
+      });
 
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_subtitle');
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_description');
@@ -762,7 +876,7 @@ describe('translationMetadata', () => {
       });
     });
 
-    it('should handle multiple blocks', () => {
+    it('should handle multiple blocks', async () => {
       const frenchOnly = [{ name: 'French', code: 'fr' }];
       const expectedBlock2Subtitle = 'éditeur de photos pro, montage professionnel, '
         + 'modifier des photos, outils photo, édition d\'image, filtres photo, '
@@ -771,7 +885,10 @@ describe('translationMetadata', () => {
         + 'filtres et effets avancés, retoucher et améliorer les images, '
         + 'studio photo créatif';
 
-      const result = buildLanguageMetadata(mockKeywords, frenchOnly);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: frenchOnly,
+        keywordsData: mockKeywords,
+      });
 
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_1_subtitle');
       expect(result.fr).to.have.property('keywords|aso-app_apple_listing_2_subtitle');
@@ -785,26 +902,26 @@ describe('translationMetadata', () => {
       });
     });
 
-    it('should return empty object if keywordsData is null', () => {
-      const result = buildLanguageMetadata(null, languageMapping);
-      expect(result).to.deep.equal({});
+    it('should omit translationMetadata when keywords file is missing', async () => {
+      const url = await metadataUrl({
+        langs: languageMapping,
+        keywordsData: null,
+      });
+      expect(url.translationMetadata).to.be.undefined;
     });
 
-    it('should return empty object if langs is null', () => {
-      const result = buildLanguageMetadata(mockKeywords, null);
-      expect(result).to.deep.equal({});
-    });
-
-    it('should skip metadata keys starting with colon', () => {
-      const targetLangs = [{ code: 'fr' }];
-      const result = buildLanguageMetadata(mockKeywords, languageMapping, targetLangs);
+    it('should skip metadata keys starting with colon', async () => {
+      const { translationMetadata: result } = await metadataUrl({
+        langs: languageMapping,
+        keywordsData: mockKeywords,
+      });
 
       const keys = Object.keys(result.fr || {});
       const hasDescriptionKey = keys.some((key) => key.includes('description'));
       expect(hasDescriptionKey).to.be.true;
     });
 
-    it('should handle language name not found in languageMapping', () => {
+    it('should handle language name not found in languageMapping', async () => {
       const keywordsWithUnknownLang = {
         'aso-app (apple, listing) (1)': {
           total: 1,
@@ -814,21 +931,27 @@ describe('translationMetadata', () => {
         },
       };
 
-      const result = buildLanguageMetadata(keywordsWithUnknownLang, languageMapping);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: languageMapping,
+        keywordsData: keywordsWithUnknownLang,
+      });
 
-      expect(Object.keys(result)).to.have.lengthOf(0);
+      expect(Object.keys(result || {})).to.have.lengthOf(0);
     });
 
-    it('should exclude language field from metadata', () => {
+    it('should exclude language field from metadata', async () => {
       const frenchOnly = [{ name: 'French', code: 'fr' }];
-      const result = buildLanguageMetadata(mockKeywords, frenchOnly);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: frenchOnly,
+        keywordsData: mockKeywords,
+      });
 
       const keys = Object.keys(result.fr || {});
       const hasLanguageKey = keys.some((key) => key.includes('language'));
       expect(hasLanguageKey).to.be.false;
     });
 
-    it('should send keywords with updated false when flag is empty or no', () => {
+    it('should send keywords with updated false when flag is empty or no', async () => {
       const keywords = {
         'aso-app (google, listing) (1)': {
           data: [{
@@ -840,7 +963,11 @@ describe('translationMetadata', () => {
           }],
         },
       };
-      const result = buildLanguageMetadata(keywords, [{ name: 'French', code: 'fr' }]);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: [{ name: 'French', code: 'fr' }],
+        keywordsData: keywords,
+        blockSchemaJson: googleKeywordsBlockSchemaJson,
+      });
       expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
         value: 'keyword text',
         updated: false,
@@ -851,7 +978,7 @@ describe('translationMetadata', () => {
       });
     });
 
-    it('should send empty value when updated is yes and keywords were deleted', () => {
+    it('should send empty value when updated is yes and keywords were deleted', async () => {
       const keywords = {
         'aso-app (google, listing) (1)': {
           data: [{
@@ -861,14 +988,18 @@ describe('translationMetadata', () => {
           }],
         },
       };
-      const result = buildLanguageMetadata(keywords, [{ name: 'Japanese', code: 'ja' }]);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: [{ name: 'Japanese', code: 'ja' }],
+        keywordsData: keywords,
+        blockSchemaJson: googleKeywordsBlockSchemaJson,
+      });
       expect(result.ja['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
         value: '',
         updated: true,
       });
     });
 
-    it('should trim keyword value before send', () => {
+    it('should trim keyword value before send', async () => {
       const keywords = {
         'aso-app (google, listing) (1)': {
           data: [{
@@ -878,14 +1009,18 @@ describe('translationMetadata', () => {
           }],
         },
       };
-      const result = buildLanguageMetadata(keywords, [{ name: 'French', code: 'fr' }]);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: [{ name: 'French', code: 'fr' }],
+        keywordsData: keywords,
+        blockSchemaJson: googleKeywordsBlockSchemaJson,
+      });
       expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
         value: 'keyword text',
         updated: true,
       });
     });
 
-    it('should send legacy keywords with updated false when column is missing', () => {
+    it('should send legacy keywords with updated false when column is missing', async () => {
       const legacyKeywords = {
         'aso-app (google, listing) (1)': {
           data: [{
@@ -894,14 +1029,18 @@ describe('translationMetadata', () => {
           }],
         },
       };
-      const result = buildLanguageMetadata(legacyKeywords, [{ name: 'French', code: 'fr' }]);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: [{ name: 'French', code: 'fr' }],
+        keywordsData: legacyKeywords,
+        blockSchemaJson: googleKeywordsBlockSchemaJson,
+      });
       expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
         value: 'legacy keyword',
         updated: false,
       });
     });
 
-    it('should build metadata from single-sheet keywords files with :sheetname', () => {
+    it('should build metadata from single-sheet keywords files with :sheetname', async () => {
       const singleSheetKeywords = {
         total: 2,
         limit: 2,
@@ -925,9 +1064,10 @@ describe('translationMetadata', () => {
         ':sheetname': 'aso-app (apple, listing) (1)',
         ':type': 'sheet',
       };
-      const result = buildLanguageMetadata(singleSheetKeywords, [
-        { name: 'French', code: 'fr' },
-      ]);
+      const { translationMetadata: result } = await metadataUrl({
+        langs: [{ name: 'French', code: 'fr' }],
+        keywordsData: singleSheetKeywords,
+      });
 
       expect(result.fr['keywords|aso-app_apple_listing_1_subtitle']).to.deep.equal({
         value: 'mot-clé sous-titre',
@@ -939,7 +1079,7 @@ describe('translationMetadata', () => {
       });
     });
 
-    it('should skip keyword metadata when single-sheet file has no :sheetname', () => {
+    it('should skip keyword metadata when single-sheet file has no :sheetname', async () => {
       const singleSheetKeywords = {
         total: 1,
         limit: 1,
@@ -951,12 +1091,12 @@ describe('translationMetadata', () => {
         }],
         ':type': 'sheet',
       };
-      const warnStub = sinon.stub(console, 'warn');
-      const result = buildLanguageMetadata(singleSheetKeywords, [{ name: 'French', code: 'fr' }]);
-      warnStub.restore();
+      const url = await metadataUrl({
+        langs: [{ name: 'French', code: 'fr' }],
+        keywordsData: singleSheetKeywords,
+      });
 
-      expect(result).to.deep.equal({});
-      expect(warnStub.calledOnce).to.be.true;
+      expect(url.translationMetadata).to.be.undefined;
     });
 
     describe('normalizeKeywordsFile', () => {
@@ -1015,6 +1155,7 @@ describe('translationMetadata', () => {
           ],
         },
       };
+      const listingBlockSchemaJson = blockSchemaJsonFromParsed(listingSchema);
       const listingHtml = `
         <div class="aso-app listing apple">
           <div>
@@ -1023,21 +1164,22 @@ describe('translationMetadata', () => {
           </div>
         </div>
       `;
-      const metadataOptions = () => ({
-        constantsHtml: mockConstantsHtml,
-        pageHtml: listingHtml,
-        parsedSchema: listingSchema,
-      });
 
       before(async () => {
         mockConstantsHtml = await readFile({ path: './mocks/page-constants.html' });
       });
 
-      it('should add placeholders metadata for target languages only', () => {
-        const result = buildLanguageMetadata(null, [
-          { name: 'Japanese', code: 'ja' },
-          { name: 'French', code: 'fr' },
-        ], metadataOptions());
+      it('should add placeholders metadata for target languages only', async () => {
+        const { translationMetadata: result } = await metadataUrl({
+          html: listingHtml,
+          langs: [
+            { name: 'Japanese', code: 'ja' },
+            { name: 'French', code: 'fr' },
+          ],
+          constantsHtml: mockConstantsHtml,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: null,
+        });
 
         expect(result).to.deep.equal({
           ja: {
@@ -1048,7 +1190,7 @@ describe('translationMetadata', () => {
         });
       });
 
-      it('should resolve placeholders when slug is one of multiple block classes', () => {
+      it('should resolve placeholders when slug is one of multiple block classes', async () => {
         const constantsHtml = `
           <body><main><div>
             <div class="legacy-wrapper legal-terms">
@@ -1059,15 +1201,13 @@ describe('translationMetadata', () => {
             </div>
           </div></main></body>
         `;
-        const result = buildLanguageMetadata(
-          null,
-          [{ name: 'Japanese', code: 'ja' }],
-          {
-            constantsHtml,
-            pageHtml: listingHtml,
-            parsedSchema: listingSchema,
-          },
-        );
+        const { translationMetadata: result } = await metadataUrl({
+          html: listingHtml,
+          langs: [{ name: 'Japanese', code: 'ja' }],
+          constantsHtml,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: null,
+        });
 
         expect(result).to.deep.equal({
           ja: {
@@ -1078,9 +1218,13 @@ describe('translationMetadata', () => {
         });
       });
 
-      it('should include both keywords and placeholders for the same locale', () => {
-        const result = buildLanguageMetadata(
-          {
+      it('should include both keywords and placeholders for the same locale', async () => {
+        const { translationMetadata: result } = await metadataUrl({
+          html: listingHtml,
+          langs: [{ name: 'Japanese', code: 'ja' }],
+          constantsHtml: mockConstantsHtml,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: {
             'aso-app (apple, listing) (1)': {
               data: [{
                 language: 'Japanese',
@@ -1089,9 +1233,7 @@ describe('translationMetadata', () => {
               }],
             },
           },
-          [{ name: 'Japanese', code: 'ja' }],
-          metadataOptions(),
-        );
+        });
 
         expect(result).to.deep.equal({
           ja: {
@@ -1106,7 +1248,7 @@ describe('translationMetadata', () => {
         });
       });
 
-      it('should include multiple placeholder slugs in one field when all are mapped', () => {
+      it('should include multiple placeholder slugs in one field when all are mapped', async () => {
         const constantsHtml = `
           <body><main><div>
             <div class="legal-terms">
@@ -1131,10 +1273,12 @@ describe('translationMetadata', () => {
             </div>
           </div>
         `;
-        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+        const { translationMetadata: result } = await metadataUrl({
+          html: pageHtml,
+          langs: [{ name: 'Japanese', code: 'ja' }],
           constantsHtml,
-          pageHtml,
-          parsedSchema: listingSchema,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: null,
         });
 
         expect(result).to.deep.equal({
@@ -1147,7 +1291,7 @@ describe('translationMetadata', () => {
         });
       });
 
-      it('should omit unmapped slugs but keep mapped ones in placeholders metadata', () => {
+      it('should omit unmapped slugs but keep mapped ones in placeholders metadata', async () => {
         const constantsHtml = `
           <body><main><div>
             <div class="legal-terms">
@@ -1172,10 +1316,12 @@ describe('translationMetadata', () => {
             </div>
           </div>
         `;
-        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+        const { translationMetadata: result } = await metadataUrl({
+          html: pageHtml,
+          langs: [{ name: 'Japanese', code: 'ja' }],
           constantsHtml,
-          pageHtml,
-          parsedSchema: listingSchema,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: null,
         });
 
         expect(result).to.deep.equal({
@@ -1187,7 +1333,7 @@ describe('translationMetadata', () => {
         });
       });
 
-      it('should omit placeholders metadata when no slugs resolve for a target locale', () => {
+      it('should omit placeholders metadata when no slugs resolve for a target locale', async () => {
         const constantsHtml = `
           <body><main><div>
             <div class="legal-terms">
@@ -1216,19 +1362,21 @@ describe('translationMetadata', () => {
             </div>
           </div>
         `;
-        const result = buildLanguageMetadata(null, [
-          { name: 'Japanese', code: 'ja' },
-          { name: 'French', code: 'fr' },
-        ], {
+        const url = await metadataUrl({
+          html: pageHtml,
+          langs: [
+            { name: 'Japanese', code: 'ja' },
+            { name: 'French', code: 'fr' },
+          ],
           constantsHtml,
-          pageHtml,
-          parsedSchema: listingSchema,
+          blockSchemaJson: listingBlockSchemaJson,
+          keywordsData: null,
         });
 
-        expect(result).to.deep.equal({});
+        expect(url.translationMetadata).to.be.undefined;
       });
 
-      it('should emit separate placeholders metadata per field with different slug sets', () => {
+      it('should emit separate placeholders metadata per field with different slug sets', async () => {
         const constantsHtml = `
           <body><main><div>
             <div class="legal-terms">
@@ -1276,10 +1424,12 @@ describe('translationMetadata', () => {
             </div>
           </div>
         `;
-        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+        const { translationMetadata: result } = await metadataUrl({
+          html: pageHtml,
+          langs: [{ name: 'Japanese', code: 'ja' }],
           constantsHtml,
-          pageHtml,
-          parsedSchema: schema,
+          blockSchemaJson: blockSchemaJsonFromParsed(schema),
+          keywordsData: null,
         });
 
         expect(result).to.deep.equal({
@@ -1295,7 +1445,6 @@ describe('translationMetadata', () => {
       });
     });
   });
-
   describe('addSeoGlossary (languageContext)', () => {
     const org = 'test-org';
     const site = 'test-site';

--- a/test/loc/glaas/translationMetadata.test.js
+++ b/test/loc/glaas/translationMetadata.test.js
@@ -9,6 +9,7 @@ import {
   annotateHTML,
   needsKeywordsMetadata,
   buildLanguageMetadata,
+  normalizeKeywordsFile,
   loadSeoGlossary,
   addSeoGlossary,
   isUpdatedColumn,
@@ -897,6 +898,91 @@ describe('translationMetadata', () => {
       expect(result.fr['keywords|aso-app_google_listing_1_short-description']).to.deep.equal({
         value: 'legacy keyword',
         updated: false,
+      });
+    });
+
+    it('should build metadata from single-sheet keywords files with :sheetname', () => {
+      const singleSheetKeywords = {
+        total: 2,
+        limit: 2,
+        offset: 0,
+        data: [
+          {
+            language: 'English',
+            Subtitle: '',
+            'Subtitle (updated)': '',
+            Description: '',
+            'Description (updated)': '',
+          },
+          {
+            language: 'French',
+            Subtitle: 'mot-clé sous-titre',
+            'Subtitle (updated)': 'yes',
+            Description: 'mot-clé description',
+            'Description (updated)': 'yes',
+          },
+        ],
+        ':sheetname': 'aso-app (apple, listing) (1)',
+        ':type': 'sheet',
+      };
+      const result = buildLanguageMetadata(singleSheetKeywords, [
+        { name: 'French', code: 'fr' },
+      ]);
+
+      expect(result.fr['keywords|aso-app_apple_listing_1_subtitle']).to.deep.equal({
+        value: 'mot-clé sous-titre',
+        updated: true,
+      });
+      expect(result.fr['keywords|aso-app_apple_listing_1_description']).to.deep.equal({
+        value: 'mot-clé description',
+        updated: true,
+      });
+    });
+
+    it('should skip keyword metadata when single-sheet file has no :sheetname', () => {
+      const singleSheetKeywords = {
+        total: 1,
+        limit: 1,
+        offset: 0,
+        data: [{
+          language: 'French',
+          Subtitle: 'orphaned keyword',
+          'Subtitle (updated)': 'yes',
+        }],
+        ':type': 'sheet',
+      };
+      const warnStub = sinon.stub(console, 'warn');
+      const result = buildLanguageMetadata(singleSheetKeywords, [{ name: 'French', code: 'fr' }]);
+      warnStub.restore();
+
+      expect(result).to.deep.equal({});
+      expect(warnStub.calledOnce).to.be.true;
+    });
+
+    describe('normalizeKeywordsFile', () => {
+      it('should convert single-sheet format to multi-sheet using :sheetname', () => {
+        const singleSheet = {
+          total: 1,
+          offset: 0,
+          limit: 1,
+          data: [{ language: 'French', Subtitle: 'test' }],
+          ':sheetname': 'aso-app (apple, listing) (1)',
+          ':type': 'sheet',
+        };
+        const result = normalizeKeywordsFile(singleSheet);
+
+        expect(result[':type']).to.equal('multi-sheet');
+        expect(result[':names']).to.deep.equal(['aso-app (apple, listing) (1)']);
+        expect(result['aso-app (apple, listing) (1)'].data).to.deep.equal(singleSheet.data);
+      });
+
+      it('should return input unchanged for multi-sheet files', () => {
+        const multiSheet = {
+          ':type': 'multi-sheet',
+          ':names': ['aso-app (apple, listing) (1)'],
+          'aso-app (apple, listing) (1)': { data: [{ language: 'French' }] },
+        };
+        expect(normalizeKeywordsFile(multiSheet)).to.equal(multiSheet);
       });
     });
 

--- a/test/loc/glaas/translationMetadata.test.js
+++ b/test/loc/glaas/translationMetadata.test.js
@@ -812,6 +812,267 @@ describe('translationMetadata', () => {
       const hasLanguageKey = keys.some((key) => key.includes('language'));
       expect(hasLanguageKey).to.be.false;
     });
+
+    describe('placeholders from constants metadata file', () => {
+      let mockConstantsHtml;
+      const listingSchema = {
+        'aso-app_apple_listing': {
+          selector: '.aso-app.apple.listing',
+          fields: [
+            {
+              fieldName: 'Description',
+              fieldKey: 'description',
+              charCount: '4000',
+              keywordsInjection: true,
+            },
+          ],
+        },
+      };
+      const listingHtml = `
+        <div class="aso-app listing apple">
+          <div>
+            <div><p>Description</p></div>
+            <div><p>Intro copy</p><p>{{legal-terms}}</p></div>
+          </div>
+        </div>
+      `;
+      const metadataOptions = () => ({
+        constantsHtml: mockConstantsHtml,
+        pageHtml: listingHtml,
+        parsedSchema: listingSchema,
+      });
+
+      before(async () => {
+        mockConstantsHtml = await readFile({ path: './mocks/page-constants.html' });
+      });
+
+      it('should add placeholders metadata for target languages only', () => {
+        const result = buildLanguageMetadata(null, [
+          { name: 'Japanese', code: 'ja' },
+          { name: 'French', code: 'fr' },
+        ], metadataOptions());
+
+        expect(result).to.deep.equal({
+          ja: {
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>[オプションのアクセス権]</p><p>カメラ: ページをスキャン</p>',
+            },
+          },
+        });
+      });
+
+      it('should include both keywords and placeholders for the same locale', () => {
+        const result = buildLanguageMetadata(
+          {
+            'aso-app (apple, listing) (1)': {
+              data: [{
+                language: 'Japanese',
+                Description: 'keyword string',
+              }],
+            },
+          },
+          [{ name: 'Japanese', code: 'ja' }],
+          metadataOptions(),
+        );
+
+        expect(result).to.deep.equal({
+          ja: {
+            'keywords|aso-app_apple_listing_1_description': 'keyword string',
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>[オプションのアクセス権]</p><p>カメラ: ページをスキャン</p>',
+            },
+          },
+        });
+      });
+
+      it('should include multiple placeholder slugs in one field when all are mapped', () => {
+        const constantsHtml = `
+          <body><main>
+            <div class="aso-constants legal-terms">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>LEGAL JA</p></div>
+              </div>
+            </div>
+            <div class="aso-constants privacy-note">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>PRIVACY JA</p></div>
+              </div>
+            </div>
+          </main></body>
+        `;
+        const pageHtml = `
+          <div class="aso-app listing apple">
+            <div>
+              <div><p>Description</p></div>
+              <div><p>{{legal-terms}}</p><p>{{privacy-note}}</p></div>
+            </div>
+          </div>
+        `;
+        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+          constantsHtml,
+          pageHtml,
+          parsedSchema: listingSchema,
+        });
+
+        expect(result).to.deep.equal({
+          ja: {
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>LEGAL JA</p>',
+              'privacy-note': '<p>PRIVACY JA</p>',
+            },
+          },
+        });
+      });
+
+      it('should omit unmapped slugs but keep mapped ones in placeholders metadata', () => {
+        const constantsHtml = `
+          <body><main>
+            <div class="aso-constants legal-terms">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>LEGAL JA</p></div>
+              </div>
+            </div>
+            <div class="aso-constants privacy-note">
+              <div>
+                <div><p>Japanese</p></div>
+                <div></div>
+              </div>
+            </div>
+          </main></body>
+        `;
+        const pageHtml = `
+          <div class="aso-app listing apple">
+            <div>
+              <div><p>Description</p></div>
+              <div><p>{{legal-terms}} and {{privacy-note}}</p></div>
+            </div>
+          </div>
+        `;
+        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+          constantsHtml,
+          pageHtml,
+          parsedSchema: listingSchema,
+        });
+
+        expect(result).to.deep.equal({
+          ja: {
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>LEGAL JA</p>',
+            },
+          },
+        });
+      });
+
+      it('should omit placeholders metadata when no slugs resolve for a target locale', () => {
+        const constantsHtml = `
+          <body><main>
+            <div class="aso-constants legal-terms">
+              <div>
+                <div><p>Japanese</p></div>
+                <div></div>
+              </div>
+              <div>
+                <div><p>French</p></div>
+                <div></div>
+              </div>
+            </div>
+            <div class="aso-constants privacy-note">
+              <div>
+                <div><p>Japanese</p></div>
+                <div></div>
+              </div>
+            </div>
+          </main></body>
+        `;
+        const pageHtml = `
+          <div class="aso-app listing apple">
+            <div>
+              <div><p>Description</p></div>
+              <div><p>{{legal-terms}} {{privacy-note}}</p></div>
+            </div>
+          </div>
+        `;
+        const result = buildLanguageMetadata(null, [
+          { name: 'Japanese', code: 'ja' },
+          { name: 'French', code: 'fr' },
+        ], {
+          constantsHtml,
+          pageHtml,
+          parsedSchema: listingSchema,
+        });
+
+        expect(result).to.deep.equal({});
+      });
+
+      it('should emit separate placeholders metadata per field with different slug sets', () => {
+        const constantsHtml = `
+          <body><main>
+            <div class="aso-constants legal-terms">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>LEGAL JA</p></div>
+              </div>
+            </div>
+            <div class="aso-constants promo-disclaimer">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>PROMO JA</p></div>
+              </div>
+            </div>
+          </main></body>
+        `;
+        const schema = {
+          'aso-app_apple_listing': {
+            selector: '.aso-app.apple.listing',
+            fields: [
+              {
+                fieldName: 'Description',
+                fieldKey: 'description',
+                charCount: '4000',
+                keywordsInjection: true,
+              },
+              {
+                fieldName: 'Promotional Text',
+                fieldKey: 'promotional-text',
+                charCount: '170',
+                keywordsInjection: false,
+              },
+            ],
+          },
+        };
+        const pageHtml = `
+          <div class="aso-app listing apple">
+            <div>
+              <div><p>Description</p></div>
+              <div><p>{{legal-terms}}</p></div>
+            </div>
+            <div>
+              <div><p>Promotional Text</p></div>
+              <div><p>{{promo-disclaimer}}</p></div>
+            </div>
+          </div>
+        `;
+        const result = buildLanguageMetadata(null, [{ name: 'Japanese', code: 'ja' }], {
+          constantsHtml,
+          pageHtml,
+          parsedSchema: schema,
+        });
+
+        expect(result).to.deep.equal({
+          ja: {
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>LEGAL JA</p>',
+            },
+            'placeholders|aso-app_apple_listing_1_promotional-text': {
+              'promo-disclaimer': '<p>PROMO JA</p>',
+            },
+          },
+        });
+      });
+    });
   });
 
   describe('addSeoGlossary (languageContext)', () => {

--- a/test/loc/glaas/translationMetadata.test.js
+++ b/test/loc/glaas/translationMetadata.test.js
@@ -1048,6 +1048,36 @@ describe('translationMetadata', () => {
         });
       });
 
+      it('should resolve placeholders when slug is one of multiple block classes', () => {
+        const constantsHtml = `
+          <body><main><div>
+            <div class="legacy-wrapper legal-terms">
+              <div>
+                <div><p>Japanese</p></div>
+                <div><p>LEGACY JA</p></div>
+              </div>
+            </div>
+          </div></main></body>
+        `;
+        const result = buildLanguageMetadata(
+          null,
+          [{ name: 'Japanese', code: 'ja' }],
+          {
+            constantsHtml,
+            pageHtml: listingHtml,
+            parsedSchema: listingSchema,
+          },
+        );
+
+        expect(result).to.deep.equal({
+          ja: {
+            'placeholders|aso-app_apple_listing_1_description': {
+              'legal-terms': '<p>LEGACY JA</p>',
+            },
+          },
+        });
+      });
+
       it('should include both keywords and placeholders for the same locale', () => {
         const result = buildLanguageMetadata(
           {
@@ -1078,20 +1108,20 @@ describe('translationMetadata', () => {
 
       it('should include multiple placeholder slugs in one field when all are mapped', () => {
         const constantsHtml = `
-          <body><main>
-            <div class="aso-constants legal-terms">
+          <body><main><div>
+            <div class="legal-terms">
               <div>
                 <div><p>Japanese</p></div>
                 <div><p>LEGAL JA</p></div>
               </div>
             </div>
-            <div class="aso-constants privacy-note">
+            <div class="privacy-note">
               <div>
                 <div><p>Japanese</p></div>
                 <div><p>PRIVACY JA</p></div>
               </div>
             </div>
-          </main></body>
+          </div></main></body>
         `;
         const pageHtml = `
           <div class="aso-app listing apple">
@@ -1119,20 +1149,20 @@ describe('translationMetadata', () => {
 
       it('should omit unmapped slugs but keep mapped ones in placeholders metadata', () => {
         const constantsHtml = `
-          <body><main>
-            <div class="aso-constants legal-terms">
+          <body><main><div>
+            <div class="legal-terms">
               <div>
                 <div><p>Japanese</p></div>
                 <div><p>LEGAL JA</p></div>
               </div>
             </div>
-            <div class="aso-constants privacy-note">
+            <div class="privacy-note">
               <div>
                 <div><p>Japanese</p></div>
                 <div></div>
               </div>
             </div>
-          </main></body>
+          </div></main></body>
         `;
         const pageHtml = `
           <div class="aso-app listing apple">
@@ -1159,8 +1189,8 @@ describe('translationMetadata', () => {
 
       it('should omit placeholders metadata when no slugs resolve for a target locale', () => {
         const constantsHtml = `
-          <body><main>
-            <div class="aso-constants legal-terms">
+          <body><main><div>
+            <div class="legal-terms">
               <div>
                 <div><p>Japanese</p></div>
                 <div></div>
@@ -1170,13 +1200,13 @@ describe('translationMetadata', () => {
                 <div></div>
               </div>
             </div>
-            <div class="aso-constants privacy-note">
+            <div class="privacy-note">
               <div>
                 <div><p>Japanese</p></div>
                 <div></div>
               </div>
             </div>
-          </main></body>
+          </div></main></body>
         `;
         const pageHtml = `
           <div class="aso-app listing apple">
@@ -1200,20 +1230,20 @@ describe('translationMetadata', () => {
 
       it('should emit separate placeholders metadata per field with different slug sets', () => {
         const constantsHtml = `
-          <body><main>
-            <div class="aso-constants legal-terms">
+          <body><main><div>
+            <div class="legal-terms">
               <div>
                 <div><p>Japanese</p></div>
                 <div><p>LEGAL JA</p></div>
               </div>
             </div>
-            <div class="aso-constants promo-disclaimer">
+            <div class="promo-disclaimer">
               <div>
                 <div><p>Japanese</p></div>
                 <div><p>PROMO JA</p></div>
               </div>
             </div>
-          </main></body>
+          </div></main></body>
         `;
         const schema = {
           'aso-app_apple_listing': {


### PR DESCRIPTION
- Keep fixed copy in per-page -constants file with {{slug}} tokens in listings so translation leaves legal/fixed text unchanged
- Resolve constants at preview, copy, and export
- Extend keywords JSON generation with companion "(updated)" columns for GLaaS handoff
