### PR TITLE
fix resume conversation flow

### DIFF
--- a/nx2/blocks/chat/ao/chat-controller-ao.js
+++ b/nx2/blocks/chat/ao/chat-controller-ao.js
@@ -711,11 +711,39 @@ export default class ChatControllerAO {
     this._ws?.close();
   }
 
+  // Every interaction-response method below sends through this instead of a bare
+  // this._ws.send(...): AO's session for an episode goes idle almost immediately
+  // once a turn suspends, so the socket has commonly already silently reconnected
+  // by the time the user actually answers. Reconnect first if needed, same as
+  // sendMessage() already does for its own upload-delay case.
+  async _ensureReady() {
+    if (this._ws?.readyState === WebSocket.OPEN && this._ready) return true;
+    await this.connect();
+    return !!this._ready;
+  }
+
+  _reportUndeliverable() {
+    this._messages = [...this._messages, {
+      role: ROLE.ASSISTANT,
+      content: 'Error: could not deliver your response. Please try again.',
+    }];
+    this._update();
+  }
+
   // Mirrors chat-controller.js's approveToolCall: resolves the clicked card, bulk-approves
   // any other pending cards with the same tool name on "always approve", then answers all
-  // of those decisions in one PERMISSION_RESPONSE frame (AO resumes the turn as soon as any
-  // response arrives, so partial/staggered responses aren't supported).
-  approveToolCall = (toolCallId, approved, always = false) => {
+  // of those decisions in one permission-response DataPart (AO resumes the turn as soon as
+  // any response arrives, so partial/staggered responses aren't supported). Sent via the
+  // generic RESUME op rather than the dedicated PERMISSION_RESPONSE frame: RESUME is a
+  // valid *first* op on a fresh connection (the server dispatches on the DataPart's own
+  // "type"), while PERMISSION_RESPONSE is only ever valid as a *later* op — and per
+  // _ensureReady above, the connection here is commonly fresh. manifestId/debugMode are
+  // required on RESUME too, not just USER_INPUT: AO re-resolves the episode's manifest
+  // from each op's own fields (confirmed directly against aep-ai source) — omitting them
+  // silently rebuilds (or discards a live, cached session for) the worker under AO's
+  // default manifest instead of experience-workspace, dropping the da-content plugin's
+  // MCP servers entirely.
+  approveToolCall = async (toolCallId, approved, always = false) => {
     const card = this._toolCards?.get(toolCallId);
     if (!card) return;
 
@@ -739,16 +767,23 @@ export default class ChatControllerAO {
     this._toolCards = next;
     this._update();
 
-    this._ws?.send(JSON.stringify({
-      type: AO_FRAME.PERMISSION_RESPONSE,
+    if (!(await this._ensureReady())) {
+      this._reportUndeliverable();
+      return;
+    }
+    this._ws.send(JSON.stringify({
+      type: AO_FRAME.RESUME,
       turn_id: card.turnId,
-      decisions,
+      data: { type: 'permission-response', decisions },
+      manifestId: AO_MANIFEST_ID,
+      debugMode: true,
     }));
   };
 
   // answersByQuestionId: { [questionId]: string[] } — selected option labels plus any
-  // free-text answer, already merged by the question-card UI.
-  answerQuestion = (answersByQuestionId) => {
+  // free-text answer, already merged by the question-card UI. Sent via RESUME, same
+  // reasoning as approveToolCall above.
+  answerQuestion = async (answersByQuestionId) => {
     if (!this._pendingQuestion) return;
     const { turnId, questions } = this._pendingQuestion;
     const answers = questions.map((q) => ({
@@ -757,36 +792,54 @@ export default class ChatControllerAO {
     }));
     this._pendingQuestion = null;
     this._update();
-    this._ws?.send(JSON.stringify({
-      type: AO_FRAME.QUESTION_RESPONSE,
+
+    if (!(await this._ensureReady())) {
+      this._reportUndeliverable();
+      return;
+    }
+    this._ws.send(JSON.stringify({
+      type: AO_FRAME.RESUME,
       turn_id: turnId,
-      answers,
-      declined: false,
+      data: { type: 'question-response', answers, declined: false },
+      manifestId: AO_MANIFEST_ID,
+      debugMode: true,
     }));
   };
 
-  declineQuestion = () => {
+  declineQuestion = async () => {
     if (!this._pendingQuestion) return;
     const { turnId } = this._pendingQuestion;
     this._pendingQuestion = null;
     this._update();
-    this._ws?.send(JSON.stringify({
-      type: AO_FRAME.QUESTION_RESPONSE,
+
+    if (!(await this._ensureReady())) {
+      this._reportUndeliverable();
+      return;
+    }
+    this._ws.send(JSON.stringify({
+      type: AO_FRAME.RESUME,
       turn_id: turnId,
-      answers: [],
-      declined: true,
+      data: { type: 'question-response', answers: [], declined: true },
+      manifestId: AO_MANIFEST_ID,
+      debugMode: true,
     }));
   };
 
   // Plan approval has no dedicated WS frame type of its own — the server dispatches
   // by DataPart "type" inside the generic RESUME op, so this sends a "plan-response"
-  // part wrapped in a RESUME frame instead.
-  respondToPlanApproval = (decision, feedback = '') => {
+  // part wrapped in a RESUME frame instead. See approveToolCall above: RESUME
+  // re-resolves the manifest per-op, so manifestId/debugMode must be repeated here too.
+  respondToPlanApproval = async (decision, feedback = '') => {
     if (!this._pendingPlanApproval) return;
     const { turnId } = this._pendingPlanApproval;
     this._pendingPlanApproval = null;
     this._update();
-    this._ws?.send(JSON.stringify({
+
+    if (!(await this._ensureReady())) {
+      this._reportUndeliverable();
+      return;
+    }
+    this._ws.send(JSON.stringify({
       type: AO_FRAME.RESUME,
       turn_id: turnId,
       data: {
@@ -795,6 +848,8 @@ export default class ChatControllerAO {
         feedback,
         edited_plan_content: null,
       },
+      manifestId: AO_MANIFEST_ID,
+      debugMode: true,
     }));
   };
 

--- a/nx2/blocks/chat/ao/chat-controller-ao.js
+++ b/nx2/blocks/chat/ao/chat-controller-ao.js
@@ -366,9 +366,7 @@ export default class ChatControllerAO {
       // response channel is that popup — re-enabling the plain chat input here would let
       // the user answer in two conflicting ways at once. Only fall back to _done() if
       // nothing is actually pending.
-      const hasPendingApproval = [...(this._toolCards?.values() ?? [])]
-        .some((c) => c.state === AO_TOOL_STATE.APPROVAL_REQUESTED);
-      if (!this._pendingQuestion && !hasPendingApproval && !this._pendingPlanApproval) {
+      if (!this._hasPendingInteraction()) {
         this._done();
       }
       return;
@@ -379,9 +377,22 @@ export default class ChatControllerAO {
     // different frames with the message in different places.
     if (evt.type === AO_EVENT.ERROR_CONNECTION || evt.type === AO_EVENT.ERROR_SESSION) {
       const message = evt.data?.message ?? evt.message ?? 'Something went wrong.';
-      this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: `Error: ${message}` }];
+      // _done() first, so any partial streamed response it flushes lands in
+      // history before this error message, not after it.
       this._done();
+      this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: `Error: ${message}` }];
+      this._update();
     }
+  }
+
+  // True only while a turn is genuinely suspended waiting for a permission/question/
+  // plan reply. Used by the "don't clobber/auto-resume over live state" checks — e.g.
+  // don't treat a turn as done, or silently reconcile onto a newer episode, or show a
+  // spurious connection error, while the user still has something pending to answer.
+  _hasPendingInteraction() {
+    const hasPendingApproval = [...(this._toolCards?.values() ?? [])]
+      .some((c) => c.state === AO_TOOL_STATE.APPROVAL_REQUESTED);
+    return !!(this._pendingQuestion || this._pendingPlanApproval || hasPendingApproval);
   }
 
   async _openSocket() {
@@ -457,9 +468,20 @@ export default class ChatControllerAO {
         const wasReady = this._ready;
         this._ready = false;
         this._connected = false;
-        if (this._thinking) {
-          this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: 'Error: connection closed' }];
+        // _thinking stays true across a pending question/approval/plan (see the
+        // turn_suspended handler) purely to keep the plain input disabled while a
+        // popup is the only valid response channel — it does NOT mean a turn is
+        // still actively in flight. AO tears down the episode's worker almost
+        // immediately after suspending a turn to ask something, so the socket
+        // closing right here is the normal, expected shape of "waiting on the
+        // user," not a dropped connection — don't show an error for it. The
+        // pending card stays up; answering it still works (it reconnects and
+        // sends via RESUME).
+        if (this._thinking && !this._hasPendingInteraction()) {
+          // _done() first, so any partial streamed response it flushes lands in
+          // history before this error message, not after it.
           this._done();
+          this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: 'Error: connection closed' }];
         }
         if (!wasReady) {
           rejectAuth(new Error(`WebSocket closed before auth resolved (code ${event.code})`));
@@ -621,10 +643,7 @@ export default class ChatControllerAO {
     }
 
     if (String(this._episodeId) === latestId) {
-      const hasPendingApproval = [...(this._toolCards?.values() ?? [])]
-        .some((c) => c.state === AO_TOOL_STATE.APPROVAL_REQUESTED);
-      if (this._thinking
-        || this._pendingQuestion || this._pendingPlanApproval || hasPendingApproval) {
+      if (this._thinking || this._hasPendingInteraction()) {
         return;
       }
       this._messages = await this._fetchEpisodeMessages(latestId);
@@ -671,6 +690,15 @@ export default class ChatControllerAO {
   };
 
   _done() {
+    // A turn can end (error, abort, or a dropped connection) before its text_done
+    // event ever arrives. Flush whatever streamed in so far into a real message
+    // first — otherwise clearing _streamingText below silently discards it, and
+    // the assistant's (partial) response just vanishes from history instead of
+    // showing whatever was actually received.
+    if (this._streaming) {
+      this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: this._streaming }];
+      this._streaming = '';
+    }
     this._thinking = false;
     this._streamingText = undefined;
     this._update();

--- a/test/nx2/blocks/chat/ao/chat-controller-ao.test.js
+++ b/test/nx2/blocks/chat/ao/chat-controller-ao.test.js
@@ -57,103 +57,132 @@ describe('chat-controller-ao approveToolCall', () => {
     ]);
   }
 
-  it('sends a single-decision PERMISSION_RESPONSE frame', () => {
+  // A mock this open/ready lets _ensureReady() short-circuit without calling the
+  // real connect() (which would try to open an actual WebSocket).
+  function readyWs(sent) {
+    return { readyState: WebSocket.OPEN, send: (msg) => sent.push(JSON.parse(msg)) };
+  }
+
+  it('sends a single-decision RESUME/permission-response frame with the manifest pinned', async () => {
     const { controller } = makeController();
     seedPending(controller);
     const sent = [];
-    controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ws = readyWs(sent);
+    controller._ready = true;
 
-    controller.approveToolCall('a', true);
+    await controller.approveToolCall('a', true);
 
     expect(sent).to.have.length(1);
     expect(sent[0]).to.deep.equal({
-      type: 'PERMISSION_RESPONSE', turn_id: 'turn-1', decisions: { a: { approved: true } },
+      type: 'RESUME',
+      turn_id: 'turn-1',
+      data: { type: 'permission-response', decisions: { a: { approved: true } } },
+      manifestId: 'experience-workspace',
+      debugMode: true,
     });
     expect(controller._toolCards.get('a').state).to.equal('approved');
     expect(controller._toolCards.get('b').state).to.equal('approval-requested');
   });
 
-  it('bulk-approves other pending calls of the same tool on "always approve"', () => {
+  it('bulk-approves other pending calls of the same tool on "always approve"', async () => {
     const { controller } = makeController();
     seedPending(controller);
     const sent = [];
-    controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ws = readyWs(sent);
+    controller._ready = true;
 
-    controller.approveToolCall('a', true, true);
+    await controller.approveToolCall('a', true, true);
 
-    expect(sent[0].decisions).to.deep.equal({
+    expect(sent[0].data.decisions).to.deep.equal({
       a: { approved: true }, b: { approved: true },
     });
     expect(controller._toolCards.get('b').state).to.equal('approved');
   });
 
-  it('marks a rejection without bulk-affecting other pending calls', () => {
+  it('marks a rejection without bulk-affecting other pending calls', async () => {
     const { controller } = makeController();
     seedPending(controller);
-    controller._ws = { send: () => {} };
+    controller._ws = readyWs([]);
+    controller._ready = true;
 
-    controller.approveToolCall('a', false);
+    await controller.approveToolCall('a', false);
 
     expect(controller._toolCards.get('a').state).to.equal('rejected');
     expect(controller._toolCards.get('b').state).to.equal('approval-requested');
   });
 
-  it('is a no-op for an unknown toolCallId', () => {
+  it('is a no-op for an unknown toolCallId', async () => {
     const { controller } = makeController();
     seedPending(controller);
     let sendCalled = false;
     controller._ws = { send: () => { sendCalled = true; } };
 
-    controller.approveToolCall('missing', true);
+    await controller.approveToolCall('missing', true);
 
     expect(sendCalled).to.equal(false);
   });
 });
 
 describe('chat-controller-ao questions', () => {
-  it('answerQuestion sends merged options + free text per question, then clears', () => {
+  function readyWs(sent) {
+    return { readyState: WebSocket.OPEN, send: (msg) => sent.push(JSON.parse(msg)) };
+  }
+
+  it('answerQuestion sends merged options + free text per question, then clears', async () => {
     const { controller } = makeController();
     controller._pendingQuestion = { turnId: 't1', questions: [{ id: 'q1' }, { id: 'q2' }] };
     const sent = [];
-    controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ws = readyWs(sent);
+    controller._ready = true;
 
-    controller.answerQuestion({ q1: ['Yes'], q2: [] });
+    await controller.answerQuestion({ q1: ['Yes'], q2: [] });
 
     expect(sent[0]).to.deep.equal({
-      type: 'QUESTION_RESPONSE',
+      type: 'RESUME',
       turn_id: 't1',
-      answers: [
-        { question_id: 'q1', selected_options: ['Yes'] },
-        { question_id: 'q2', selected_options: [] },
-      ],
-      declined: false,
+      data: {
+        type: 'question-response',
+        answers: [
+          { question_id: 'q1', selected_options: ['Yes'] },
+          { question_id: 'q2', selected_options: [] },
+        ],
+        declined: false,
+      },
+      manifestId: 'experience-workspace',
+      debugMode: true,
     });
     expect(controller._pendingQuestion).to.equal(null);
   });
 
-  it('declineQuestion sends declined:true with no answers', () => {
+  it('declineQuestion sends declined:true with no answers', async () => {
     const { controller } = makeController();
     controller._pendingQuestion = { turnId: 't1', questions: [{ id: 'q1' }] };
     const sent = [];
-    controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ws = readyWs(sent);
+    controller._ready = true;
 
-    controller.declineQuestion();
+    await controller.declineQuestion();
 
     expect(sent[0]).to.deep.equal({
-      type: 'QUESTION_RESPONSE', turn_id: 't1', answers: [], declined: true,
+      type: 'RESUME',
+      turn_id: 't1',
+      data: { type: 'question-response', answers: [], declined: true },
+      manifestId: 'experience-workspace',
+      debugMode: true,
     });
     expect(controller._pendingQuestion).to.equal(null);
   });
 });
 
 describe('chat-controller-ao plan approval', () => {
-  it('respondToPlanApproval sends a RESUME frame with a plan-response part', () => {
+  it('respondToPlanApproval sends a RESUME frame with a plan-response part and the manifest pinned', async () => {
     const { controller } = makeController();
     controller._pendingPlanApproval = { turnId: 't1', planContent: '# Plan' };
     const sent = [];
-    controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ws = { readyState: WebSocket.OPEN, send: (msg) => sent.push(JSON.parse(msg)) };
+    controller._ready = true;
 
-    controller.respondToPlanApproval('reject', 'needs more detail');
+    await controller.respondToPlanApproval('reject', 'needs more detail');
 
     expect(sent[0]).to.deep.equal({
       type: 'RESUME',
@@ -161,6 +190,8 @@ describe('chat-controller-ao plan approval', () => {
       data: {
         type: 'plan-response', decision: 'reject', feedback: 'needs more detail', edited_plan_content: null,
       },
+      manifestId: 'experience-workspace',
+      debugMode: true,
     });
     expect(controller._pendingPlanApproval).to.equal(null);
   });

--- a/test/nx2/blocks/chat/chat-backend.test.js
+++ b/test/nx2/blocks/chat/chat-backend.test.js
@@ -128,19 +128,27 @@ describe('ChatBackend AO-only actions wrapping AO', () => {
     expect(backend.getSkills()).to.deep.equal(['writeBlog', 'summarize']);
   });
 
-  it('answerQuestion delegates through to a real QUESTION_RESPONSE frame', () => {
+  it('answerQuestion delegates through to a real RESUME/question-response frame', async () => {
     const { backend } = makeBackend(true);
     backend._controller._pendingQuestion = { turnId: 't1', questions: [{ id: 'q1' }] };
     const sent = [];
-    backend._controller._ws = { send: (msg) => sent.push(JSON.parse(msg)) };
+    backend._controller._ws = {
+      readyState: WebSocket.OPEN, send: (msg) => sent.push(JSON.parse(msg)),
+    };
+    backend._controller._ready = true;
 
-    backend.answerQuestion({ q1: ['Yes'] });
+    await backend.answerQuestion({ q1: ['Yes'] });
 
     expect(sent[0]).to.deep.equal({
-      type: 'QUESTION_RESPONSE',
+      type: 'RESUME',
       turn_id: 't1',
-      answers: [{ question_id: 'q1', selected_options: ['Yes'] }],
-      declined: false,
+      data: {
+        type: 'question-response',
+        answers: [{ question_id: 'q1', selected_options: ['Yes'] }],
+        declined: false,
+      },
+      manifestId: 'experience-workspace',
+      debugMode: true,
     });
   });
 });


### PR DESCRIPTION
Ensure every resumed conversation also includes manifest id explicitly

https://da.live/canvas?nx=manifest&nxver=2#/exp-workspace/frescopa/index