### PR TITLE
feat(chat): add responsive image preview support

### DIFF
--- a/nx2/blocks/chat/chat.css
+++ b/nx2/blocks/chat/chat.css
@@ -330,6 +330,17 @@
       height: 1px;
       background: var(--s2-gray-200);
     }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      max-height: 400px;
+      border-radius: var(--s2-corner-radius-300);
+      margin: var(--s2-spacing-100) 0;
+      object-fit: contain;
+      display: block;
+      border: 1px solid var(--s2-gray-200);
+    }
   }
 
   .message-content code {


### PR DESCRIPTION
Adds CSS styling for responsive image display in chat message content.

Images returned in markdown format `![alt](url)` now render with responsive styling:
- Max width: 100% (responsive to container)  
- Max height: 400px
- Maintains aspect ratio with object-fit: contain
- Rounded corners and subtle border
- Block display with vertical spacing

**Note:** This is a CSS-only change. Markdown image support already exists in the renderer - this PR only adds proper styling so images display correctly instead of rendering unstyled.