### PR TITLE
fix(ew): harden css selector for quick-edit canvas block selection pill

### DIFF
--- a/nx/public/plugins/quick-edit/quick-edit.css
+++ b/nx/public/plugins/quick-edit/quick-edit.css
@@ -282,6 +282,7 @@ da-palette .da-palette-field {
   left: 0;
   pointer-events: none;
   z-index: 9999;
+  box-sizing: border-box;
 }
 
 .qe-selected-box {
@@ -292,6 +293,7 @@ da-palette .da-palette-field {
   outline: 2px solid var(--s2-blue-600);
   background: transparent;
   pointer-events: none;
+  box-sizing: border-box;
 }
 
 .qe-hover-box {
@@ -302,37 +304,57 @@ da-palette .da-palette-field {
   outline: 1px solid var(--s2-blue-600);
   background: transparent;
   pointer-events: none;
+  box-sizing: border-box;
 }
 
-.qe-selected-pill {
+#qe-selection-overlay .qe-selected-pill {
   position: absolute;
   top: 0;
   left: 0;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  max-width: none;
+  min-height: 0;
+  max-height: none;
+  margin: 0;
   display: flex;
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
   background: var(--s2-blue-600);
   color: #fff;
-  font-family: inherit;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   font-size: 12px;
+  font-style: normal;
   font-weight: 600;
   line-height: 1.4;
-  border: 0;
+  letter-spacing: normal;
+  text-align: left;
+  text-decoration: none;
+  text-transform: none;
   white-space: nowrap;
-  pointer-events: none; 
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  box-sizing: border-box;
+  pointer-events: none;
   z-index: 1;
 }
 
-.qe-selected-pill.is-hover {
+#qe-selection-overlay .qe-selected-pill.is-hover {
   pointer-events: auto;
   cursor: pointer;
 }
 
-.qe-pill-grip {
+#qe-selection-overlay .qe-pill-grip {
   width: 12px;
   height: 12px;
   flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
   background-color: currentcolor;
   mask: url("/nx/img/icons/S2_Icon_Select_20_N.svg") no-repeat center / contain;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
#605 added the ability to select blocks and images in layout mode. Project level CSS styles may interfere with the quick-edit styles for the pill.

Harden the CSS selector and update styles so that doesn't happen.

BEFORE:
<img width="2742" height="964" alt="2026-07-27 12 57 24" src="https://github.com/user-attachments/assets/535ea279-44b9-43f8-abf2-090fb4a47af1" />

AFTER:
<img width="2742" height="964" alt="2026-07-27 12 57 41" src="https://github.com/user-attachments/assets/b6dd9da7-6b31-4fee-8e61-53d49405762b" />
