### PR TITLE
fix(api): resolve source.save contentUrl from response location header

### DIFF
--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -272,9 +272,13 @@ export const source = {
       const resp = await daFetch({ url, opts });
       // hlx6 source save returns an empty body, whereas DA returns
       // { source: { contentUrl } }. Normalize the success case to that shape
-      // (contentUrl = the source URL just written) so callers can read
-      // source.contentUrl uniformly across hlx5/hlx6.
-      return resp.ok ? withSourceJson(resp, url) : resp;
+      // so callers can read source.contentUrl uniformly across hlx5/hlx6.
+      // contentUrl comes from the response's location header (resolved
+      // against the request url) since the server may write the source to a
+      // different canonical path than the one requested.
+      const location = resp.headers.get('location') || '';
+      const sourceUrl = new URL(location, url).href;
+      return resp.ok ? withSourceJson(resp, sourceUrl) : resp;
     }
     const formData = new FormData();
     formData.append('data', new Blob([body], { type: TYPE_MAP[ext] }));

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -457,6 +457,28 @@ describe('api.js', () => {
       expect(json.source.contentUrl).to.equal(`${AEM_API}/${o}/sites/${s}/source/docs/.foo/image.png`);
     });
 
+    it('source.save hlx6 uses the response location header for contentUrl when present', async () => {
+      restoreFetch();
+      installFetch({ body: '', headers: { location: '/docs/renamed.png' } });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const blob = new Blob(['binary'], { type: 'image/png' });
+      const resp = await source.save({ org: o, site: s, path: '/docs/image.png', body: blob });
+      expect(resp.ok).to.equal(true);
+      const json = await resp.json();
+      expect(json.source.contentUrl).to.equal(`${AEM_API}/docs/renamed.png`);
+      expect(json.source.contentUrl).to.be.a('string');
+    });
+
+    it('source.save hlx6 resolves an absolute location header as-is', async () => {
+      restoreFetch();
+      const absolute = 'https://example.com/other/path/image.png';
+      installFetch({ body: '', headers: { location: absolute } });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const resp = await source.save({ org: o, site: s, path: '/docs/image.png', body: new Blob(['x']) });
+      const json = await resp.json();
+      expect(json.source.contentUrl).to.equal(absolute);
+    });
+
     it('source.save hlx6 does not normalize non-ok responses', async () => {
       restoreFetch();
       installFetch({ status: 403, body: '' });


### PR DESCRIPTION
## Summary
- `source.save` (hlx6 branch) now derives the normalized `contentUrl` from the POST response's `location` header (resolved against the request URL) instead of assuming the server wrote to the exact requested path — the source-bus save can land at a different canonical location.
- Fixes a type regression in that in-progress change: `new URL(location, url)` produced a `URL` object instead of a string, silently breaking the string contract `contentUrl` has always had (relied on by `chat-controller.js`'s `attachmentRef` handling and by `imageDrop.js` in da-live). Now uses `.href` so it stays a string.
- Adds two tests: relative `location` header resolves against the request URL, and an absolute `location` header passes through unchanged.

## Test plan
- [x] `npm test` — full suite passes (1132 passed, 0 failed)
- [x] `npm run lint` — clean (pre-existing unrelated warnings only)
- [x] New tests `source.save hlx6 uses the response location header for contentUrl when present` and `source.save hlx6 resolves an absolute location header as-is` pass, along with the existing `source.save hlx6 normalizes empty body to { source: { contentUrl } }` test (now also validated as a string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)