### PR TITLE
fix: retry Smartling API calls on 429/5xx to avoid batch-job failures

### DIFF
--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -1,6 +1,7 @@
 import { Queue } from '../../../../../nx2/public/utils/tree.js';
 import { addDnt, removeDnt } from '../../dnt/dnt.js';
 import { DA_TRANSLATE } from '../../../../../nx2/utils/utils.js';
+import fetchWithRetry from '../../utils/fetchWithRetry.js';
 
 export const dnt = { addDnt };
 
@@ -46,7 +47,7 @@ function refreshTheToken(name, env, endpoint) {
     const body = JSON.stringify({ refreshToken: currRefreshToken });
     const opts = { ...BASE_OPTS, body };
 
-    const resp = await fetch(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
     if (!resp.ok) token = undefined;
     const json = await resp.json();
 
@@ -84,7 +85,7 @@ export async function connect(service) {
 
   const opts = { ...BASE_OPTS, body };
 
-  const resp = await fetch(`${endpoint}/auth-api/v2/authenticate`, opts);
+  const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate`, opts);
   if (!resp.ok) return false;
   const json = await resp.json();
   const { accessToken, refreshToken } = json?.response?.data || {};
@@ -111,7 +112,7 @@ async function uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls) {
 
     const opts = { method: 'POST', body, headers: { Authorization: `Bearer ${token}` } };
 
-    const resp = await fetch(uploadUrl, opts);
+    const resp = await fetchWithRetry(uploadUrl, opts);
     const json = await resp.json();
     results.push(json.response.code);
   }
@@ -129,7 +130,7 @@ async function createJob(endpoint, projectId, title, langs) {
   opts.headers.Authorization = `Bearer ${token}`;
 
   const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs`;
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { translationJobUid: jobUid } = json.response.data;
@@ -148,7 +149,7 @@ async function createBatch(endpoint, projectId, jobUid, urls) {
 
   const url = `${endpoint}/job-batches-api/v2/projects/${projectId}/batches`;
 
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { batchUid } = json.response.data;
@@ -159,7 +160,7 @@ async function downloadFile(opts, origin, projectId, lang, url) {
   const reqUrl = new URL(`${origin}/files-api/v2/projects/${projectId}/locales/${lang.code}/file`);
   reqUrl.searchParams.append('fileUri', url.daBasePath);
 
-  const resp = await fetch(reqUrl, opts);
+  const resp = await fetchWithRetry(reqUrl, opts);
   return resp.text();
 }
 
@@ -263,7 +264,7 @@ export async function getStatusAll({
   langs.forEach((lang) => { lang.translation.translated = 0; });
 
   for (const url of urls) {
-    const resp = await fetch(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
     const { response } = await resp.json();
     if (response.code !== 'SUCCESS') return;
     const langReports = response?.data?.contentProgressReport;

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -2,6 +2,11 @@ const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_BASE_DELAY_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 30000;
 
+/**
+ * Default retry predicate: rate-limited or server-error responses.
+ * @param {number} status - The response's HTTP status code.
+ * @returns {boolean} Whether the status should trigger a retry.
+ */
 function isDefaultRetryable(status) {
   return status === 429 || status >= 500;
 }
@@ -41,6 +46,12 @@ export default async function fetchWithRetry(url, opts, config = {}) {
     isRetryable = isDefaultRetryable,
   } = config;
 
+  /**
+   * Makes one fetch attempt, retrying itself (with a delay) if the
+   * response is retryable and attempts remain.
+   * @param {number} attemptNum - Zero-based attempt count so far.
+   * @returns {Promise<Response>} The final response (ok or not).
+   */
   async function attempt(attemptNum) {
     const resp = await fetch(url, opts);
     if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -1,0 +1,60 @@
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+function isDefaultRetryable(status) {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Resolves after the given delay.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Fetches, retrying on rate-limit/transient-failure responses with
+ * exponential backoff and jitter, honoring a Retry-After header when the
+ * service provides one. Shared across loc connectors (Smartling,
+ * Lionbridge, ...) whose translation APIs enforce request-rate and/or
+ * concurrent-request limits.
+ * @param {string|URL} url - The request URL.
+ * @param {Object} opts - Fetch options.
+ * @param {Object} [config]
+ * @param {number} [config.maxRetries] - Max retry attempts after the
+ *  initial request.
+ * @param {number} [config.baseDelayMs] - Base delay before the first
+ *  retry; doubles each subsequent attempt.
+ * @param {number} [config.maxDelayMs] - Delay cap, before jitter.
+ * @param {(status: number) => boolean} [config.isRetryable] - Whether a
+ *  response status should trigger a retry. Defaults to 429 and 5xx.
+ * @returns {Promise<Response>} The final response (ok or not).
+ */
+export default async function fetchWithRetry(url, opts, config = {}) {
+  const {
+    maxRetries = DEFAULT_MAX_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    isRetryable = isDefaultRetryable,
+  } = config;
+
+  async function attempt(attemptNum) {
+    const resp = await fetch(url, opts);
+    if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;
+
+    const retryAfterSecs = Number(resp.headers.get('retry-after'));
+    const backoff = Math.min(baseDelayMs * (2 ** attemptNum), maxDelayMs);
+    const jitter = Math.random() * backoff * 0.3;
+    const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+      ? retryAfterSecs * 1000
+      : backoff + jitter;
+
+    await wait(delayMs);
+    return attempt(attemptNum + 1);
+  }
+
+  return attempt(0);
+}

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -39,14 +39,23 @@ class NxLocTranslate extends LitElement {
     super.update();
   }
 
+  /**
+   * Sets up the connector for this project's translation service.
+   *
+   * Augments (does not copy) `this.project.options.service` so that
+   * `this._service` stays the same object connectors mutate — e.g.
+   * Smartling's `sendAllLanguages` sets `service.jobUid` after this runs.
+   * A spread/copy here would leave `this._service` permanently stale for
+   * any property a connector adds after initial setup, until the next
+   * full page load rebuilds it from the freshly persisted project.
+   * @returns {Promise<void>}
+   */
   async setupService() {
-    const connector = await setupConnector(this.project.options.service);
-    this._service = {
-      ...this.project.options.service,
-      connector,
-      org: this.project.org,
-      site: this.project.site,
-    };
+    const { service } = this.project.options;
+    service.connector = await setupConnector(service);
+    service.org = this.project.org;
+    service.site = this.project.site;
+    this._service = service;
     this._connected = await this._service.connector.isConnected(this._service);
   }
 

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -120,4 +120,69 @@ describe('smartling connector - legacy origin rewriting', () => {
     const call = calls.find((c) => c.url.includes('/files-api/v2/projects'));
     expect(call.url).to.include(`${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/locales/fr-FR/file`);
   });
+
+  it('retries a 429 from getStatusAll progress polling before succeeding', async () => {
+    let progressCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/progress')) {
+        progressCalls += 1;
+        if (progressCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response(JSON.stringify({
+          response: {
+            code: 'SUCCESS',
+            data: { contentProgressReport: [{ targetLocaleId: 'fr-FR', progress: null }] },
+          },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(progressCalls).to.equal(2);
+    expect(langs[0].translation.status).to.equal('translated');
+  });
+
+  it('retries a 429 from saveItems file download before succeeding', async () => {
+    let downloadCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/files-api/v2/projects')) {
+        downloadCalls += 1;
+        if (downloadCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response('translated content', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const lang = { code: 'fr-FR' };
+    const urls = [{ daBasePath: '/page', ext: 'html' }];
+    const saveFn = async (url) => { url.status = 'success'; };
+
+    await saveItems({
+      org, site, service, lang, urls, saveFn,
+    });
+
+    expect(downloadCalls).to.equal(2);
+    expect(urls[0].status).to.equal('success');
+  });
 });

--- a/test/loc/utils/fetchWithRetry.test.js
+++ b/test/loc/utils/fetchWithRetry.test.js
@@ -1,0 +1,99 @@
+import { expect } from '@esm-bundle/chai';
+import fetchWithRetry from '../../../nx/blocks/loc/utils/fetchWithRetry.js';
+
+let origFetch;
+
+function installFetch(handler) {
+  origFetch = window.fetch;
+  window.fetch = handler;
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+describe('fetchWithRetry', () => {
+  afterEach(() => restoreFetch());
+
+  it('returns the response immediately when it is not retryable', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(1);
+  });
+
+  it('retries a 429, honoring Retry-After, then succeeds', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('retries a 503 with exponential backoff when there is no Retry-After', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 503 });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { baseDelayMs: 5, maxDelayMs: 20 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('gives up after maxRetries and returns the last failing response', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 429, headers: { 'Retry-After': '0.001' } });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { maxRetries: 2 });
+
+    expect(resp.status).to.equal(429);
+    expect(calls).to.equal(3); // initial attempt + 2 retries
+  });
+
+  it('does not retry statuses outside the default retryable set', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 404 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(404);
+    expect(calls).to.equal(1);
+  });
+
+  it('honors a custom isRetryable predicate', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 418, headers: { 'Retry-After': '0.001' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { isRetryable: (status) => status === 418 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
The Smartling connector had no retry/backoff logic anywhere, so any `429` (rate limit) or transient `5xx` from Smartling's API failed the call outright. Two spots make this especially likely during larger batch jobs:

- `getStatusAll` polls `/file/progress` once per url in a tight sequential loop, no delay, no retry.
- `saveItems` downloads translated files 5-at-a-time via a concurrency-5 `Queue`.

Per [Smartling's own docs](https://help.smartling.com/hc/en-us/articles/1260805145550-Rate-Limits) (via search — the page itself sits behind a Cloudflare challenge), they enforce **two separate limits**: a request-rate limit and a concurrent-request limit, scoped per user/project/account depending on endpoint. Recommended handling is exponential backoff with jitter, capped at 30–60s, 5–10 max retries.

## Changes
- New shared `nx/blocks/loc/utils/fetchWithRetry.js`: exponential backoff + jitter, honors `Retry-After` when present, configurable `maxRetries`/`baseDelayMs`/`maxDelayMs`/`isRetryable` (defaults: 5 retries, 500ms base, 30s cap, retries on 429 and 5xx).
- Every `fetch` call in the Smartling connector now goes through it.
- Built as a shared utility rather than a one-off, since Lionbridge's connector (#656) needed the identical fix — that PR has been updated to use this same utility instead of its own inline copy, rather than maintain two copies.
- **Bug fix found during live verification** (`nx/blocks/loc/views/translate/translate.js`): `setupService()` built `this._service` via a spread/copy of `this.project.options.service`, taken once when the Translate view connects, before any job exists. Smartling's `sendAllLanguages` later sets `jobUid` directly on the original object; the copy never saw it, so `getStatusAll` crashed (`Cannot read properties of undefined (reading 'value')`) if you checked status in the same session without a page reload in between. Fixed to augment/reference the same object instead of copying it. Not Smartling-specific — affects any connector storing request state on `service` rather than per-lang.

## Tests
- New `test/loc/utils/fetchWithRetry.test.js`: retry-then-succeed on 429 (honoring `Retry-After`) and on 503 (exponential backoff), gives up after `maxRetries`, ignores non-retryable statuses, custom `isRetryable` override.
- Two new regression tests in the Smartling suite confirming `getStatusAll` and `saveItems` actually retry a 429 and succeed on the next attempt.
- Full `npm test` (1204 tests) and lint pass.

## Verification
Full end-to-end through the real DA Translate app UI (`da.live/apps/loc`) against a real test site (`scdemos/smartling-demo` — new GitHub repo + AEM Code Sync + DA content) and a real Smartling project (project-scoped API token, per Smartling's own recommendation for dev/testing): created a project, sent a real page for translation, checked status, and confirmed real machine-translated French content landed at `/fr/test-page.html` (not just an echo — genuinely translated by Smartling).

Also confirmed along the way that Smartling's connector must go through the `https://translate.da.live` proxy (never `api.smartling.com` directly from the browser — that hits a CORS block), which `resolveOrigin`'s legacy-rewrite logic already assumes but isn't otherwise documented anywhere.

Marking as draft pending final review pass.