### PR TITLE
fix: support version creation shortcut in wyswyg

### DIFF
--- a/nx/public/plugins/quick-edit/src/simple-keymap.js
+++ b/nx/public/plugins/quick-edit/src/simple-keymap.js
@@ -159,6 +159,20 @@ function handleUndoRedo(view, event, port) {
   return false;
 }
 
+function handleNewVersion(view, event, port) {
+  if ((event.ctrlKey || event.metaKey) && event.altKey && event.code === 'KeyS') {
+    event.preventDefault();
+
+    port.postMessage({
+      type: 'new-version',
+    });
+
+    return true;
+  }
+
+  return false;
+}
+
 export function createSimpleKeymap(port) {
   return new Plugin({
     props: {
@@ -171,6 +185,9 @@ export function createSimpleKeymap(port) {
 
         const undoRedoHandled = handleUndoRedo(view, event, port);
         if (undoRedoHandled) return true;
+
+        const newVersionHandled = handleNewVersion(view, event, port);
+        if (newVersionHandled) return true;
 
         return false;
       },

--- a/nx/public/plugins/quick-edit/src/simple-keymap.js
+++ b/nx/public/plugins/quick-edit/src/simple-keymap.js
@@ -159,6 +159,20 @@ function handleUndoRedo(view, event, port) {
   return false;
 }
 
+function handleNewVersion(view, event, port) {
+  if ((event.ctrlKey || event.metaKey) && event.altKey && (event.key === 's' || event.key === 'S')) {
+    event.preventDefault();
+
+    port.postMessage({
+      type: 'new-version',
+    });
+
+    return true;
+  }
+
+  return false;
+}
+
 export function createSimpleKeymap(port) {
   return new Plugin({
     props: {
@@ -171,6 +185,9 @@ export function createSimpleKeymap(port) {
 
         const undoRedoHandled = handleUndoRedo(view, event, port);
         if (undoRedoHandled) return true;
+
+        const newVersionHandled = handleNewVersion(view, event, port);
+        if (newVersionHandled) return true;
 
         return false;
       },

--- a/nx/public/plugins/quick-edit/src/simple-keymap.js
+++ b/nx/public/plugins/quick-edit/src/simple-keymap.js
@@ -159,20 +159,6 @@ function handleUndoRedo(view, event, port) {
   return false;
 }
 
-function handleNewVersion(view, event, port) {
-  if ((event.ctrlKey || event.metaKey) && event.altKey && (event.key === 's' || event.key === 'S')) {
-    event.preventDefault();
-
-    port.postMessage({
-      type: 'new-version',
-    });
-
-    return true;
-  }
-
-  return false;
-}
-
 export function createSimpleKeymap(port) {
   return new Plugin({
     props: {
@@ -185,9 +171,6 @@ export function createSimpleKeymap(port) {
 
         const undoRedoHandled = handleUndoRedo(view, event, port);
         if (undoRedoHandled) return true;
-
-        const newVersionHandled = handleNewVersion(view, event, port);
-        if (newVersionHandled) return true;
 
         return false;
       },

--- a/nx2/public/plugins/quick-edit/src/simple-keymap.js
+++ b/nx2/public/plugins/quick-edit/src/simple-keymap.js
@@ -159,6 +159,20 @@ function handleUndoRedo(view, event, port) {
   return false;
 }
 
+function handleNewVersion(view, event, port) {
+  if ((event.ctrlKey || event.metaKey) && event.altKey && (event.key === 's' || event.key === 'S')) {
+    event.preventDefault();
+
+    port.postMessage({
+      type: 'new-version',
+    });
+
+    return true;
+  }
+
+  return false;
+}
+
 export function createSimpleKeymap(port) {
   return new Plugin({
     props: {
@@ -171,6 +185,9 @@ export function createSimpleKeymap(port) {
 
         const undoRedoHandled = handleUndoRedo(view, event, port);
         if (undoRedoHandled) return true;
+
+        const newVersionHandled = handleNewVersion(view, event, port);
+        if (newVersionHandled) return true;
 
         return false;
       },

--- a/nx2/public/plugins/quick-edit/src/simple-keymap.js
+++ b/nx2/public/plugins/quick-edit/src/simple-keymap.js
@@ -160,7 +160,7 @@ function handleUndoRedo(view, event, port) {
 }
 
 function handleNewVersion(view, event, port) {
-  if ((event.ctrlKey || event.metaKey) && event.altKey && (event.key === 's' || event.key === 'S')) {
+  if ((event.ctrlKey || event.metaKey) && event.altKey && event.code === 'KeyS') {
     event.preventDefault();
 
     port.postMessage({


### PR DESCRIPTION
Support new version creation via shortcut while editing in wyswyg mode

Needs https://github.com/adobe/da-live/pull/1111 in parallel