### PR TITLE
fix: media copy for authenticated preview.da.live sites

### DIFF
--- a/nx/blocks/media-library/core/export.js
+++ b/nx/blocks/media-library/core/export.js
@@ -1,4 +1,4 @@
-import { etcFetch } from './urls.js';
+import { etcFetch, resolveMediaUrl } from './urls.js';
 import { getMediaType, getSubtype } from './media.js';
 import { decodeDisplayName, getFileName } from './files.js';
 import { t } from './messages.js';
@@ -113,18 +113,29 @@ async function insertMediaViaPluginSdk(media) {
   actions.closeLibrary?.();
 }
 
-async function copyImageToClipboard(imageUrl) {
+async function copyImageToClipboard(imageUrl, org, repo, usePreviewDaLive = false) {
+  const fetchUrl = (org && repo && usePreviewDaLive)
+    ? resolveMediaUrl(imageUrl, org, repo, true)
+    : imageUrl;
+
   let response;
   try {
-    const url = new URL(imageUrl);
+    const url = new URL(fetchUrl);
     if (url.origin !== window.location.origin) {
-      response = await etcFetch(imageUrl, 'cors');
+      // Check actual hostname, not just parameter - defense against sending credentials
+      // to external images when usePreviewDaLive=true (resolveMediaUrl may not convert them)
+      const isPreviewDaLive = url.hostname.endsWith('.preview.da.live');
+      if (isPreviewDaLive) {
+        response = await fetch(fetchUrl, { credentials: 'include' });
+      } else {
+        response = await etcFetch(fetchUrl, 'cors');
+      }
     }
   } catch (e) {
     /* fall through to direct fetch for invalid or relative URLs */
   }
 
-  response ||= await fetch(imageUrl);
+  response ||= await fetch(fetchUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`);
   }
@@ -160,7 +171,8 @@ async function copyImageToClipboard(imageUrl) {
   }
 
   // Copy multiple formats like browser's "Copy image" does
-  // Include HTML and text with the original URL so document editors can deduplicate
+  // Use original imageUrl (not fetchUrl) so pasted content has canonical URLs
+  // that work in published documents, not preview-specific URLs
   const escapedUrl = escapeHtml(imageUrl);
   const clipboardItem = new ClipboardItem({
     [mimeType]: clipboardBlob,
@@ -171,7 +183,7 @@ async function copyImageToClipboard(imageUrl) {
   await navigator.clipboard.write([clipboardItem]);
 }
 
-export async function copyMediaToClipboard(media) {
+export async function copyMediaToClipboard(media, org, repo, usePreviewDaLive = false) {
   const mediaUrl = media.url;
   const mediaType = getMediaType(media);
   const plugin = isMediaLibraryPluginMode();
@@ -199,7 +211,7 @@ export async function copyMediaToClipboard(media) {
 
   try {
     if (mediaType === 'image') {
-      await copyImageToClipboard(mediaUrl);
+      await copyImageToClipboard(mediaUrl, org, repo, usePreviewDaLive);
       if (plugin) {
         return {
           heading: t('NOTIFY_PLUGIN_FALLBACK_HEADING'),

--- a/nx/blocks/media-library/core/urls.js
+++ b/nx/blocks/media-library/core/urls.js
@@ -252,7 +252,8 @@ export function isInternalToSite(urlString, org, repo) {
     const url = new URL(urlString);
 
     const isAemDomain = url.hostname === `main--${repo}--${org}.aem.page`
-        || url.hostname === `main--${repo}--${org}.aem.live`;
+        || url.hostname === `main--${repo}--${org}.aem.live`
+        || url.hostname === `main--${repo}--${org}.preview.da.live`;
 
     const hasOrgRepoPath = url.pathname.startsWith(`/${org}/${repo}/`);
 

--- a/nx/blocks/media-library/media-library.js
+++ b/nx/blocks/media-library/media-library.js
@@ -1170,7 +1170,8 @@ class NxMediaLibrary extends LitElement {
     if (!media) return;
 
     try {
-      const result = await copyMediaToClipboard(media);
+      const usePreviewDaLive = this.siteAuthInfo?.requiresAuth || false;
+      const result = await copyMediaToClipboard(media, this.org, this.repo, usePreviewDaLive);
       if (result.silent) return;
       const isError = result.heading === 'Error';
       showNotification(result.heading, result.message, isError ? 'danger' : 'success');

--- a/nx/blocks/media-library/ui/views/mediainfo/mediainfo.js
+++ b/nx/blocks/media-library/ui/views/mediainfo/mediainfo.js
@@ -1344,7 +1344,12 @@ class NxMediaInfo extends LitElement {
   async handleCopyUrl() {
     if (!this.media?.url) return;
     try {
-      const result = await copyMediaToClipboard(this.media);
+      const result = await copyMediaToClipboard(
+        this.media,
+        this.org,
+        this.repo,
+        this.usePreviewDaLive,
+      );
       if (result.silent) return;
       const isError = result.heading === 'Error';
       this.showModalNotification(result.heading, result.message, isError ? 'danger' : 'success');


### PR DESCRIPTION
Fixes media copy functionality for authenticated preview sites.

**Test:**
- Authenticated site: https://da.live/apps/media-library?nx=mlcopy#/aemsites/da-bacom-blog
- Unauthenticated site: https://da.live/apps/media-library?nx=mlcopy#/kmurugulla/brightpath

**Changes:**
- Use direct fetch with credentials for `.preview.da.live` URLs
- Use CORS proxy for `.aem.live`/`.aem.page` and external URLs
- Added `usePreviewDaLive` parameter to copy functions