### PR TITLE
fix(ew): disable link navigation when quick-edit is embedded

### DIFF
--- a/nx/public/plugins/quick-edit/quick-edit.js
+++ b/nx/public/plugins/quick-edit/quick-edit.js
@@ -66,6 +66,13 @@ function onMessage(e, ctx) {
   }
 }
 
+// Disables link clicks. When the page is embedded, it must not navigate away.
+function blockLinkNavigation() {
+  document.addEventListener('click', (e) => {
+    if (e.target.closest('a')) e.preventDefault();
+  }, true);
+}
+
 function setupParentController(loadPage) {
   const listener = (e) => {
     const isInit = e.data?.type === MESSAGE_TYPES.INIT;
@@ -73,6 +80,7 @@ function setupParentController(loadPage) {
 
     const port = e.ports[0];
     parentControllerPort = port;
+    blockLinkNavigation();
 
     const ctx = {
       initialized: true,


### PR DESCRIPTION
Links inside content (e.g. a card block's placeholder image) previously navigated the whole page away when clicked in an embedded/parent-controlled context, breaking out of the surrounding experience.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

- Fixes adobe/da-live#1130

Test steps:
- Open a page with **block with links** inside (`/canvas?#/exp-workspace/frescopa/drafts/orlowska/try-and-try-again` has _product-list-page-custom_)
- Check that links are active
- Open browser's console and override da.live/nx/public/plugins/quick-edit/quick-edit.js
- Check that links are no longer active