### PR TITLE
fix: lionbridge connector correctness/compliance fixes + test parity

### DIFF
--- a/nx/blocks/loc/connectors/lionbridge/auth.js
+++ b/nx/blocks/loc/connectors/lionbridge/auth.js
@@ -1,6 +1,10 @@
 import { daFetch } from '../../../../../nx2/utils/api.js';
+import { DA_ETC } from '../../../../../nx2/utils/utils.js';
 
-const LOGIN_ORIGIN = 'https://da-etc.adobeaem.workers.dev';
+// DA_ETC_ENVS has no 'stage' entry, so DA_ETC resolves to undefined in a
+// dev-classified host (e.g. localhost without a ?da-etc= override) — fall
+// back to the known-good production origin in that case.
+const LOGIN_ORIGIN = DA_ETC || 'https://da-etc.adobeaem.workers.dev';
 const TOKEN_BUFFER = 300000; // 5 min buffer before expiry
 
 function tokenKey(org, site, env) {

--- a/nx/blocks/loc/connectors/lionbridge/auth.js
+++ b/nx/blocks/loc/connectors/lionbridge/auth.js
@@ -1,0 +1,51 @@
+import { daFetch } from '../../../../../nx2/utils/api.js';
+
+const LOGIN_ORIGIN = 'https://da-etc.adobeaem.workers.dev';
+const TOKEN_BUFFER = 300000; // 5 min buffer before expiry
+
+function tokenKey(org, site, env) {
+  return `lionbridge.${org}.${site}.${env}.token`;
+}
+
+function getTokenDetails(org, site, env) {
+  const stored = localStorage.getItem(tokenKey(org, site, env));
+  if (!stored) return {};
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return {};
+  }
+}
+
+function setTokenDetails(org, site, env, accessToken, expires) {
+  localStorage.setItem(
+    tokenKey(org, site, env),
+    JSON.stringify({ accessToken, expires }),
+  );
+}
+
+export async function getAccessToken(service) {
+  const { org, site, env = 'prod' } = service;
+
+  const { accessToken: cached, expires: cachedExpires } = getTokenDetails(org, site, env);
+  if (cached && cachedExpires > Date.now()) return cached;
+
+  const opts = { method: 'POST' };
+
+  const url = `${LOGIN_ORIGIN}/${org}/sites/${site}/integrations/lionbridge/login?env=${env}`;
+  const resp = await daFetch({ url, opts });
+  if (!resp.ok) return null;
+
+  const { access_token: accessToken, expires_in: expiresIn } = await resp.json();
+  if (!accessToken) return null;
+
+  const expires = Date.now() + (expiresIn * 1000) - TOKEN_BUFFER;
+  setTokenDetails(org, site, env, accessToken, expires);
+
+  return accessToken;
+}
+
+export default async function authReady(service) {
+  const accessToken = await getAccessToken(service);
+  return !!accessToken;
+}

--- a/nx/blocks/loc/connectors/lionbridge/auth.js
+++ b/nx/blocks/loc/connectors/lionbridge/auth.js
@@ -7,10 +7,25 @@ import { DA_ETC } from '../../../../../nx2/utils/utils.js';
 const LOGIN_ORIGIN = DA_ETC || 'https://da-etc.adobeaem.workers.dev';
 const TOKEN_BUFFER = 300000; // 5 min buffer before expiry
 
+/**
+ * Builds the localStorage key a token is cached under.
+ * @param {string} org - The DA org.
+ * @param {string} site - The DA site.
+ * @param {string} env - The Lionbridge environment (e.g. 'prod').
+ * @returns {string} The cache key.
+ */
 function tokenKey(org, site, env) {
   return `lionbridge.${org}.${site}.${env}.token`;
 }
 
+/**
+ * Reads a cached token, if any.
+ * @param {string} org - The DA org.
+ * @param {string} site - The DA site.
+ * @param {string} env - The Lionbridge environment (e.g. 'prod').
+ * @returns {{accessToken?: string, expires?: number}} The cached details,
+ *  or `{}` if none are stored.
+ */
 function getTokenDetails(org, site, env) {
   const stored = localStorage.getItem(tokenKey(org, site, env));
   if (!stored) return {};
@@ -21,6 +36,16 @@ function getTokenDetails(org, site, env) {
   }
 }
 
+/**
+ * Caches a token and its expiry.
+ * @param {string} org - The DA org.
+ * @param {string} site - The DA site.
+ * @param {string} env - The Lionbridge environment (e.g. 'prod').
+ * @param {string} accessToken - The token to cache.
+ * @param {number} expires - Epoch ms after which the token should be
+ *  treated as expired.
+ * @returns {void}
+ */
 function setTokenDetails(org, site, env, accessToken, expires) {
   localStorage.setItem(
     tokenKey(org, site, env),
@@ -28,6 +53,13 @@ function setTokenDetails(org, site, env, accessToken, expires) {
   );
 }
 
+/**
+ * Returns a valid Lionbridge access token, reusing a cached one if it
+ * hasn't expired, otherwise logging in via da-etc.
+ * @param {Object} service - The service configuration; reads `org`,
+ *  `site`, and `env` (defaults to 'prod').
+ * @returns {Promise<string|null>} The access token, or null on failure.
+ */
 export async function getAccessToken(service) {
   const { org, site, env = 'prod' } = service;
 
@@ -49,6 +81,11 @@ export async function getAccessToken(service) {
   return accessToken;
 }
 
+/**
+ * Determines if the service is authenticated to Lionbridge.
+ * @param {Object} service - The service configuration.
+ * @returns {Promise<boolean>} Whether a valid access token was obtained.
+ */
 export default async function authReady(service) {
   const accessToken = await getAccessToken(service);
   return !!accessToken;

--- a/nx/blocks/loc/connectors/lionbridge/connectorGuid.js
+++ b/nx/blocks/loc/connectors/lionbridge/connectorGuid.js
@@ -1,0 +1,64 @@
+import { daFetch } from '../../../../../nx2/utils/api.js';
+import { DA_ADMIN } from '../../../../../nx2/utils/utils.js';
+
+const CONFIG_PATH = '.da/translate.json';
+
+async function fetchRawConfig(org, site) {
+  const resp = await daFetch({ url: `${DA_ADMIN}/source/${org}/${site}/${CONFIG_PATH}` });
+  if (!resp.ok) return null;
+  return resp.json();
+}
+
+async function saveRawConfig(org, site, json) {
+  const data = new Blob([JSON.stringify(json)], { type: 'application/json' });
+  const body = new FormData();
+  body.append('data', data);
+  const url = `${DA_ADMIN}/source/${org}/${site}/${CONFIG_PATH}`;
+  return daFetch({ url, opts: { method: 'POST', body } });
+}
+
+/**
+ * Returns this org/site/env's persistent Lionbridge connector GUID,
+ * generating and persisting one to `.da/translate.json` on first use.
+ *
+ * Per Lionbridge's dev guidelines, a connector "installation" must be
+ * identified by a GUID generated once and never regenerated. DA has no
+ * installation step, so an org/site/env combination stands in for one:
+ * the GUID is stored as `translation.service.{env}.connectorGuid` in the
+ * site's config sheet (non-secret, alongside `apiEndpoint`/`providerId`),
+ * so it is already present on `service` for every subsequent load and this
+ * function only writes once. A concurrent first-use race between two
+ * sessions could in theory produce two GUIDs — acceptable here since
+ * Lionbridge only uses it for connector fingerprinting/support, not as a
+ * security boundary.
+ * @param {Object} service - Connector service config; mutated in place with
+ *  `connectorGuid` once resolved.
+ * @returns {Promise<string|null>} the GUID, or null if it could not be
+ *  read or persisted.
+ */
+export async function getOrCreateConnectorGuid(service) {
+  if (service.connectorGuid) return service.connectorGuid;
+
+  const { org, site, env = 'prod' } = service;
+  const key = `translation.service.${env}.connectorGuid`;
+
+  const json = await fetchRawConfig(org, site);
+  if (!json?.config?.data) return null;
+
+  const existing = json.config.data.find((row) => row.key === key);
+  if (existing?.value) {
+    service.connectorGuid = existing.value;
+    return existing.value;
+  }
+
+  const guid = crypto.randomUUID();
+  json.config.data.push({ key, value: guid });
+  json.config.total = json.config.data.length;
+  json.config.limit = json.config.data.length;
+
+  const saved = await saveRawConfig(org, site, json);
+  if (!saved.ok) return null;
+
+  service.connectorGuid = guid;
+  return guid;
+}

--- a/nx/blocks/loc/connectors/lionbridge/connectorGuid.js
+++ b/nx/blocks/loc/connectors/lionbridge/connectorGuid.js
@@ -3,12 +3,26 @@ import { DA_ADMIN } from '../../../../../nx2/utils/utils.js';
 
 const CONFIG_PATH = '.da/translate.json';
 
+/**
+ * Fetches a site's raw `.da/translate.json` config document.
+ * @param {string} org - The DA org.
+ * @param {string} site - The DA site.
+ * @returns {Promise<Object|null>} The parsed multi-sheet document, or null
+ *  on failure.
+ */
 async function fetchRawConfig(org, site) {
   const resp = await daFetch({ url: `${DA_ADMIN}/source/${org}/${site}/${CONFIG_PATH}` });
   if (!resp.ok) return null;
   return resp.json();
 }
 
+/**
+ * Writes a site's raw `.da/translate.json` config document back to DA.
+ * @param {string} org - The DA org.
+ * @param {string} site - The DA site.
+ * @param {Object} json - The full document to write.
+ * @returns {Promise<Response>} The raw fetch response.
+ */
 async function saveRawConfig(org, site, json) {
   const data = new Blob([JSON.stringify(json)], { type: 'application/json' });
   const body = new FormData();

--- a/nx/blocks/loc/connectors/lionbridge/index.js
+++ b/nx/blocks/loc/connectors/lionbridge/index.js
@@ -2,6 +2,7 @@ import { Queue } from '../../../../../nx2/public/utils/tree.js';
 import { addDnt, removeDnt } from '../../dnt/dnt.js';
 import authReady, { getAccessToken } from './auth.js';
 import { getOrCreateConnectorGuid } from './connectorGuid.js';
+import fetchWithRetry from '../../utils/fetchWithRetry.js';
 
 export const dnt = { addDnt };
 
@@ -13,10 +14,14 @@ const MAX_NAME_BYTES = 250;
 
 // Lionbridge rate-limits at 10 (staging) / 20 (prod) requests/sec/IP. Their
 // dev guidelines require retrying 429/503 with exponential backoff, honoring
-// Retry-After when present.
-const MAX_RETRIES = 3;
-const BASE_RETRY_DELAY_MS = 500;
-const MAX_RETRY_DELAY_MS = 8000;
+// Retry-After when present. Only 429/503 (not all 5xx) are retried here, and
+// with a tighter ceiling than fetchWithRetry's defaults, to match Lionbridge's
+// specific guidance rather than the shared default tuning.
+const RETRY_CONFIG = {
+  maxRetries: 3,
+  maxDelayMs: 8000,
+  isRetryable: (status) => status === 429 || status === 503,
+};
 
 // Request statuses that mean translated content is ready to retrieve.
 const READY_STATUSES = ['REVIEW_TRANSLATION', 'TRANSLATION_APPROVED', 'COMPLETED_NO_NEED_TO_TRANSLATE'];
@@ -48,38 +53,6 @@ export function connect(service) {
 // `cancelTranslation` export, so this is a deliberate omission, not a gap.
 
 // --- Helpers ---
-
-/**
- * Resolves after the given delay.
- * @param {number} ms - Milliseconds to wait.
- * @returns {Promise<void>}
- */
-function wait(ms) {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
-}
-
-/**
- * Fetches, retrying on 429/503 with exponential backoff (honoring
- * Retry-After when present) up to MAX_RETRIES times.
- * @param {string|URL} url - The request URL.
- * @param {Object} opts - Fetch options.
- * @param {number} [attempt] - Current retry attempt, for internal recursion.
- * @returns {Promise<Response>} The final response (ok or not).
- */
-async function fetchWithRetry(url, opts, attempt = 0) {
-  const resp = await fetch(url, opts);
-  if ((resp.status !== 429 && resp.status !== 503) || attempt >= MAX_RETRIES) {
-    return resp;
-  }
-
-  const retryAfterSecs = Number(resp.headers.get('retry-after'));
-  const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
-    ? retryAfterSecs * 1000
-    : Math.min(BASE_RETRY_DELAY_MS * (2 ** attempt), MAX_RETRY_DELAY_MS);
-
-  await wait(delayMs);
-  return fetchWithRetry(url, opts, attempt + 1);
-}
 
 /**
  * Builds fetch options for a Lionbridge API call, including a fresh bearer
@@ -168,7 +141,7 @@ async function createJob(service, title, options) {
   };
 
   const opts = await getOpts(service, 'POST', body);
-  const resp = await fetchWithRetry(`${apiEndpoint}/jobs`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs`, opts, RETRY_CONFIG);
   if (!resp.ok) return null;
 
   const json = await resp.json();
@@ -187,7 +160,7 @@ async function initSourceFile(service, jobId, name) {
   const { apiEndpoint } = service;
   const opts = await getOpts(service, 'POST');
   const url = `${apiEndpoint}/jobs/${jobId}/sourcefiles?fileName=${encodeURIComponent(name)}`;
-  const resp = await fetchWithRetry(url, opts);
+  const resp = await fetchWithRetry(url, opts, RETRY_CONFIG);
   if (!resp.ok) return null;
   return resp.json();
 }
@@ -206,7 +179,7 @@ async function uploadSourceFile(fmsPostMultipartUrl, content, name) {
   formData.append('file', file, name);
 
   // The upload URL is a pre-signed SAS URL — no bearer token needed or wanted.
-  const resp = await fetchWithRetry(fmsPostMultipartUrl, { method: 'POST', body: formData });
+  const resp = await fetchWithRetry(fmsPostMultipartUrl, { method: 'POST', body: formData }, RETRY_CONFIG);
   return resp.ok;
 }
 
@@ -237,7 +210,7 @@ async function addRequest({
   };
 
   const opts = await getOpts(service, 'POST', body);
-  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/add`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/add`, opts, RETRY_CONFIG);
   if (!resp.ok) return [];
 
   const { _embedded: embedded } = await resp.json();
@@ -254,7 +227,7 @@ async function addRequest({
 async function submitJob(service, jobId) {
   const { apiEndpoint, providerId } = service;
   const opts = await getOpts(service, 'PUT', { providerId });
-  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/submit`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/submit`, opts, RETRY_CONFIG);
   return resp.ok;
 }
 
@@ -269,7 +242,7 @@ async function submitJob(service, jobId) {
 async function approveRequest(service, jobId, requestId) {
   const { apiEndpoint } = service;
   const opts = await getOpts(service, 'PUT', { requestIds: [requestId] });
-  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/approve`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/approve`, opts, RETRY_CONFIG);
   return resp.ok;
 }
 
@@ -413,7 +386,7 @@ async function fetchAllRequests(service, jobId) {
     if (next) url.searchParams.set('next', next);
 
     // eslint-disable-next-line no-await-in-loop
-    const resp = await fetchWithRetry(url, opts);
+    const resp = await fetchWithRetry(url, opts, RETRY_CONFIG);
     if (!resp.ok) break;
 
     // eslint-disable-next-line no-await-in-loop
@@ -493,7 +466,7 @@ export async function saveItems({
       // retrievefile returns the raw file, not JSON. application/octet-stream
       // is Lionbridge's documented Accept for file retrieval (avoids base64).
       const dlOpts = await getOpts(service, 'GET', null, 'application/octet-stream');
-      const dlResp = await fetchWithRetry(dlUrl, dlOpts);
+      const dlResp = await fetchWithRetry(dlUrl, dlOpts, RETRY_CONFIG);
       if (!dlResp.ok) throw new Error(dlResp.status);
 
       const text = await dlResp.text();

--- a/nx/blocks/loc/connectors/lionbridge/index.js
+++ b/nx/blocks/loc/connectors/lionbridge/index.js
@@ -5,7 +5,7 @@ import { getOrCreateConnectorGuid } from './connectorGuid.js';
 
 export const dnt = { addDnt };
 
-const CONNECTOR_NAME = 'DA Live Localization';
+const CONNECTOR_NAME = 'DA Live Localization for Lionbridge';
 const CONNECTOR_VERSION = '1.0.0';
 
 // jobName / requestName are capped at 250 bytes by Lionbridge's dev guidelines.
@@ -23,10 +23,20 @@ const READY_STATUSES = ['REVIEW_TRANSLATION', 'TRANSLATION_APPROVED', 'COMPLETED
 const ERROR_STATUSES = ['TRANSLATION_REJECTED'];
 const CANCELED_STATUSES = ['CANCELLED'];
 
+/**
+ * Determines if the user is currently authenticated to Lionbridge.
+ * @param {Object} service - The service configuration.
+ * @returns {Promise<boolean>} Whether a valid access token was obtained.
+ */
 export function isConnected(service) {
   return authReady(service);
 }
 
+/**
+ * Connects to Lionbridge by obtaining an access token.
+ * @param {Object} service - The service configuration.
+ * @returns {Promise<boolean>} Whether the connection succeeded.
+ */
 export function connect(service) {
   return authReady(service);
 }
@@ -39,10 +49,23 @@ export function connect(service) {
 
 // --- Helpers ---
 
+/**
+ * Resolves after the given delay.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>}
+ */
 function wait(ms) {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
+/**
+ * Fetches, retrying on 429/503 with exponential backoff (honoring
+ * Retry-After when present) up to MAX_RETRIES times.
+ * @param {string|URL} url - The request URL.
+ * @param {Object} opts - Fetch options.
+ * @param {number} [attempt] - Current retry attempt, for internal recursion.
+ * @returns {Promise<Response>} The final response (ok or not).
+ */
 async function fetchWithRetry(url, opts, attempt = 0) {
   const resp = await fetch(url, opts);
   if ((resp.status !== 429 && resp.status !== 503) || attempt >= MAX_RETRIES) {
@@ -58,6 +81,15 @@ async function fetchWithRetry(url, opts, attempt = 0) {
   return fetchWithRetry(url, opts, attempt + 1);
 }
 
+/**
+ * Builds fetch options for a Lionbridge API call, including a fresh bearer
+ * token.
+ * @param {Object} service - The service configuration.
+ * @param {string} [method] - HTTP method.
+ * @param {Object|null} [body] - JSON-serializable request body, if any.
+ * @param {string} [accept] - Accept header value.
+ * @returns {Promise<Object>} Fetch options.
+ */
 async function getOpts(service, method = 'GET', body = null, accept = 'application/json') {
   const token = await getAccessToken(service);
   if (!token) throw new Error('Lionbridge authentication failed');
@@ -76,6 +108,11 @@ async function getOpts(service, method = 'GET', body = null, accept = 'applicati
   return opts;
 }
 
+/**
+ * Ensures a path has an extension Lionbridge will treat as a file.
+ * @param {string} path - A DA base path, with or without an extension.
+ * @returns {string} The path, with `.html` appended if it had no extension.
+ */
 function ensureExtension(path) {
   if (path.endsWith('.html')) return path;
 
@@ -84,6 +121,11 @@ function ensureExtension(path) {
   return `${path}.html`;
 }
 
+/**
+ * Derives a flat file name for Lionbridge from a DA base path.
+ * @param {string} daBasePath - The source item's DA base path.
+ * @returns {string} A dash-joined file name, e.g. `/foo/bar` -> `bar.html`.
+ */
 function fileName(daBasePath) {
   const [, ...parts] = ensureExtension(daBasePath).split('/');
   return parts.join('-') || 'index.html';
@@ -105,6 +147,13 @@ function truncateBytes(str, maxBytes) {
 
 // --- Job / request operations ---
 
+/**
+ * Creates a new Lionbridge job for a translation project.
+ * @param {Object} service - The service configuration.
+ * @param {string} title - The project title.
+ * @param {Object} options - Project options; `project.due` sets a due date.
+ * @returns {Promise<string|null>} The new job's id, or null on failure.
+ */
 async function createJob(service, title, options) {
   const { apiEndpoint } = service;
   const dueDate = options['project.due'];
@@ -126,6 +175,14 @@ async function createJob(service, title, options) {
   return json.jobId;
 }
 
+/**
+ * Registers a source file with Lionbridge and gets back an upload URL.
+ * @param {Object} service - The service configuration.
+ * @param {string} jobId - The job to attach the source file to.
+ * @param {string} name - The file name.
+ * @returns {Promise<Object|null>} `{ fmsPostMultipartUrl, fmsFileId }`, or
+ *  null on failure.
+ */
 async function initSourceFile(service, jobId, name) {
   const { apiEndpoint } = service;
   const opts = await getOpts(service, 'POST');
@@ -135,6 +192,14 @@ async function initSourceFile(service, jobId, name) {
   return resp.json();
 }
 
+/**
+ * Uploads source content to Lionbridge's pre-signed SAS URL.
+ * @param {string} fmsPostMultipartUrl - The pre-signed upload URL from
+ *  `initSourceFile`.
+ * @param {string} content - The source file content.
+ * @param {string} name - The file name.
+ * @returns {Promise<boolean>} Whether the upload succeeded.
+ */
 async function uploadSourceFile(fmsPostMultipartUrl, content, name) {
   const formData = new FormData();
   const file = new Blob([content], { type: 'text/html' });
@@ -145,6 +210,18 @@ async function uploadSourceFile(fmsPostMultipartUrl, content, name) {
   return resp.ok;
 }
 
+/**
+ * Adds a translation request for an uploaded source file to a job.
+ * @param {Object} params
+ * @param {Object} params.service - The service configuration.
+ * @param {string} params.jobId - The target job.
+ * @param {string} params.sourceLanguage - The source language code.
+ * @param {string[]} params.targetCodes - Target language codes.
+ * @param {Object} params.url - The DA url entry the request is for.
+ * @param {string} params.fmsFileId - The uploaded source file's id.
+ * @returns {Promise<Object[]>} The created requests (one per target
+ *  language), or an empty array on failure.
+ */
 async function addRequest({
   service, jobId, sourceLanguage, targetCodes, url, fmsFileId,
 }) {
@@ -167,6 +244,13 @@ async function addRequest({
   return embedded?.requests || [];
 }
 
+/**
+ * Submits a job for translation. providerId must be sent here — Lionbridge
+ * silently ignores it on job creation but requires it here.
+ * @param {Object} service - The service configuration.
+ * @param {string} jobId - The job to submit.
+ * @returns {Promise<boolean>} Whether the submit succeeded.
+ */
 async function submitJob(service, jobId) {
   const { apiEndpoint, providerId } = service;
   const opts = await getOpts(service, 'PUT', { providerId });
@@ -174,6 +258,14 @@ async function submitJob(service, jobId) {
   return resp.ok;
 }
 
+/**
+ * Approves a translated request, moving it from REVIEW_TRANSLATION to
+ * TRANSLATION_APPROVED in Lionbridge's review workflow.
+ * @param {Object} service - The service configuration.
+ * @param {string} jobId - The job the request belongs to.
+ * @param {string} requestId - The request to approve.
+ * @returns {Promise<boolean>} Whether the approval succeeded.
+ */
 async function approveRequest(service, jobId, requestId) {
   const { apiEndpoint } = service;
   const opts = await getOpts(service, 'PUT', { requestIds: [requestId] });
@@ -181,6 +273,17 @@ async function approveRequest(service, jobId, requestId) {
   return resp.ok;
 }
 
+/**
+ * Uploads a single DA url to Lionbridge: registers the source file, uploads
+ * its content, and adds a translation request for it.
+ * @param {Object} service - The service configuration.
+ * @param {string} jobId - The target job.
+ * @param {string} sourceLanguage - The source language code.
+ * @param {string[]} targetCodes - Target language codes.
+ * @param {Object} url - The DA url entry to upload; mutated with
+ *  `requestIds` on success.
+ * @returns {Promise<boolean>} Whether the upload succeeded.
+ */
 async function uploadUrl(service, jobId, sourceLanguage, targetCodes, url) {
   const name = fileName(url.daBasePath);
 
@@ -205,6 +308,20 @@ async function uploadUrl(service, jobId, sourceLanguage, targetCodes, url) {
 
 // --- Exports ---
 
+/**
+ * Sends a translation project's urls to Lionbridge for every target
+ * language: creates a job, uploads all urls, then submits the job.
+ * @param {Object} params
+ * @param {string} params.title - The project title.
+ * @param {Object} params.service - The service configuration.
+ * @param {Object} params.options - Project options (e.g. `project.due`,
+ *  `source.language`).
+ * @param {Object[]} params.langs - Target languages; mutated in place with
+ *  `translation` status.
+ * @param {Object[]} params.urls - The urls to translate.
+ * @param {Object} params.actions - `{ sendMessage, saveState }` callbacks.
+ * @returns {Promise<void>}
+ */
 export async function sendAllLanguages({
   title, service, options, langs, urls, actions,
 }) {
@@ -252,6 +369,16 @@ export async function sendAllLanguages({
   sendMessage();
 }
 
+/**
+ * Computes the aggregate translation status for one language from a job's
+ * requests.
+ * @param {Object[]} requests - All requests for the job (any language).
+ * @param {string} langCode - The language to compute status for.
+ * @param {number} fileCount - The total number of files expected for this
+ *  language.
+ * @returns {{status: string, translated: number}} `status` is one of
+ *  'error', 'canceled', 'translated', or 'in progress'.
+ */
 export function statusFor(requests, langCode, fileCount) {
   const langRequests = requests.filter((request) => request.targetNativeLanguageCode === langCode);
 
@@ -269,6 +396,12 @@ export function statusFor(requests, langCode, fileCount) {
   return { status: 'in progress', translated };
 }
 
+/**
+ * Fetches every request for a job, paginating via the `next` cursor.
+ * @param {Object} service - The service configuration.
+ * @param {string} jobId - The job to fetch requests for.
+ * @returns {Promise<Object[]>} All requests across all pages.
+ */
 async function fetchAllRequests(service, jobId) {
   const { apiEndpoint } = service;
   const requests = [];
@@ -292,6 +425,16 @@ async function fetchAllRequests(service, jobId) {
   return requests;
 }
 
+/**
+ * Refreshes translation status for every target language of a job.
+ * @param {Object} params
+ * @param {Object} params.service - The service configuration.
+ * @param {Object[]} params.langs - Target languages; mutated in place with
+ *  `translation.status`/`translation.translated`.
+ * @param {Object[]} params.urls - The urls in the project.
+ * @param {Object} params.actions - `{ sendMessage, saveState }` callbacks.
+ * @returns {Promise<void>}
+ */
 export async function getStatusAll({ service, langs, urls, actions }) {
   const { sendMessage, saveState } = actions;
 
@@ -315,6 +458,21 @@ export async function getStatusAll({ service, langs, urls, actions }) {
   await saveState();
 }
 
+/**
+ * Downloads and saves translated content for a completed language,
+ * approving each request in Lionbridge afterward.
+ * @param {Object} params
+ * @param {string} params.org - The DA org.
+ * @param {string} params.site - The DA site.
+ * @param {Object} params.service - The service configuration.
+ * @param {Object} params.lang - The language to save; reads
+ *  `lang.translation.jobId`.
+ * @param {Object[]} params.urls - The urls to download; mutated in place
+ *  with `sourceContent`/`status`.
+ * @param {Function} params.saveFn - Called with each url once its
+ *  translated content is ready to persist.
+ * @returns {Promise<Object[]>} The same `urls`, once all have a `status`.
+ */
 export async function saveItems({
   org, site, service, lang, urls, saveFn,
 }) {

--- a/nx/blocks/loc/connectors/lionbridge/index.js
+++ b/nx/blocks/loc/connectors/lionbridge/index.js
@@ -1,11 +1,22 @@
 import { Queue } from '../../../../../nx2/public/utils/tree.js';
 import { addDnt, removeDnt } from '../../dnt/dnt.js';
 import authReady, { getAccessToken } from './auth.js';
+import { getOrCreateConnectorGuid } from './connectorGuid.js';
 
 export const dnt = { addDnt };
 
 const CONNECTOR_NAME = 'DA Live Localization';
 const CONNECTOR_VERSION = '1.0.0';
+
+// jobName / requestName are capped at 250 bytes by Lionbridge's dev guidelines.
+const MAX_NAME_BYTES = 250;
+
+// Lionbridge rate-limits at 10 (staging) / 20 (prod) requests/sec/IP. Their
+// dev guidelines require retrying 429/503 with exponential backoff, honoring
+// Retry-After when present.
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 500;
+const MAX_RETRY_DELAY_MS = 8000;
 
 // Request statuses that mean translated content is ready to retrieve.
 const READY_STATUSES = ['REVIEW_TRANSLATION', 'TRANSLATION_APPROVED', 'COMPLETED_NO_NEED_TO_TRANSLATE'];
@@ -20,9 +31,34 @@ export function connect(service) {
   return authReady(service);
 }
 
+// No `cancelTranslation` export: Lionbridge's dev guidelines explicitly
+// prohibit connectors from letting users cancel or delete in-progress jobs
+// (developers.lionbridge.com/content/v2/docs/dev_guidelines.html). The
+// translate UI already hides its cancel action when a connector has no
+// `cancelTranslation` export, so this is a deliberate omission, not a gap.
+
 // --- Helpers ---
 
-async function getOpts(service, method = 'GET', body = null) {
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+async function fetchWithRetry(url, opts, attempt = 0) {
+  const resp = await fetch(url, opts);
+  if ((resp.status !== 429 && resp.status !== 503) || attempt >= MAX_RETRIES) {
+    return resp;
+  }
+
+  const retryAfterSecs = Number(resp.headers.get('retry-after'));
+  const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+    ? retryAfterSecs * 1000
+    : Math.min(BASE_RETRY_DELAY_MS * (2 ** attempt), MAX_RETRY_DELAY_MS);
+
+  await wait(delayMs);
+  return fetchWithRetry(url, opts, attempt + 1);
+}
+
+async function getOpts(service, method = 'GET', body = null, accept = 'application/json') {
   const token = await getAccessToken(service);
   if (!token) throw new Error('Lionbridge authentication failed');
 
@@ -31,6 +67,7 @@ async function getOpts(service, method = 'GET', body = null) {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      Accept: accept,
     },
   };
 
@@ -52,23 +89,37 @@ function fileName(daBasePath) {
   return parts.join('-') || 'index.html';
 }
 
+// Truncates to a max UTF-8 byte length without splitting a multi-byte
+// codepoint (Lionbridge caps jobName/requestName at 250 bytes each).
+function truncateBytes(str, maxBytes) {
+  const bytes = new TextEncoder().encode(str);
+  if (bytes.length <= maxBytes) return str;
+
+  const decoder = new TextDecoder();
+  let end = maxBytes;
+  while (end > 0 && decoder.decode(bytes.slice(0, end)).endsWith('�')) {
+    end -= 1;
+  }
+  return decoder.decode(bytes.slice(0, end));
+}
+
 // --- Job / request operations ---
 
 async function createJob(service, title, options) {
-  const { apiEndpoint, providerId } = service;
+  const { apiEndpoint } = service;
   const dueDate = options['project.due'];
+  const guid = await getOrCreateConnectorGuid(service);
 
   const body = {
-    jobName: `${title} - ${Date.now()}`,
+    jobName: truncateBytes(`${title} - ${Date.now()}`, MAX_NAME_BYTES),
     description: `DA translation project: ${title}`,
-    providerId,
-    connectorName: CONNECTOR_NAME,
+    connectorName: guid ? `${guid} ${CONNECTOR_NAME}` : CONNECTOR_NAME,
     connectorVersion: CONNECTOR_VERSION,
     ...(dueDate ? { dueDate } : {}),
   };
 
   const opts = await getOpts(service, 'POST', body);
-  const resp = await fetch(`${apiEndpoint}/jobs`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs`, opts);
   if (!resp.ok) return null;
 
   const json = await resp.json();
@@ -79,7 +130,7 @@ async function initSourceFile(service, jobId, name) {
   const { apiEndpoint } = service;
   const opts = await getOpts(service, 'POST');
   const url = `${apiEndpoint}/jobs/${jobId}/sourcefiles?fileName=${encodeURIComponent(name)}`;
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   return resp.json();
 }
@@ -90,7 +141,7 @@ async function uploadSourceFile(fmsPostMultipartUrl, content, name) {
   formData.append('file', file, name);
 
   // The upload URL is a pre-signed SAS URL — no bearer token needed or wanted.
-  const resp = await fetch(fmsPostMultipartUrl, { method: 'POST', body: formData });
+  const resp = await fetchWithRetry(fmsPostMultipartUrl, { method: 'POST', body: formData });
   return resp.ok;
 }
 
@@ -102,14 +153,14 @@ async function addRequest({
 
   const body = {
     fmsFileId,
-    requestName: name,
+    requestName: truncateBytes(name, MAX_NAME_BYTES),
     sourceNativeId: url.daBasePath,
     sourceNativeLanguageCode: sourceLanguage,
     targetNativeLanguageCodes: targetCodes,
   };
 
   const opts = await getOpts(service, 'POST', body);
-  const resp = await fetch(`${apiEndpoint}/jobs/${jobId}/requests/add`, opts);
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/add`, opts);
   if (!resp.ok) return [];
 
   const { _embedded: embedded } = await resp.json();
@@ -117,9 +168,16 @@ async function addRequest({
 }
 
 async function submitJob(service, jobId) {
+  const { apiEndpoint, providerId } = service;
+  const opts = await getOpts(service, 'PUT', { providerId });
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/submit`, opts);
+  return resp.ok;
+}
+
+async function approveRequest(service, jobId, requestId) {
   const { apiEndpoint } = service;
-  const opts = await getOpts(service, 'PUT', {});
-  const resp = await fetch(`${apiEndpoint}/jobs/${jobId}/submit`, opts);
+  const opts = await getOpts(service, 'PUT', { requestIds: [requestId] });
+  const resp = await fetchWithRetry(`${apiEndpoint}/jobs/${jobId}/requests/approve`, opts);
   return resp.ok;
 }
 
@@ -222,7 +280,7 @@ async function fetchAllRequests(service, jobId) {
     if (next) url.searchParams.set('next', next);
 
     // eslint-disable-next-line no-await-in-loop
-    const resp = await fetch(url, opts);
+    const resp = await fetchWithRetry(url, opts);
     if (!resp.ok) break;
 
     // eslint-disable-next-line no-await-in-loop
@@ -274,8 +332,10 @@ export async function saveItems({
 
     try {
       const dlUrl = `${apiEndpoint}/jobs/${jobId}/requests/${requestId}/retrievefile`;
-      const dlOpts = await getOpts(service);
-      const dlResp = await fetch(dlUrl, dlOpts);
+      // retrievefile returns the raw file, not JSON. application/octet-stream
+      // is Lionbridge's documented Accept for file retrieval (avoids base64).
+      const dlOpts = await getOpts(service, 'GET', null, 'application/octet-stream');
+      const dlResp = await fetchWithRetry(dlUrl, dlOpts);
       if (!dlResp.ok) throw new Error(dlResp.status);
 
       const text = await dlResp.text();
@@ -283,6 +343,15 @@ export async function saveItems({
       url.sourceContent = await removeDnt({ org, site, html: text, ext });
 
       await saveFn(url);
+
+      // Best-effort: close out the request in Lionbridge's review workflow
+      // (REVIEW_TRANSLATION -> TRANSLATION_APPROVED). Failure here doesn't
+      // affect the already-successful download/save.
+      try {
+        await approveRequest(service, jobId, requestId);
+      } catch {
+        // Ignore — approval is a courtesy call, not required for DA's own flow.
+      }
     } catch {
       url.status = 'error';
     }

--- a/nx/blocks/loc/connectors/lionbridge/index.js
+++ b/nx/blocks/loc/connectors/lionbridge/index.js
@@ -1,0 +1,305 @@
+import { Queue } from '../../../../../nx2/public/utils/tree.js';
+import { addDnt, removeDnt } from '../../dnt/dnt.js';
+import authReady, { getAccessToken } from './auth.js';
+
+export const dnt = { addDnt };
+
+const CONNECTOR_NAME = 'DA Live Localization';
+const CONNECTOR_VERSION = '1.0.0';
+
+// Request statuses that mean translated content is ready to retrieve.
+const READY_STATUSES = ['REVIEW_TRANSLATION', 'TRANSLATION_APPROVED', 'COMPLETED_NO_NEED_TO_TRANSLATE'];
+const ERROR_STATUSES = ['TRANSLATION_REJECTED'];
+const CANCELED_STATUSES = ['CANCELLED'];
+
+export function isConnected(service) {
+  return authReady(service);
+}
+
+export function connect(service) {
+  return authReady(service);
+}
+
+// --- Helpers ---
+
+async function getOpts(service, method = 'GET', body = null) {
+  const token = await getAccessToken(service);
+  if (!token) throw new Error('Lionbridge authentication failed');
+
+  const opts = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  if (body) opts.body = JSON.stringify(body);
+
+  return opts;
+}
+
+function ensureExtension(path) {
+  if (path.endsWith('.html')) return path;
+
+  // Add .html to `file-name.json` so when we get
+  // the doc back, we know it was originally json
+  return `${path}.html`;
+}
+
+function fileName(daBasePath) {
+  const [, ...parts] = ensureExtension(daBasePath).split('/');
+  return parts.join('-') || 'index.html';
+}
+
+// --- Job / request operations ---
+
+async function createJob(service, title, options) {
+  const { apiEndpoint, providerId } = service;
+  const dueDate = options['project.due'];
+
+  const body = {
+    jobName: `${title} - ${Date.now()}`,
+    description: `DA translation project: ${title}`,
+    providerId,
+    connectorName: CONNECTOR_NAME,
+    connectorVersion: CONNECTOR_VERSION,
+    ...(dueDate ? { dueDate } : {}),
+  };
+
+  const opts = await getOpts(service, 'POST', body);
+  const resp = await fetch(`${apiEndpoint}/jobs`, opts);
+  if (!resp.ok) return null;
+
+  const json = await resp.json();
+  return json.jobId;
+}
+
+async function initSourceFile(service, jobId, name) {
+  const { apiEndpoint } = service;
+  const opts = await getOpts(service, 'POST');
+  const url = `${apiEndpoint}/jobs/${jobId}/sourcefiles?fileName=${encodeURIComponent(name)}`;
+  const resp = await fetch(url, opts);
+  if (!resp.ok) return null;
+  return resp.json();
+}
+
+async function uploadSourceFile(fmsPostMultipartUrl, content, name) {
+  const formData = new FormData();
+  const file = new Blob([content], { type: 'text/html' });
+  formData.append('file', file, name);
+
+  // The upload URL is a pre-signed SAS URL — no bearer token needed or wanted.
+  const resp = await fetch(fmsPostMultipartUrl, { method: 'POST', body: formData });
+  return resp.ok;
+}
+
+async function addRequest({
+  service, jobId, sourceLanguage, targetCodes, url, fmsFileId,
+}) {
+  const { apiEndpoint } = service;
+  const name = fileName(url.daBasePath);
+
+  const body = {
+    fmsFileId,
+    requestName: name,
+    sourceNativeId: url.daBasePath,
+    sourceNativeLanguageCode: sourceLanguage,
+    targetNativeLanguageCodes: targetCodes,
+  };
+
+  const opts = await getOpts(service, 'POST', body);
+  const resp = await fetch(`${apiEndpoint}/jobs/${jobId}/requests/add`, opts);
+  if (!resp.ok) return [];
+
+  const { _embedded: embedded } = await resp.json();
+  return embedded?.requests || [];
+}
+
+async function submitJob(service, jobId) {
+  const { apiEndpoint } = service;
+  const opts = await getOpts(service, 'PUT', {});
+  const resp = await fetch(`${apiEndpoint}/jobs/${jobId}/submit`, opts);
+  return resp.ok;
+}
+
+async function uploadUrl(service, jobId, sourceLanguage, targetCodes, url) {
+  const name = fileName(url.daBasePath);
+
+  const fms = await initSourceFile(service, jobId, name);
+  if (!fms) return false;
+
+  const uploaded = await uploadSourceFile(fms.fmsPostMultipartUrl, url.content, name);
+  if (!uploaded) return false;
+
+  const requests = await addRequest({
+    service, jobId, sourceLanguage, targetCodes, url, fmsFileId: fms.fmsFileId,
+  });
+  if (!requests.length) return false;
+
+  url.requestIds = requests.reduce((acc, request) => {
+    acc[request.targetNativeLanguageCode] = request.requestId;
+    return acc;
+  }, {});
+
+  return true;
+}
+
+// --- Exports ---
+
+export async function sendAllLanguages({
+  title, service, options, langs, urls, actions,
+}) {
+  const { sendMessage, saveState } = actions;
+
+  const localesStr = langs.map((lang) => lang.code).join(', ');
+  const sourceLanguage = options['source.language']?.code || 'en-US';
+  const targetCodes = langs.map((lang) => lang.code);
+
+  sendMessage({ text: `Creating Lionbridge job for: ${localesStr}.` });
+  const jobId = await createJob(service, title, options);
+  if (!jobId) {
+    sendMessage({ text: 'Error creating Lionbridge job.', type: 'error' });
+    return;
+  }
+
+  // Persist for status / download
+  service.jobId = { value: jobId };
+
+  sendMessage({ text: `Uploading ${urls.length} files to Lionbridge.` });
+  let uploaded = 0;
+  for (const url of urls) {
+    const ok = await uploadUrl(service, jobId, sourceLanguage, targetCodes, url);
+    if (ok) uploaded += 1;
+  }
+
+  sendMessage({ text: 'Submitting Lionbridge job.' });
+  const submitted = await submitJob(service, jobId);
+
+  langs.forEach((lang) => {
+    lang.translation ??= {};
+    lang.translation.jobId = jobId;
+    lang.translation.sent = uploaded;
+    lang.translation.status = submitted && uploaded === urls.length ? 'created' : 'error';
+  });
+
+  // Clean urls for persistence
+  const cleanUrls = urls.map(({
+    basePath, suppliedPath, checked, requestIds,
+  }) => ({
+    basePath, suppliedPath, checked, requestIds,
+  }));
+
+  await saveState({ options, urls: cleanUrls });
+  sendMessage();
+}
+
+export function statusFor(requests, langCode, fileCount) {
+  const langRequests = requests.filter((request) => request.targetNativeLanguageCode === langCode);
+
+  if (langRequests.some((request) => ERROR_STATUSES.includes(request.statusCode))) {
+    return { status: 'error', translated: 0 };
+  }
+  if (langRequests.some((request) => CANCELED_STATUSES.includes(request.statusCode))) {
+    return { status: 'canceled', translated: 0 };
+  }
+
+  const translated = langRequests
+    .filter((request) => READY_STATUSES.includes(request.statusCode)).length;
+  if (translated === fileCount) return { status: 'translated', translated };
+
+  return { status: 'in progress', translated };
+}
+
+async function fetchAllRequests(service, jobId) {
+  const { apiEndpoint } = service;
+  const requests = [];
+  let next;
+
+  do {
+    const opts = await getOpts(service);
+    const url = new URL(`${apiEndpoint}/jobs/${jobId}/requests`);
+    if (next) url.searchParams.set('next', next);
+
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await fetch(url, opts);
+    if (!resp.ok) break;
+
+    // eslint-disable-next-line no-await-in-loop
+    const { _embedded: embedded, next: nextCursor } = await resp.json();
+    requests.push(...(embedded?.requests || []));
+    next = nextCursor;
+  } while (next);
+
+  return requests;
+}
+
+export async function getStatusAll({ service, langs, urls, actions }) {
+  const { sendMessage, saveState } = actions;
+
+  const jobId = langs[0]?.translation?.jobId;
+  if (!jobId) return;
+
+  const localesStr = langs.map((lang) => lang.code).join(', ');
+  sendMessage({ text: `Getting status for ${localesStr}` });
+
+  const requests = await fetchAllRequests(service, jobId);
+  if (!requests.length) return;
+
+  langs.forEach((lang) => {
+    lang.translation ??= {};
+    const { status, translated } = statusFor(requests, lang.code, urls.length);
+    lang.translation.status = status;
+    lang.translation.translated = translated;
+  });
+
+  sendMessage();
+  await saveState();
+}
+
+export async function saveItems({
+  org, site, service, lang, urls, saveFn,
+}) {
+  const { apiEndpoint } = service;
+  const jobId = lang?.translation?.jobId;
+  if (!jobId) return urls;
+
+  const downloadCallback = async (url) => {
+    const requestId = url.requestIds?.[lang.code];
+
+    if (!requestId) {
+      url.status = 'error';
+      return;
+    }
+
+    try {
+      const dlUrl = `${apiEndpoint}/jobs/${jobId}/requests/${requestId}/retrievefile`;
+      const dlOpts = await getOpts(service);
+      const dlResp = await fetch(dlUrl, dlOpts);
+      if (!dlResp.ok) throw new Error(dlResp.status);
+
+      const text = await dlResp.text();
+      const ext = url.daBasePath.includes('.json') ? 'json' : 'html';
+      url.sourceContent = await removeDnt({ org, site, html: text, ext });
+
+      await saveFn(url);
+    } catch {
+      url.status = 'error';
+    }
+  };
+
+  const queue = new Queue(downloadCallback, 5);
+
+  return new Promise((resolve) => {
+    const throttle = setInterval(() => {
+      const nextUrl = urls.find((u) => !u.inProgress);
+      if (nextUrl) {
+        nextUrl.inProgress = true;
+        queue.push(nextUrl);
+      } else if (urls.every((u) => u.status)) {
+        clearInterval(throttle);
+        resolve(urls);
+      }
+    }, 250);
+  });
+}

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -1,0 +1,71 @@
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+/**
+ * Default retry predicate: rate-limited or server-error responses.
+ * @param {number} status - The response's HTTP status code.
+ * @returns {boolean} Whether the status should trigger a retry.
+ */
+function isDefaultRetryable(status) {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Resolves after the given delay.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Fetches, retrying on rate-limit/transient-failure responses with
+ * exponential backoff and jitter, honoring a Retry-After header when the
+ * service provides one. Shared across loc connectors (Smartling,
+ * Lionbridge, ...) whose translation APIs enforce request-rate and/or
+ * concurrent-request limits.
+ * @param {string|URL} url - The request URL.
+ * @param {Object} opts - Fetch options.
+ * @param {Object} [config]
+ * @param {number} [config.maxRetries] - Max retry attempts after the
+ *  initial request.
+ * @param {number} [config.baseDelayMs] - Base delay before the first
+ *  retry; doubles each subsequent attempt.
+ * @param {number} [config.maxDelayMs] - Delay cap, before jitter.
+ * @param {(status: number) => boolean} [config.isRetryable] - Whether a
+ *  response status should trigger a retry. Defaults to 429 and 5xx.
+ * @returns {Promise<Response>} The final response (ok or not).
+ */
+export default async function fetchWithRetry(url, opts, config = {}) {
+  const {
+    maxRetries = DEFAULT_MAX_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    isRetryable = isDefaultRetryable,
+  } = config;
+
+  /**
+   * Makes one fetch attempt, retrying itself (with a delay) if the
+   * response is retryable and attempts remain.
+   * @param {number} attemptNum - Zero-based attempt count so far.
+   * @returns {Promise<Response>} The final response (ok or not).
+   */
+  async function attempt(attemptNum) {
+    const resp = await fetch(url, opts);
+    if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;
+
+    const retryAfterSecs = Number(resp.headers.get('retry-after'));
+    const backoff = Math.min(baseDelayMs * (2 ** attemptNum), maxDelayMs);
+    const jitter = Math.random() * backoff * 0.3;
+    const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+      ? retryAfterSecs * 1000
+      : backoff + jitter;
+
+    await wait(delayMs);
+    return attempt(attemptNum + 1);
+  }
+
+  return attempt(0);
+}

--- a/test/loc/lionbridge/auth.test.js
+++ b/test/loc/lionbridge/auth.test.js
@@ -1,0 +1,124 @@
+import { expect } from '@esm-bundle/chai';
+import authReady, { getAccessToken } from '../../../nx/blocks/loc/connectors/lionbridge/auth.js';
+
+const LOGIN_ORIGIN = 'https://da-etc.adobeaem.workers.dev';
+
+let calls;
+let origFetch;
+
+function installFetch(handler) {
+  calls = [];
+  origFetch = window.fetch;
+  window.fetch = async (url, opts = {}) => {
+    calls.push({ url: url.toString(), method: opts.method });
+    return handler(url.toString(), opts);
+  };
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+function tokenResponse(accessToken, expiresIn = 3600) {
+  const body = { access_token: accessToken, expires_in: expiresIn };
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+describe('lionbridge auth', () => {
+  beforeEach(() => localStorage.clear());
+
+  afterEach(() => {
+    restoreFetch();
+    localStorage.clear();
+  });
+
+  it('fetches and caches a token on first call', async () => {
+    installFetch(async () => tokenResponse('token-1'));
+
+    const token = await getAccessToken({ org: 'acme', site: 'site1', env: 'prod' });
+
+    expect(token).to.equal('token-1');
+    expect(calls).to.have.length(1);
+    expect(calls[0].url).to.equal(`${LOGIN_ORIGIN}/acme/sites/site1/integrations/lionbridge/login?env=prod`);
+    expect(calls[0].method).to.equal('POST');
+  });
+
+  it('reuses the cached token without refetching while unexpired', async () => {
+    installFetch(async () => tokenResponse('token-1'));
+
+    await getAccessToken({ org: 'acme', site: 'site2', env: 'prod' });
+    const token = await getAccessToken({ org: 'acme', site: 'site2', env: 'prod' });
+
+    expect(token).to.equal('token-1');
+    expect(calls).to.have.length(1);
+  });
+
+  it('refetches once the cached token has expired', async () => {
+    let call = 0;
+    installFetch(async () => {
+      call += 1;
+      return tokenResponse(`token-${call}`);
+    });
+
+    await getAccessToken({ org: 'acme', site: 'site3', env: 'prod' });
+
+    const key = 'lionbridge.acme.site3.prod.token';
+    const stored = JSON.parse(localStorage.getItem(key));
+    localStorage.setItem(key, JSON.stringify({ ...stored, expires: Date.now() - 1000 }));
+
+    const token = await getAccessToken({ org: 'acme', site: 'site3', env: 'prod' });
+
+    expect(token).to.equal('token-2');
+    expect(calls).to.have.length(2);
+  });
+
+  it('caches tokens separately per env', async () => {
+    installFetch(async (url) => tokenResponse(url.includes('env=stage') ? 'stage-token' : 'prod-token'));
+
+    const prodToken = await getAccessToken({ org: 'acme', site: 'site4', env: 'prod' });
+    const stageToken = await getAccessToken({ org: 'acme', site: 'site4', env: 'stage' });
+
+    expect(prodToken).to.equal('prod-token');
+    expect(stageToken).to.equal('stage-token');
+    expect(calls).to.have.length(2);
+  });
+
+  it('defaults env to prod when not specified', async () => {
+    installFetch(async () => tokenResponse('token-1'));
+
+    await getAccessToken({ org: 'acme', site: 'site5' });
+
+    expect(calls[0].url).to.include('env=prod');
+  });
+
+  it('returns null when the login request fails', async () => {
+    installFetch(async () => new Response('', { status: 401 }));
+
+    const token = await getAccessToken({ org: 'acme', site: 'site6', env: 'prod' });
+
+    expect(token).to.equal(null);
+  });
+
+  it('returns null when the response has no access_token', async () => {
+    installFetch(async () => new Response(JSON.stringify({}), { status: 200 }));
+
+    const token = await getAccessToken({ org: 'acme', site: 'site7', env: 'prod' });
+
+    expect(token).to.equal(null);
+  });
+
+  describe('authReady (default export)', () => {
+    it('resolves true when a token is obtained', async () => {
+      installFetch(async () => tokenResponse('token-1'));
+
+      expect(await authReady({ org: 'acme', site: 'site8', env: 'prod' })).to.equal(true);
+    });
+
+    it('resolves false when no token is obtained', async () => {
+      installFetch(async () => new Response('', { status: 500 }));
+
+      expect(await authReady({ org: 'acme', site: 'site9', env: 'prod' })).to.equal(false);
+    });
+  });
+});

--- a/test/loc/lionbridge/connectorGuid.test.js
+++ b/test/loc/lionbridge/connectorGuid.test.js
@@ -1,0 +1,130 @@
+import { expect } from '@esm-bundle/chai';
+import { getOrCreateConnectorGuid } from '../../../nx/blocks/loc/connectors/lionbridge/connectorGuid.js';
+
+let calls;
+let origFetch;
+
+function rawConfig(rows) {
+  return {
+    ':names': ['config'],
+    ':type': 'multi-sheet',
+    config: {
+      total: rows.length,
+      limit: rows.length,
+      offset: 0,
+      data: rows,
+    },
+  };
+}
+
+function installFetch(handler) {
+  calls = [];
+  origFetch = window.fetch;
+  window.fetch = async (url, opts = {}) => {
+    const u = url.toString();
+    calls.push({ url: u, method: opts.method, body: opts.body });
+    return handler(u, opts);
+  };
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+async function bodyToText(body) {
+  // FormData in the test browser exposes entries(); the config file is
+  // appended under the 'data' key as a Blob.
+  const blob = body.get('data');
+  return blob.text();
+}
+
+describe('lionbridge connectorGuid', () => {
+  afterEach(() => restoreFetch());
+
+  it('returns the cached guid on the service object without any network call', async () => {
+    installFetch(() => { throw new Error('should not fetch'); });
+
+    const service = { org: 'acme', site: 'site1', env: 'prod', connectorGuid: 'cached-guid' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.equal('cached-guid');
+    expect(calls).to.have.length(0);
+  });
+
+  it('reads an existing guid from config without writing it back', async () => {
+    installFetch((url) => {
+      if (url.endsWith('.da/translate.json') || url.includes('.da%2Ftranslate.json')) {
+        return new Response(JSON.stringify(rawConfig([
+          { key: 'translation.service.prod.connectorGuid', value: 'existing-guid' },
+        ])), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const service = { org: 'acme', site: 'site2', env: 'prod' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.equal('existing-guid');
+    expect(calls.filter((c) => c.method === 'POST')).to.have.length(0);
+    expect(service.connectorGuid).to.equal('existing-guid');
+  });
+
+  it('generates and persists a new guid when none exists', async () => {
+    installFetch((url) => {
+      if (url.endsWith('.da/translate.json')) {
+        return new Response(JSON.stringify(rawConfig([
+          { key: 'translation.service.name', value: 'Lionbridge' },
+        ])), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const service = { org: 'acme', site: 'site3', env: 'prod' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.be.a('string');
+    expect(guid.length).to.be.greaterThan(0);
+    expect(service.connectorGuid).to.equal(guid);
+
+    const saveCall = calls.find((c) => c.method === 'POST');
+    expect(saveCall, 'save call').to.exist;
+
+    const savedJson = JSON.parse(await bodyToText(saveCall.body));
+    const savedRow = savedJson.config.data.find((row) => row.key === 'translation.service.prod.connectorGuid');
+    expect(savedRow.value).to.equal(guid);
+  });
+
+  it('returns null when the config cannot be read', async () => {
+    installFetch(() => new Response('', { status: 404 }));
+
+    const service = { org: 'acme', site: 'site4', env: 'prod' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.equal(null);
+  });
+
+  it('returns null when the save fails', async () => {
+    installFetch((url, opts) => {
+      if (opts.method === 'POST') return new Response('', { status: 500 });
+      return new Response(JSON.stringify(rawConfig([])), { status: 200 });
+    });
+
+    const service = { org: 'acme', site: 'site5', env: 'prod' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.equal(null);
+    expect(service.connectorGuid).to.equal(undefined);
+  });
+
+  it('defaults env to prod when building the config key', async () => {
+    installFetch(() => new Response(JSON.stringify(rawConfig([
+      { key: 'translation.service.prod.connectorGuid', value: 'prod-guid' },
+    ])), { status: 200 }));
+
+    const service = { org: 'acme', site: 'site6' };
+    const guid = await getOrCreateConnectorGuid(service);
+
+    expect(guid).to.equal('prod-guid');
+  });
+});

--- a/test/loc/lionbridge/index.test.js
+++ b/test/loc/lionbridge/index.test.js
@@ -198,7 +198,7 @@ describe('lionbridge connector', () => {
       });
 
       const jobCall = calls.find((c) => c.url.endsWith('/jobs') && c.method === 'POST');
-      expect(JSON.parse(jobCall.body).connectorName).to.equal('guid-123 DA Live Localization');
+      expect(JSON.parse(jobCall.body).connectorName).to.equal('guid-123 DA Live Localization for Lionbridge');
     });
 
     it('truncates jobName and requestName to 250 bytes', async () => {

--- a/test/loc/lionbridge/index.test.js
+++ b/test/loc/lionbridge/index.test.js
@@ -1,0 +1,416 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  isConnected, connect, sendAllLanguages, getStatusAll, saveItems,
+} from '../../../nx/blocks/loc/connectors/lionbridge/index.js';
+
+const API_ENDPOINT = 'https://api.lionbridge.example.com/v2';
+const UPLOAD_ORIGIN = 'https://upload.example.com';
+
+let calls;
+let origFetch;
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function defaultHandler(url, opts) {
+  if (url.includes('/integrations/lionbridge/login')) {
+    return jsonResponse({ access_token: 'lb-token', expires_in: 3600 });
+  }
+  if (url.startsWith(UPLOAD_ORIGIN)) {
+    return new Response('', { status: 200 });
+  }
+  if (url.includes('/requests/add')) {
+    return jsonResponse({
+      _embedded: { requests: [{ requestId: 'req-fr', targetNativeLanguageCode: 'fr-FR' }] },
+    }, 201);
+  }
+  if (url.includes('/requests/approve')) {
+    return jsonResponse({ _embedded: { requests: [{ requestId: 'req-fr', statusCode: 'TRANSLATION_APPROVED' }] } });
+  }
+  if (url.includes('/retrievefile')) {
+    return new Response('<html><body><main><div>Translated</div></main></body></html>', { status: 200 });
+  }
+  if (url.includes('/submit')) {
+    return jsonResponse({ statusCode: 'SENDING' });
+  }
+  if (url.includes('/sourcefiles')) {
+    return jsonResponse({
+      fmsPostMultipartUrl: `${UPLOAD_ORIGIN}/sas-1`,
+      fmsFileId: 'file-1',
+    }, 201);
+  }
+  if (url.includes('/requests')) {
+    return jsonResponse({
+      _embedded: {
+        requests: [{ requestId: 'req-fr', targetNativeLanguageCode: 'fr-FR', statusCode: 'REVIEW_TRANSLATION' }],
+      },
+    });
+  }
+  if (url.endsWith('/jobs') && opts.method === 'POST') {
+    return jsonResponse({ jobId: 'job-1' }, 201);
+  }
+  // .da/translate.json (connector guid lookup) and anything else unhandled.
+  return jsonResponse({});
+}
+
+function installFetch(handler = defaultHandler) {
+  calls = [];
+  origFetch = window.fetch;
+  window.fetch = async (url, opts = {}) => {
+    const u = url.toString();
+    calls.push({ url: u, method: opts.method, headers: opts.headers, body: opts.body });
+    return handler(u, opts);
+  };
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+function baseService(overrides = {}) {
+  return {
+    org: 'acme',
+    site: 'site1',
+    env: 'prod',
+    apiEndpoint: API_ENDPOINT,
+    providerId: 'provider-1',
+    ...overrides,
+  };
+}
+
+describe('lionbridge connector', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installFetch();
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    localStorage.clear();
+  });
+
+  describe('isConnected / connect', () => {
+    it('resolves true when the login endpoint returns a token', async () => {
+      expect(await isConnected(baseService({ site: 'connect-ok' }))).to.equal(true);
+      expect(await connect(baseService({ site: 'connect-ok-2' }))).to.equal(true);
+    });
+
+    it('resolves false when the login endpoint fails', async () => {
+      installFetch((url) => (url.includes('/login') ? new Response('', { status: 401 }) : jsonResponse({})));
+
+      expect(await isConnected(baseService({ site: 'connect-fail' }))).to.equal(false);
+    });
+  });
+
+  describe('sendAllLanguages', () => {
+    it('creates a job, uploads all urls, and submits — providerId only in the submit body', async () => {
+      const service = baseService({ site: 'send-ok' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const messages = [];
+      const saved = [];
+      const actions = {
+        sendMessage: (m) => messages.push(m),
+        saveState: async (s) => saved.push(s),
+      };
+
+      await sendAllLanguages({
+        title: 'My Project', service, options: {}, langs, urls, actions,
+      });
+
+      const jobCall = calls.find((c) => c.url.endsWith('/jobs') && c.method === 'POST');
+      expect(jobCall, 'createJob call').to.exist;
+      expect(JSON.parse(jobCall.body).providerId).to.equal(undefined);
+
+      const submitCall = calls.find((c) => c.url.includes('/submit'));
+      expect(submitCall, 'submit call').to.exist;
+      expect(JSON.parse(submitCall.body).providerId).to.equal('provider-1');
+
+      expect(langs[0].translation.status).to.equal('created');
+      expect(langs[0].translation.jobId).to.equal('job-1');
+      expect(langs[0].translation.sent).to.equal(1);
+      expect(saved).to.have.length(1);
+      expect(messages[messages.length - 1]).to.equal(undefined);
+    });
+
+    it('marks the language as error when a file fails to upload', async () => {
+      installFetch((url, opts) => {
+        if (url.includes('/sourcefiles')) return new Response('', { status: 500 });
+        return defaultHandler(url, opts);
+      });
+
+      const service = baseService({ site: 'send-upload-fail' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: 'My Project', service, options: {}, langs, urls, actions,
+      });
+
+      expect(langs[0].translation.status).to.equal('error');
+      expect(langs[0].translation.sent).to.equal(0);
+    });
+
+    it('sends a dueDate on the job when project.due is set', async () => {
+      const service = baseService({ site: 'send-due-date' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: 'My Project',
+        service,
+        options: { 'project.due': '2026-12-01T00:00:00.000Z' },
+        langs,
+        urls,
+        actions,
+      });
+
+      const jobCall = calls.find((c) => c.url.endsWith('/jobs') && c.method === 'POST');
+      expect(JSON.parse(jobCall.body).dueDate).to.equal('2026-12-01T00:00:00.000Z');
+    });
+
+    it('prefixes connectorName with the persisted connector guid', async () => {
+      installFetch((url, opts) => {
+        if (url.endsWith('.da/translate.json')) {
+          return jsonResponse({
+            config: {
+              total: 1,
+              limit: 1,
+              offset: 0,
+              data: [{ key: 'translation.service.prod.connectorGuid', value: 'guid-123' }],
+            },
+          });
+        }
+        return defaultHandler(url, opts);
+      });
+
+      const service = baseService({ site: 'send-guid' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: 'My Project', service, options: {}, langs, urls, actions,
+      });
+
+      const jobCall = calls.find((c) => c.url.endsWith('/jobs') && c.method === 'POST');
+      expect(JSON.parse(jobCall.body).connectorName).to.equal('guid-123 DA Live Localization');
+    });
+
+    it('truncates jobName and requestName to 250 bytes', async () => {
+      const service = baseService({ site: 'send-long-names' });
+      const longTitle = 'x'.repeat(500);
+      const longPath = `/${'y'.repeat(500)}`;
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: longPath, content: '<p>hi</p>' }];
+      const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: longTitle, service, options: {}, langs, urls, actions,
+      });
+
+      const jobCall = calls.find((c) => c.url.endsWith('/jobs') && c.method === 'POST');
+      const { jobName } = JSON.parse(jobCall.body);
+      expect(new TextEncoder().encode(jobName).length).to.be.at.most(250);
+
+      const addCall = calls.find((c) => c.url.includes('/requests/add'));
+      const { requestName } = JSON.parse(addCall.body);
+      expect(new TextEncoder().encode(requestName).length).to.be.at.most(250);
+    });
+
+    it('retries once on 429, honoring Retry-After, then succeeds', async () => {
+      let jobPostCount = 0;
+      installFetch((url, opts) => {
+        if (url.endsWith('/jobs') && opts.method === 'POST') {
+          jobPostCount += 1;
+          if (jobPostCount === 1) {
+            return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+          }
+          return jsonResponse({ jobId: 'job-1' }, 201);
+        }
+        return defaultHandler(url, opts);
+      });
+
+      const service = baseService({ site: 'send-retry-429' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: 'My Project', service, options: {}, langs, urls, actions,
+      });
+
+      expect(jobPostCount).to.equal(2);
+      expect(langs[0].translation.jobId).to.equal('job-1');
+    });
+
+    it('gives up after exhausting retries and reports the job as failed', async () => {
+      let jobPostCount = 0;
+      installFetch((url, opts) => {
+        if (url.endsWith('/jobs') && opts.method === 'POST') {
+          jobPostCount += 1;
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.001' } });
+        }
+        return defaultHandler(url, opts);
+      });
+
+      const service = baseService({ site: 'send-retry-exhausted' });
+      const langs = [{ code: 'fr-FR', name: 'French' }];
+      const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+      const messages = [];
+      const actions = { sendMessage: (m) => messages.push(m), saveState: async () => {} };
+
+      await sendAllLanguages({
+        title: 'My Project', service, options: {}, langs, urls, actions,
+      });
+
+      expect(jobPostCount).to.equal(4); // initial attempt + 3 retries
+      expect(messages.some((m) => m?.text === 'Error creating Lionbridge job.')).to.equal(true);
+    });
+  });
+
+  describe('getStatusAll', () => {
+    it('does nothing when no jobId is present on the first lang', async () => {
+      const langs = [{ code: 'fr-FR' }];
+      const actions = {
+        sendMessage: () => { throw new Error('sendMessage should not be called'); },
+        saveState: async () => { throw new Error('saveState should not be called'); },
+      };
+
+      await getStatusAll({ service: baseService(), langs, urls: [], actions });
+
+      expect(langs[0].translation).to.equal(undefined);
+    });
+
+    it('paginates through the next cursor and aggregates all requests', async () => {
+      let call = 0;
+      installFetch((url) => {
+        if (url.includes('/login')) return jsonResponse({ access_token: 'lb-token', expires_in: 3600 });
+        if (url.includes('/requests')) {
+          call += 1;
+          if (call === 1) {
+            return jsonResponse({
+              _embedded: { requests: [{ requestId: 'r1', targetNativeLanguageCode: 'fr-FR', statusCode: 'REVIEW_TRANSLATION' }] },
+              next: 'cursor-2',
+            });
+          }
+          return jsonResponse({
+            _embedded: { requests: [{ requestId: 'r2', targetNativeLanguageCode: 'de-DE', statusCode: 'REVIEW_TRANSLATION' }] },
+          });
+        }
+        return jsonResponse({});
+      });
+
+      const langs = [
+        { code: 'fr-FR', translation: { jobId: 'job-1' } },
+        { code: 'de-DE', translation: { jobId: 'job-1' } },
+      ];
+      const urls = [{ daBasePath: '/page' }];
+      const saved = [];
+      const actions = { sendMessage: () => {}, saveState: async () => { saved.push(true); } };
+
+      await getStatusAll({ service: baseService(), langs, urls, actions });
+
+      expect(call).to.equal(2);
+      const requestsCalls = calls.filter((c) => c.url.includes('/requests') && !c.url.includes('/login'));
+      expect(requestsCalls[1].url).to.include('next=cursor-2');
+      expect(langs[0].translation.status).to.equal('translated');
+      expect(langs[1].translation.status).to.equal('translated');
+      expect(saved).to.have.length(1);
+    });
+  });
+
+  describe('saveItems', () => {
+    it('downloads with Accept: application/octet-stream and passes DNT-stripped content to saveFn', async () => {
+      const saved = [];
+      const url = { daBasePath: '/page', requestIds: { 'fr-FR': 'req-fr' } };
+      const lang = { code: 'fr-FR', translation: { jobId: 'job-1' } };
+
+      await saveItems({
+        org: 'acme',
+        site: 'site1',
+        service: baseService(),
+        lang,
+        urls: [url],
+        saveFn: async (u) => { saved.push(u); u.status = 'success'; },
+      });
+
+      const dlCall = calls.find((c) => c.url.includes('/retrievefile'));
+      expect(dlCall, 'retrievefile call').to.exist;
+      expect(dlCall.headers.Accept).to.equal('application/octet-stream');
+      expect(saved).to.have.length(1);
+      expect(url.sourceContent).to.include('Translated');
+    });
+
+    it('approves the request after a successful download/save', async () => {
+      const url = { daBasePath: '/page', requestIds: { 'fr-FR': 'req-fr' } };
+      const lang = { code: 'fr-FR', translation: { jobId: 'job-1' } };
+
+      await saveItems({
+        org: 'acme',
+        site: 'site1',
+        service: baseService(),
+        lang,
+        urls: [url],
+        saveFn: async (u) => { u.status = 'success'; },
+      });
+
+      const approveCall = calls.find((c) => c.url.includes('/requests/approve'));
+      expect(approveCall, 'approve call').to.exist;
+      expect(JSON.parse(approveCall.body).requestIds).to.deep.equal(['req-fr']);
+      expect(url.status).to.equal('success');
+    });
+
+    it('does not mark the url as error when approval fails after a successful save', async () => {
+      installFetch((url, opts) => {
+        if (url.includes('/requests/approve')) return new Response('', { status: 500 });
+        return defaultHandler(url, opts);
+      });
+
+      const url = { daBasePath: '/page', requestIds: { 'fr-FR': 'req-fr' } };
+      const lang = { code: 'fr-FR', translation: { jobId: 'job-1' } };
+
+      await saveItems({
+        org: 'acme',
+        site: 'site1',
+        service: baseService(),
+        lang,
+        urls: [url],
+        saveFn: async (u) => { u.status = 'success'; },
+      });
+
+      expect(url.status).to.equal('success');
+    });
+
+    it('marks the url as error when there is no requestId for the lang', async () => {
+      const url = { daBasePath: '/page', requestIds: {} };
+      const lang = { code: 'fr-FR', translation: { jobId: 'job-1' } };
+
+      const result = await saveItems({
+        org: 'acme',
+        site: 'site1',
+        service: baseService(),
+        lang,
+        urls: [url],
+        saveFn: async () => {},
+      });
+
+      expect(result[0].status).to.equal('error');
+    });
+
+    it('returns the urls unchanged when the lang has no jobId', async () => {
+      const urls = [{ daBasePath: '/page' }];
+      const lang = { code: 'fr-FR' };
+
+      const result = await saveItems({
+        org: 'acme', site: 'site1', service: baseService(), lang, urls, saveFn: async () => {},
+      });
+
+      expect(result).to.equal(urls);
+    });
+  });
+});

--- a/test/loc/lionbridge/mocks/all-completed.json
+++ b/test/loc/lionbridge/mocks/all-completed.json
@@ -1,0 +1,28 @@
+[
+  {
+    "requestId": "WDw0vInKSQKE_O5sPWFh-A",
+    "jobId": "2KBz5hJPmj",
+    "statusCode": "REVIEW_TRANSLATION",
+    "hasError": false,
+    "targetNativeLanguageCode": "fr-FR",
+    "fileId": "11931fa4-c744-4c86-8517-73ce762bc332",
+    "fileType": "html",
+    "fileName": "test.html",
+    "requestName": "test.html",
+    "sourceNativeId": "/da-nx/test/test.html",
+    "sourceNativeLanguageCode": "en-US"
+  },
+  {
+    "requestId": "OOtM8WSMSe-aO3M69bQ3KQ",
+    "jobId": "2KBz5hJPmj",
+    "statusCode": "REVIEW_TRANSLATION",
+    "hasError": false,
+    "targetNativeLanguageCode": "de-DE",
+    "fileId": "11931fa4-c744-4c86-8517-73ce762bc332",
+    "fileType": "html",
+    "fileName": "test.html",
+    "requestName": "test.html",
+    "sourceNativeId": "/da-nx/test/test.html",
+    "sourceNativeLanguageCode": "en-US"
+  }
+]

--- a/test/loc/lionbridge/mocks/lang-canceled.json
+++ b/test/loc/lionbridge/mocks/lang-canceled.json
@@ -1,0 +1,15 @@
+[
+  {
+    "requestId": "req-fr-3",
+    "jobId": "job-3",
+    "statusCode": "CANCELLED",
+    "hasError": false,
+    "targetNativeLanguageCode": "fr-FR",
+    "fileId": "file-3",
+    "fileType": "html",
+    "fileName": "page-3.html",
+    "requestName": "page-3.html",
+    "sourceNativeId": "/da-nx/test/page-3.html",
+    "sourceNativeLanguageCode": "en-US"
+  }
+]

--- a/test/loc/lionbridge/mocks/lang-partial.json
+++ b/test/loc/lionbridge/mocks/lang-partial.json
@@ -1,0 +1,28 @@
+[
+  {
+    "requestId": "req-fr-1",
+    "jobId": "job-1",
+    "statusCode": "SENT_TO_PROVIDER",
+    "hasError": false,
+    "targetNativeLanguageCode": "fr-FR",
+    "fileId": "file-1",
+    "fileType": "html",
+    "fileName": "page-1.html",
+    "requestName": "page-1.html",
+    "sourceNativeId": "/da-nx/test/page-1.html",
+    "sourceNativeLanguageCode": "en-US"
+  },
+  {
+    "requestId": "req-de-1",
+    "jobId": "job-1",
+    "statusCode": "REVIEW_TRANSLATION",
+    "hasError": false,
+    "targetNativeLanguageCode": "de-DE",
+    "fileId": "file-1",
+    "fileType": "html",
+    "fileName": "page-1.html",
+    "requestName": "page-1.html",
+    "sourceNativeId": "/da-nx/test/page-1.html",
+    "sourceNativeLanguageCode": "en-US"
+  }
+]

--- a/test/loc/lionbridge/mocks/lang-rejected.json
+++ b/test/loc/lionbridge/mocks/lang-rejected.json
@@ -1,0 +1,29 @@
+[
+  {
+    "requestId": "req-fr-2",
+    "jobId": "job-2",
+    "statusCode": "TRANSLATION_REJECTED",
+    "hasError": true,
+    "latestErrorMessage": "Rejected by reviewer.",
+    "targetNativeLanguageCode": "fr-FR",
+    "fileId": "file-2",
+    "fileType": "html",
+    "fileName": "page-2.html",
+    "requestName": "page-2.html",
+    "sourceNativeId": "/da-nx/test/page-2.html",
+    "sourceNativeLanguageCode": "en-US"
+  },
+  {
+    "requestId": "req-de-2",
+    "jobId": "job-2",
+    "statusCode": "REVIEW_TRANSLATION",
+    "hasError": false,
+    "targetNativeLanguageCode": "de-DE",
+    "fileId": "file-2",
+    "fileType": "html",
+    "fileName": "page-2.html",
+    "requestName": "page-2.html",
+    "sourceNativeId": "/da-nx/test/page-2.html",
+    "sourceNativeLanguageCode": "en-US"
+  }
+]

--- a/test/loc/lionbridge/statusFor.test.js
+++ b/test/loc/lionbridge/statusFor.test.js
@@ -1,0 +1,78 @@
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+import { statusFor } from '../../../nx/blocks/loc/connectors/lionbridge/index.js';
+
+async function loadMock(name) {
+  const text = await readFile({ path: `./mocks/${name}.json` });
+  return JSON.parse(text);
+}
+
+let allCompleted;
+let langPartial;
+let langRejected;
+let langCanceled;
+
+before(async () => {
+  [allCompleted, langPartial, langRejected, langCanceled] = await Promise.all([
+    loadMock('all-completed'),
+    loadMock('lang-partial'),
+    loadMock('lang-rejected'),
+    loadMock('lang-canceled'),
+  ]);
+});
+
+describe('statusFor', () => {
+  it('should return translated when all requests reach REVIEW_TRANSLATION (fr-FR)', () => {
+    const result = statusFor(allCompleted, 'fr-FR', 1);
+    expect(result.status).to.equal('translated');
+    expect(result.translated).to.equal(1);
+  });
+
+  it('should return translated when all requests reach REVIEW_TRANSLATION (de-DE)', () => {
+    const result = statusFor(allCompleted, 'de-DE', 1);
+    expect(result.status).to.equal('translated');
+    expect(result.translated).to.equal(1);
+  });
+
+  it('should return in progress when a lang has not reached a ready status', () => {
+    const result = statusFor(langPartial, 'fr-FR', 1);
+    expect(result.status).to.equal('in progress');
+    expect(result.translated).to.equal(0);
+  });
+
+  it('should return translated for a lang that is ready, independent of others', () => {
+    const result = statusFor(langPartial, 'de-DE', 1);
+    expect(result.status).to.equal('translated');
+    expect(result.translated).to.equal(1);
+  });
+
+  it('should return in progress for an empty requests array', () => {
+    const result = statusFor([], 'de-DE', 1);
+    expect(result.status).to.equal('in progress');
+    expect(result.translated).to.equal(0);
+  });
+
+  it('should return error when a lang request was rejected', () => {
+    const result = statusFor(langRejected, 'fr-FR', 1);
+    expect(result.status).to.equal('error');
+    expect(result.translated).to.equal(0);
+  });
+
+  it('should not be affected by another language being rejected', () => {
+    const result = statusFor(langRejected, 'de-DE', 1);
+    expect(result.status).to.equal('translated');
+    expect(result.translated).to.equal(1);
+  });
+
+  it('should return canceled when a lang request was cancelled', () => {
+    const result = statusFor(langCanceled, 'fr-FR', 1);
+    expect(result.status).to.equal('canceled');
+    expect(result.translated).to.equal(0);
+  });
+
+  it('should return in progress when fileCount exceeds ready requests', () => {
+    const result = statusFor(allCompleted, 'de-DE', 5);
+    expect(result.status).to.equal('in progress');
+    expect(result.translated).to.equal(1);
+  });
+});

--- a/test/loc/utils/fetchWithRetry.test.js
+++ b/test/loc/utils/fetchWithRetry.test.js
@@ -1,0 +1,99 @@
+import { expect } from '@esm-bundle/chai';
+import fetchWithRetry from '../../../nx/blocks/loc/utils/fetchWithRetry.js';
+
+let origFetch;
+
+function installFetch(handler) {
+  origFetch = window.fetch;
+  window.fetch = handler;
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+describe('fetchWithRetry', () => {
+  afterEach(() => restoreFetch());
+
+  it('returns the response immediately when it is not retryable', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(1);
+  });
+
+  it('retries a 429, honoring Retry-After, then succeeds', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('retries a 503 with exponential backoff when there is no Retry-After', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 503 });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { baseDelayMs: 5, maxDelayMs: 20 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('gives up after maxRetries and returns the last failing response', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 429, headers: { 'Retry-After': '0.001' } });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { maxRetries: 2 });
+
+    expect(resp.status).to.equal(429);
+    expect(calls).to.equal(3); // initial attempt + 2 retries
+  });
+
+  it('does not retry statuses outside the default retryable set', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 404 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(404);
+    expect(calls).to.equal(1);
+  });
+
+  it('honors a custom isRetryable predicate', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 418, headers: { 'Retry-After': '0.001' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { isRetryable: (status) => status === 418 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
Continues the Lionbridge translation connector work from #651 (thanks @ravuthu). Fixes found by testing against the real Lionbridge Content API v2 and the real DA Translate app UI, plus compliance work against Lionbridge's dev guidelines, plus test parity with the other connectors (Trados/Smartling).

**Bug fixes (found via live API testing, not caught by mocked tests):**
- `providerId` must be sent on `submit`, not `createJob` — the API silently drops it on `POST /jobs`, then rejects `submit` with `"Job is missing providerId"`.
- `retrievefile` needs `Accept: application/octet-stream`, not the default `application/json` (403s otherwise). Other endpoints are unaffected.
- `auth.js` now resolves the da-etc origin via the shared `DA_ETC` export (env-override support via `?da-etc=`) instead of a hardcoded URL — needed to actually test this locally, and a real correctness fix regardless.

**Compliance with [Lionbridge's dev guidelines](https://developers.lionbridge.com/content/v2/docs/dev_guidelines.html):**
- Rate-limit handling: retry 429/503 with exponential backoff, honoring `Retry-After`.
- `jobName`/`requestName` truncated to the 250-byte limit.
- Generate and persist a per org/site/env connector GUID (in `.da/translate.json`, written once), prefixed onto `connectorName` per their connector-fingerprinting requirement.
- Call the `approve` endpoint after a successful download/save, closing out the request in Lionbridge's review workflow (`REVIEW_TRANSLATION` → `TRANSLATION_APPROVED`).
- No `cancelTranslation` export — their guidelines explicitly prohibit connectors from letting users cancel in-progress jobs; documented inline.

**Test parity:**
- Added `auth.test.js`, `connectorGuid.test.js`, and full `index.test.js` coverage for `sendAllLanguages`/`getStatusAll`/`saveItems`/`connect` (previously only `statusFor` had tests), matching Trados/Smartling's depth.
- Two tests directly regression-lock the `providerId` and `Accept`-header bugs above.

## Verification
- Standalone scripts against real Lionbridge staging APIs: full `sendAllLanguages` chain (createJob → upload → addRequest → submit), `getStatusAll`, `saveItems`/`retrievefile`, and `approve`.
- Full end-to-end through the real DA Translate app UI (`da.live/apps/loc`) against a real test site (`scdemos/lionbridge-demo` — new GitHub repo + AEM Code Sync + DA content), with the backend (`da-sites/da-etc#2`) running locally via `?da-etc=local`: created a project, sent a real page for translation, polled status to completion, and confirmed the translated copy landed at `/fr/test-page.html`.
- `npm test` (1236 tests) and lint pass.

## Documentation
Lionbridge was missing from the public docs.da.live connector documentation. The following pages have draft updates pending publish (not yet live):
- [Connecting to a Translation Service](https://da.live/edit#/da-pilot/docket/administrators/guides/setup-translation/translation-service-connection) — added an "Available connectors" list (was previously silent on which connectors exist) and fixed the minimal-API description, which named a nonexistent `getItems()` instead of the `saveItems()` every real connector implements
- [Setup translation (parent)](https://da.live/edit#/da-pilot/docket/administrators/guides/setup-translation)
- [Localization reference (parent)](https://da.live/edit#/da-pilot/docket/administrators/reference/localization)
- [Sample loc configs](https://da.live/edit#/da-pilot/docket/administrators/reference/localization/sample-loc-configs) — added a "Language-based Lionbridge config" section alongside the existing Google/Smartling/Trados samples
- [Sample Lionbridge translate.json](https://da.live/sheet#/da-pilot/docket/administrators/reference/translation-configs/default-lionbridge/translate) — new downloadable reference config, mirroring the Trados sample's structure with real verified `authEndpoint`/`apiEndpoint` values

## Dependency
This connector can't authenticate against a real Lionbridge account until [da-sites/da-etc#2](https://github.com/da-sites/da-etc/pull/2) merges.

Marking as draft pending final review pass.