### PR TITLE
feat(chat): include browser timezone in page context for agent

### DIFF
--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -90,7 +90,15 @@ export default class ChatController {
 
   _pageContextForAgent() {
     const { org, site, path, view } = this._context ?? {};
-    return org && site ? { org, site, path: path ?? '', view } : undefined;
+    return org && site
+      ? {
+        org,
+        site,
+        path: path ?? '',
+        view,
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }
+      : undefined;
   }
 
   async _getRoom() {

--- a/test/nx2/blocks/chat/chat-controller.test.js
+++ b/test/nx2/blocks/chat/chat-controller.test.js
@@ -103,3 +103,21 @@ describe('chat-controller _messagesForAgent', () => {
     expect(result).to.deep.equal([]); // no orphan tool-call emitted
   });
 });
+
+describe('chat-controller _pageContextForAgent', () => {
+  it('includes the browser IANA time zone alongside org/site/path/view', () => {
+    const controller = new ChatController({ onUpdate() {}, onToolDone() {} });
+    controller.setContext({ org: 'adobe', site: 'da-nx', path: '/foo', view: 'edit' });
+    const result = controller._pageContextForAgent();
+    expect(result.timeZone).to.equal(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    expect(result).to.deep.equal({
+      org: 'adobe', site: 'da-nx', path: '/foo', view: 'edit', timeZone: result.timeZone,
+    });
+  });
+
+  it('returns undefined when org/site are missing, same as before', () => {
+    const controller = new ChatController({ onUpdate() {}, onToolDone() {} });
+    controller.setContext({ path: '/foo' });
+    expect(controller._pageContextForAgent()).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
inject user's timezone to the agent context so the agent can use that for time-based tasks and schedule publish MCP tool as part of aem-agentic-plugins (that also has a get current time tool associated with it)

This PR needs to be merged in conjunction with the one in da-agent: https://github.com/adobe-rnd/da-agent/pull/58
