### PR TITLE
#608 Update panel.js to maxWidth .85 to match layout view panel sizing

### DIFF
--- a/nx2/utils/panel.js
+++ b/nx2/utils/panel.js
@@ -1,7 +1,7 @@
 import { getMetadata } from '../scripts/nx.js';
 
 const PANEL_WIDTH_MIN = 120;
-const PANEL_WIDTH_MAX = () => Math.min(1600, window.innerWidth * 0.4);
+const PANEL_WIDTH_MAX = () => Math.min(1600, window.innerWidth * 0.85);
 
 function parsePanelWidth(aside) {
   const w = aside.dataset.width?.trim();


### PR DESCRIPTION
Fix #608.

[da-nx/nx2/utils/panel.js](https://github.com/adobe/da-nx/blob/fe5e95045e81b82f8f2e40c21522a11ea699c335/nx2/utils/panel.js#L4)

Line 4 in [fe5e950](https://github.com/adobe/da-nx/commit/fe5e95045e81b82f8f2e40c21522a11ea699c335)

 const PANEL_WIDTH_MAX = () => Math.min(1600, window.innerWidth * 0.4); 
sets the max width of the panel to .4 of the window innerWidth. This is quite small for the plugins we want to implement. Our use cases are a downstream app preview (consumes EDS content) and Target campaign management within the panel.
Ideally this would like work more like Layout view where I can freely drag the panel size to have up to more like a 85-15 panel split.

Test URLs:
- Before: https://main--da-nx--adobe.hlx.live/
- After: https://main--da-nx--pgoodrich.hlx.live/
