### PR TITLE
feat(ew): show loading spinner on preview & publish

### DIFF
--- a/nx2/blocks/ew-actions/ew-actions.css
+++ b/nx2/blocks/ew-actions/ew-actions.css
@@ -106,6 +106,32 @@
   height: 18px;
 }
 
+.preview-dropdown-btn.is-busy:disabled {
+  color: light-dark(var(--s2-gray-25), #fff);
+  background-color: var(--s2-blue-900);
+}
+
+.preview-dropdown-spinner {
+  display: block;
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentcolor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: preview-dropdown-spin 0.6s linear infinite;
+}
+
+@keyframes preview-dropdown-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preview-dropdown-spinner {
+    animation-duration: 1.5s;
+  }
+}
+
 .preview-dropdown-label {
   white-space: nowrap;
 }

--- a/nx2/blocks/ew-actions/ew-actions.js
+++ b/nx2/blocks/ew-actions/ew-actions.js
@@ -58,8 +58,6 @@ class NXEwActions extends LitElement {
     _dialog: { state: true },
   };
 
-  _busy = false;
-
   get _popover() {
     return this.shadowRoot?.querySelector('nx-popover');
   }
@@ -78,6 +76,7 @@ class NXEwActions extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this._busy = false;
     this.shadowRoot.adoptedStyleSheets = [style];
     this._unsubHash = hashChange.subscribe((state) => { this._hashState = state; });
     this._loadPrepare();
@@ -254,14 +253,16 @@ class NXEwActions extends LitElement {
             ` : nothing}
             <button
               type="button"
-              class="preview-dropdown-btn${this._hasError ? ' is-error' : ''}"
+              class="preview-dropdown-btn${this._hasError ? ' is-error' : ''}${this._busy ? ' is-busy' : ''}"
               aria-label="Preview and publish"
               aria-haspopup="menu"
               aria-expanded="false"
               ?disabled=${disabled}
               @click=${this._togglePreviewPopover}
             >
-              <svg class="preview-dropdown-icon" viewBox="0 0 20 20" aria-hidden="true"><use href=${SEND_ICON_HREF}></use></svg>
+              ${this._busy
+                ? html`<span class="preview-dropdown-spinner" aria-hidden="true"></span>`
+                : html`<svg class="preview-dropdown-icon" viewBox="0 0 20 20" aria-hidden="true"><use href=${SEND_ICON_HREF}></use></svg>`}
             </button>
             <nx-popover placement="below" @close=${this._onSendPopoverClose}>
               <div class="send-popover" role="menu">


### PR DESCRIPTION
Currently there's no visual cue that something is in progress when a page is previewed or published from the paper airplane in `ew-actions`.

Adds a loading spinner.

<img width="3454" height="1910" alt="2026-07-09 20 37 44" src="https://github.com/user-attachments/assets/527b92ae-4e76-4624-8d1d-bc6137897a48" />
