### PR TITLE
fix(nx-loc-url-details): calculate and use correct editor path in preflight edit links

### DIFF
--- a/nx/blocks/loc/views/url-details/index.js
+++ b/nx/blocks/loc/views/url-details/index.js
@@ -21,7 +21,7 @@ function splitPath(path) {
 // Mirrors da-live's da-browse.js getEditor(): EW flag picks the canvas/edit
 // default, then the site's `editor.path` config rows override by longest
 // path-prefix match, so linked-page edit URLs land in the same editor browse would use.
-async function getEditorRoute(org, site, path) {
+async function getEditorRoute({ org, site, path }) {
   const isEW = await isEWEnabled({ org, site });
   const defRoute = isEW ? '/canvas#' : '/edit#';
 
@@ -47,7 +47,7 @@ export async function getEditPath(path) {
   if (hasExt) return `https://da.live/sheet#${editPath}`;
 
   const [, org, site] = path.split('/');
-  const route = await getEditorRoute(org, site, editPath);
+  const route = await getEditorRoute({ org, site, path: editPath });
 
   if (route.includes('experience.adobe.com')) {
     return `${route}/${editPath.split('/').slice(3).join('/')}`;

--- a/nx/blocks/loc/views/url-details/index.js
+++ b/nx/blocks/loc/views/url-details/index.js
@@ -1,5 +1,7 @@
 import { HLX_ADMIN } from '../../../../../nx2/utils/utils.js';
 import { daFetch } from '../../../../../nx2/utils/api.js';
+import { fetchDaConfigs, getFirstSheet } from '../../../../../nx2/utils/daConfig.js';
+import { isEWEnabled } from '../../../../../nx2/utils/ewFlags.js';
 import { getHasExt, formatDate } from '../../utils/utils.js';
 
 function getDate(suppliedDate) {
@@ -16,12 +18,43 @@ function splitPath(path) {
   return [org, site, ...parts];
 }
 
-export function getEditPath(path) {
+// Mirrors da-live's da-browse.js getEditor(): EW flag picks the canvas/edit
+// default, then the site's `editor.path` config rows override by longest
+// path-prefix match, so linked-page edit URLs land in the same editor browse would use.
+async function getEditorRoute(org, site, path) {
+  const isEW = await isEWEnabled({ org, site });
+  const defRoute = isEW ? '/canvas#' : '/edit#';
+
+  const configs = await Promise.all(fetchDaConfigs({ org, site }));
+  const rows = configs.filter(Boolean).reverse().flatMap((c) => getFirstSheet(c) || []);
+  const editorConfs = rows.reduce((acc, row) => {
+    if (row.key === 'editor.path') acc.push(row.value);
+    return acc;
+  }, []);
+
+  const matchedConfs = editorConfs.filter((conf) => path.startsWith(conf.split('=')[0]));
+  if (matchedConfs.length === 0) return defRoute;
+
+  const matchedConf = matchedConfs.sort((a, b) => b.split('=')[0].length - a.split('=')[0].length)[0];
+  return matchedConf.split('=')[1];
+}
+
+export async function getEditPath(path) {
   const hasExt = getHasExt(path);
-  const view = hasExt ? 'sheet' : 'edit';
   const indexedPath = path.endsWith('/') ? `${path}index` : path;
   const editPath = hasExt ? indexedPath.replace('.json', '') : indexedPath;
-  return `https://da.live/${view}#${editPath}`;
+
+  if (hasExt) return `https://da.live/sheet#${editPath}`;
+
+  const [, org, site] = path.split('/');
+  const route = await getEditorRoute(org, site, editPath);
+
+  if (route.includes('experience.adobe.com')) {
+    return `${route}/${editPath.split('/').slice(3).join('/')}`;
+  }
+
+  const base = route.startsWith('http') ? route : `https://da.live${route}`;
+  return `${base}${editPath}`;
 }
 
 export function getAemPaths(path) {

--- a/nx/blocks/loc/views/url-details/url-details.css
+++ b/nx/blocks/loc/views/url-details/url-details.css
@@ -29,6 +29,11 @@
     opacity: 1;
   }
 
+  &.is-loading {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
   .url-icon {
     width: 33.33px;
     height: 32px;

--- a/nx/blocks/loc/views/url-details/url-details.js
+++ b/nx/blocks/loc/views/url-details/url-details.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'da-lit';
+import { LitElement, html, nothing } from 'da-lit';
 import { loadStyle } from '../../../../../nx2/utils/utils.js';
 import { getEditPath, getAemPaths, getAemDetails } from './index.js';
 
@@ -38,10 +38,10 @@ class NxLocUrlDetails extends LitElement {
 
   render() {
     return html`
-      <a class="link-group"
+      <a class="link-group ${this._editPath ? '' : 'is-loading'}"
          aria-label="Open in author"
-         href="${this._editPath}"
-         target="${this._editPath}">
+         href="${this._editPath || nothing}"
+         target="${this._editPath || nothing}">
         <div class="url-icon edit-icon is-active"></div>
         <div class="group-text">
           <p class="group-title">Edit</p>

--- a/nx/blocks/loc/views/url-details/url-details.js
+++ b/nx/blocks/loc/views/url-details/url-details.js
@@ -16,11 +16,15 @@ class NxLocUrlDetails extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.shadowRoot.adoptedStyleSheets = [style];
-    this._editPath = getEditPath(this.path);
+    this.loadEditPath();
     const { preview, publish } = getAemPaths(this.path);
     this._previewPath = preview;
     this._publishPath = publish;
     this.getDetails();
+  }
+
+  async loadEditPath() {
+    this._editPath = await getEditPath(this.path);
   }
 
   async getDetails() {

--- a/test/nx/blocks/loc/views/url-details/index.test.js
+++ b/test/nx/blocks/loc/views/url-details/index.test.js
@@ -1,0 +1,137 @@
+import { expect } from '@esm-bundle/chai';
+import { DA_ADMIN } from '../../../../../../nx2/utils/utils.js';
+import { getEditPath } from '../../../../../../nx/blocks/loc/views/url-details/index.js';
+
+let counter = 0;
+const uniq = (label) => {
+  counter += 1;
+  return `${label}${counter}`;
+};
+
+let origFetch;
+let calls;
+
+const installFetch = (org, site, {
+  orgFlags = [], orgRows = [], siteFlags = [], siteRows = [],
+} = {}) => {
+  calls = [];
+  origFetch = window.fetch;
+  const orgUrl = `${DA_ADMIN}/config/${org}/`;
+  const siteUrl = `${DA_ADMIN}/config/${org}/${site}/`;
+  window.fetch = async (url) => {
+    const u = url.toString();
+    calls.push(u);
+    if (u === siteUrl) {
+      return { ok: true, json: async () => ({ data: siteRows, flags: { data: siteFlags } }) };
+    }
+    if (u === orgUrl) {
+      return { ok: true, json: async () => ({ data: orgRows, flags: { data: orgFlags } }) };
+    }
+    return { ok: false, status: 404 };
+  };
+};
+
+afterEach(() => {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+});
+
+describe('getEditPath', () => {
+  it('returns a sheet link for json paths without checking editor config', async () => {
+    origFetch = window.fetch;
+    window.fetch = async () => { throw new Error('fetch should not be called for json paths'); };
+
+    const org = uniq('org');
+    const site = uniq('site');
+    const path = await getEditPath(`/${org}/${site}/data.json`);
+    expect(path).to.equal(`https://da.live/sheet#/${org}/${site}/data`);
+  });
+
+  it('defaults to /edit# when EW is disabled and there is no editor.path config', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site);
+
+    const path = await getEditPath(`/${org}/${site}/page`);
+    expect(path).to.equal(`https://da.live/edit#/${org}/${site}/page`);
+  });
+
+  it('defaults to /canvas# when EW is enabled', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, { siteFlags: [{ key: 'ew.enabled', value: 'true' }] });
+
+    const path = await getEditPath(`/${org}/${site}/page`);
+    expect(path).to.equal(`https://da.live/canvas#/${org}/${site}/page`);
+  });
+
+  it('uses a matching editor.path config over the default route', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, {
+      siteRows: [{ key: 'editor.path', value: `/${org}/${site}/blog=/custom-edit#` }],
+    });
+
+    const path = await getEditPath(`/${org}/${site}/blog/post`);
+    expect(path).to.equal(`https://da.live/custom-edit#/${org}/${site}/blog/post`);
+  });
+
+  it('ignores a non-matching editor.path config and falls back to the default', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, {
+      siteRows: [{ key: 'editor.path', value: `/${org}/${site}/other=/custom-edit#` }],
+    });
+
+    const path = await getEditPath(`/${org}/${site}/blog/post`);
+    expect(path).to.equal(`https://da.live/edit#/${org}/${site}/blog/post`);
+  });
+
+  it('picks the longest matching prefix when multiple editor.path configs match', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, {
+      siteRows: [
+        { key: 'editor.path', value: `/${org}/${site}=/short-edit#` },
+        { key: 'editor.path', value: `/${org}/${site}/blog=/long-edit#` },
+      ],
+    });
+
+    const path = await getEditPath(`/${org}/${site}/blog/post`);
+    expect(path).to.equal(`https://da.live/long-edit#/${org}/${site}/blog/post`);
+  });
+
+  it('org-level editor.path config applies when there is no site-level override', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, {
+      orgRows: [{ key: 'editor.path', value: `/${org}/${site}/blog=/org-edit#` }],
+    });
+
+    const path = await getEditPath(`/${org}/${site}/blog/post`);
+    expect(path).to.equal(`https://da.live/org-edit#/${org}/${site}/blog/post`);
+  });
+
+  it('builds an experience.adobe.com link stripped of the org/site prefix', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site, {
+      siteRows: [{
+        key: 'editor.path',
+        value: `/${org}/${site}/blog=https://experience.adobe.com/#/@myorg/app`,
+      }],
+    });
+
+    const path = await getEditPath(`/${org}/${site}/blog/post`);
+    expect(path).to.equal('https://experience.adobe.com/#/@myorg/app/blog/post');
+  });
+
+  it('appends index for paths ending in a trailing slash', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    installFetch(org, site);
+
+    const path = await getEditPath(`/${org}/${site}/folder/`);
+    expect(path).to.equal(`https://da.live/edit#/${org}/${site}/folder/index`);
+  });
+});


### PR DESCRIPTION
WIP: since this makes `getEditPath` async, and there is also a very similar function in https://github.com/adobe/da-live/blob/main/blocks/browse/shared.js, sorta feels like we should make this a single global util, and/or pre-load the config so that function need not be async.

...To be Continued...

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://<branch>--{repo}--{owner}.hlx.live/
