### PR TITLE
fix(feedback): stop 404s from loadArea icon decorator

### DIFF
--- a/nx2/blocks/feedback/feedback.js
+++ b/nx2/blocks/feedback/feedback.js
@@ -91,8 +91,6 @@ class NxFeedback extends LitElement {
   }
 
   async _loadItems() {
-    // Parse directly, not via loadFragment: loadArea's icon decorator 404s
-    // on nonexistent S2_Icon_* SVGs, and we discard its DOM work anyway.
     const resp = await fetch(FEEDBACK_PATH);
     if (!resp.ok) return;
     const doc = new DOMParser().parseFromString(await resp.text(), 'text/html');

--- a/nx2/blocks/feedback/feedback.js
+++ b/nx2/blocks/feedback/feedback.js
@@ -1,7 +1,6 @@
 import { LitElement, html, nothing } from 'da-lit';
 import { getConfig } from '../../scripts/nx.js';
 import { loadStyle } from '../../utils/utils.js';
-import { loadFragment } from '../fragment/fragment.js';
 import '../shared/menu/menu.js';
 
 const { codeBase } = getConfig();
@@ -92,9 +91,14 @@ class NxFeedback extends LitElement {
   }
 
   async _loadItems() {
-    const fragment = await loadFragment(FEEDBACK_PATH);
-    if (!fragment) return;
-    this._items = parseFeedbackItems(fragment);
+    // Parse directly, not via loadFragment: loadArea's icon decorator 404s
+    // on nonexistent S2_Icon_* SVGs, and we discard its DOM work anyway.
+    const resp = await fetch(FEEDBACK_PATH);
+    if (!resp.ok) return;
+    const doc = new DOMParser().parseFromString(await resp.text(), 'text/html');
+    const main = doc.querySelector('main');
+    if (!main) return;
+    this._items = parseFeedbackItems(main);
   }
 
   _handleSelect({ detail: { id } }) {

--- a/nx2/test/unit/nx/blocks/feedback/feedback.test.js
+++ b/nx2/test/unit/nx/blocks/feedback/feedback.test.js
@@ -1,10 +1,10 @@
 import { expect } from '@esm-bundle/chai';
 import { setConfig } from '../../../../../scripts/nx.js';
 
-// fragment.js (a transitive dependency of feedback.js) captures getConfig()
-// into a module-level constant at import time, so setConfig() must resolve
-// before feedback.js is ever imported — a static import would evaluate (and
-// freeze that constant) before this file's own top-level code could run.
+// feedback.js captures getConfig() into a module-level constant at import
+// time (for ICON_HREF), so setConfig() must resolve before feedback.js is
+// ever imported — a static import would evaluate (and freeze that constant)
+// before this file's own top-level code could run.
 await setConfig({ hostnames: [] });
 const { parseFeedbackItems } = await import('../../../../../blocks/feedback/feedback.js');
 


### PR DESCRIPTION
https://main--da-live--adobe.aem.live?nx=fbicon

https://fbicon--da-nx--adobe.aem.live

Fix https://github.com/adobe/da-live/issues/1082