### PR TITLE
fix(api): strip org/site prefix from destination before building hlx6 copy URL

### DIFF
--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -337,7 +337,13 @@ export const source = {
   }) => {
     const hlx6 = await isHlx6(org, site);
     if (hlx6) {
-      const url = new URL(await getDaApiPath(SOURCE, org, site, destination));
+      // 'destination' contains '/org/site/' prefix, which is needed for DA source
+      // but not for the source bus
+      const pfx = `/${org}/${site}/`;
+      const dst = destination.startsWith(pfx)
+        ? destination.substring(pfx.length - 1)
+        : destination;
+      const url = new URL(await getDaApiPath(SOURCE, org, site, dst));
       url.searchParams.set('source', path);
       if (collision) url.searchParams.set('collision', collision);
       return daFetch({ url: url.toString(), opts: { method: 'PUT' } });

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -521,7 +521,8 @@ describe('api.js', () => {
 
     it('source.copy hlx6 PUTs with source/collision query params', async () => {
       const { org: o, site: s } = makeOrgSite({ hlx6: true });
-      await source.copy({ org: o, site: s, path: '/src.html', destination: '/dest.html', collision: 'overwrite' });
+      const destination = `/${o}/${s}/dest.html`;
+      await source.copy({ org: o, site: s, path: '/src.html', destination, collision: 'overwrite' });
       const last = lastCall();
       expect(last.method).to.equal('PUT');
       const u = new URL(last.url);
@@ -533,12 +534,13 @@ describe('api.js', () => {
 
     it('source.copy legacy POSTs to /copy/{org}/{site}{path} with destination form field', async () => {
       const { org: o, site: s } = makeOrgSite();
-      await source.copy({ org: o, site: s, path: '/src.html', destination: '/dest.html' });
+      const destination = `/${o}/${s}/dest.html`;
+      await source.copy({ org: o, site: s, path: '/src.html', destination });
       const last = lastCall();
       expect(last.url).to.equal(`${DA_ADMIN}/copy/${o}/${s}/src.html`);
       expect(last.method).to.equal('POST');
       expect(last.body).to.be.instanceof(FormData);
-      expect(last.body.get('destination')).to.equal('/dest.html');
+      expect(last.body.get('destination')).to.equal(destination);
     });
 
     it('source.move hlx6 adds move=true', async () => {


### PR DESCRIPTION
## Summary
- `source.copy` on hlx6 sites was building the source-bus URL directly from the caller-supplied `destination`, which includes the `/org/site/` prefix required by the DA source API but not valid for the hlx6 source bus path.
- Strip the `/org/site/` prefix from `destination` before passing it to `getDaApiPath` when copying on hlx6 sites, so the resulting URL targets the correct path.

## Test plan
- [x] Updated `test/nx2/utils/api.test.js` `source.copy` tests to pass a `destination` with the `/org/site/` prefix (matching real caller behavior) and assert against the stripped value.
- [x] `npm test` passes (1149 tests, 0 failed).
- [x] `npx eslint` passes on changed files.