### PR TITLE
feat: plan and tasks on top of new events model

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,24 @@
 # Worklog
 
+## 2026-08-12
+
+### nx2/blocks/chat — port plan/task/governance client onto the #648 AO architecture
+
+Rebuilt the plan-mode client (originally PR #522, `feat/plan-tasks`, written against the pre-#648 `ChatController` + inline-approval-card design) on top of the #648 "ao support via config" architecture (`ChatBackend` facade + `<nx-chat-interaction>` + adapter-shaped tool cards). #522 could not be merged mechanically — the two branches independently implemented plan/approval with incompatible structures. This branch (`feat/plan-tasks-on-648`) supersedes #522 and is the matching client for da-agent #49 (`enter_plan_mode`/`exit_plan_mode` + `data-continuation` + `:::task-item`).
+
+What it delivers, mapped to da-agent #49's server behaviour:
+- **Plan card**: `exit_plan_mode` (approval-gated, carries `{title,tasks[]}`) renders inline in the message stream as `<nx-campaign-plan-card>` in every state, Run wired to `approveToolCall`. `renderers.js#renderToolCard` special-cases it; `chat-backend.js#_daAgentPendingApproval` excludes `exit_plan_mode` so it isn't also shown as a generic bottom approval popover.
+- **Task progress**: `chat.js#_taskText` concatenates all assistant text; `mergeTaskItemsFromText` (utils/directives.js) merges `:::task-item` status into the plan card by label (last-wins) → Run→Running…→Done.
+- **Continuation gate**: continuation-gate backend ported into `chat-controller.js` (`AGENT_EVENT.CONTINUATION`, `_continuationPendingIds`, `continuationPending` on derived cards, `continueExecution`/`stopExecution`) and `utils/stream.js` (forward `data-continuation`). `chat-backend.js#_normalize` derives a `{type:'continuation'}` `pendingInteraction`; `<nx-chat-interaction>` renders a Continue/Stop card (Enter/Esc); `card-renderers.js#renderContinuationCard`.
+- **Governance card**: `evaluate_page` output → `<nx-governance-evaluation-card>` (loading/error/result) via `renderToolCard`.
+
+Design notes / decisions:
+- Kept the da-agent tool-card rendering in `renderers.js` (which #648 preserved for the da-agent path); only `card-renderers.js` gained the neutral `renderContinuationCard`. AO path untouched.
+- `renderMessageContent` still renders directive plan/task-list/governance-evaluation cards for parity, but da-agent main only emits `:::task-item` as text (plan comes via the `exit_plan_mode` tool); the directive renderers are harmless if unused.
+- Purely additive over `origin/main` (~+2184/−19 in the chat block). 150/150 chat tests pass; ESLint + Stylelint clean. Brought in #522's `messages/*` card components + CSS and `utils/directives.js`/`utils/tool-name.js` verbatim (already tested).
+
+Related da-agent work (separate repo/PR): `hotfix/disable-evaluate-continuation-gate` temporarily disables governance's `continuationApprovalPatterns` in prod (the pre-this-client `main` had no UI to service `data-continuation`, so it hung the turn). Once this client ships, revert that hotfix to re-enable the gate.
+
 ## 2026-08-07
 
 ### nx2/utils/api.js — remove stage-content.da.live rewrite workaround

--- a/nx2/blocks/chat/chat-backend.js
+++ b/nx2/blocks/chat/chat-backend.js
@@ -1,6 +1,7 @@
 import ChatController from './chat-controller.js';
 import ChatControllerAO from './ao/chat-controller-ao.js';
-import { TOOL_INPUT, TOOL_STATE } from './constants.js';
+import { TOOL_INPUT, TOOL_NAME, TOOL_STATE } from './constants.js';
+import { mcpToolName } from './utils/tool-name.js';
 
 // da-agent's own tool-input schema field names (see constants.js's TOOL_INPUT) — used
 // only here, to compute the approval-popover summary for da-agent's controller, since
@@ -49,27 +50,44 @@ export default class ChatBackend {
       toolCards, pendingApproval, pendingQuestion, pendingPlanApproval, ...rest
     } = payload;
     const approval = this._useAo ? pendingApproval : this._daAgentPendingApproval(toolCards);
+    // Continuation is da-agent-only (its controller sets card.continuationPending); AO has
+    // no equivalent, so it's never derived when wrapping AO.
+    const continuation = this._useAo ? null : this._daAgentPendingContinuation(toolCards);
     const pendingInteraction = this._pendingInteraction(
       approval,
       pendingQuestion,
       pendingPlanApproval,
+      continuation,
     );
     return { ...rest, toolCards, pendingInteraction };
   }
 
-  _pendingInteraction(approval, question, plan) {
+  _pendingInteraction(approval, question, plan, continuation) {
     if (approval) return { type: 'approval', ...approval };
     if (question) return { type: 'question', ...question };
     if (plan) return { type: 'plan', ...plan };
+    if (continuation) return { type: 'continuation', ...continuation };
     return null;
   }
 
+  // exit_plan_mode is intentionally excluded: its plan card renders inline in the message
+  // stream (renderers.js) with its own Run→approve control, so it must not also surface as
+  // a generic approval popover here.
   _daAgentPendingApproval(toolCards) {
     if (!toolCards) return null;
     for (const [toolCallId, card] of toolCards) {
-      if (card.state === TOOL_STATE.AWAITING_APPROVAL) {
+      if (card.state === TOOL_STATE.AWAITING_APPROVAL
+        && mcpToolName(card.toolName) !== TOOL_NAME.EXIT_PLAN_MODE) {
         return { toolCallId, toolName: card.toolName, summary: daAgentApprovalSummary(card.input) };
       }
+    }
+    return null;
+  }
+
+  _daAgentPendingContinuation(toolCards) {
+    if (!toolCards) return null;
+    for (const [toolCallId, card] of toolCards) {
+      if (card.continuationPending) return { toolCallId };
     }
     return null;
   }
@@ -91,6 +109,11 @@ export default class ChatBackend {
   }
 
   approveToolCall = (...args) => this._controller.approveToolCall(...args);
+
+  // Continuation gate (da-agent only): no-ops when wrapping AO's controller.
+  continueExecution = () => this._controller.continueExecution?.();
+
+  stopExecution = () => this._controller.stopExecution?.();
 
   clear() {
     return this._controller.clear();

--- a/nx2/blocks/chat/chat-controller.js
+++ b/nx2/blocks/chat/chat-controller.js
@@ -154,6 +154,8 @@ export default class ChatController {
           output: part.output,
           errorText: part.errorText,
           approvalRequired: part.approvalRequired,
+          // Ephemeral, transient continuation prompt (never persisted in message history).
+          continuationPending: this._continuationPendingIds?.has(part.toolCallId) ?? false,
         });
       });
     });
@@ -278,6 +280,19 @@ export default class ChatController {
       return;
     }
 
+    // Post-execution continuation gate: the tool already finished (its result is shown)
+    // and the server ended the turn. Flag it as awaiting a Continue/Stop decision.
+    // Ephemeral (UI-only) — nothing is pushed to _messages, so a reload simply drops the
+    // prompt while the result persists.
+    if (type === AGENT_EVENT.CONTINUATION) {
+      const existing = this._findToolPart(toolCallId);
+      if (!existing) return;
+      this._continuationPendingIds ??= new Set();
+      this._continuationPendingIds.add(toolCallId);
+      this._update();
+      return;
+    }
+
     // The agent gates this call behind user approval. Auto-approved tools skip
     // the queue and join the next batch directly.
     if (type === AGENT_EVENT.TOOL_APPROVAL_REQUEST) {
@@ -373,6 +388,42 @@ export default class ChatController {
     } finally {
       this._done();
     }
+  };
+
+  /** Clear the ephemeral continuation-pending flags (never persisted). */
+  _clearContinuationPending() {
+    this._continuationPendingIds?.clear();
+  }
+
+  // Continuation gate — user chose "Continue": resume the agentic loop. The gated tool's
+  // result is already persisted for the current turn, so re-streaming replays it to the
+  // agent (keeping the same turnId) and the model picks up where it left off.
+  continueExecution = async () => {
+    this._clearContinuationPending();
+    this._thinking = true;
+    this._update();
+    try {
+      await this._stream(this._pageContextForAgent());
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        this._messages = [...this._messages, { role: ROLE.ASSISTANT, content: `Error: ${err.message}` }];
+      }
+    } finally {
+      this._done();
+    }
+  };
+
+  // Continuation gate — user chose "Stop": record the decision as a user message and halt.
+  // No re-stream and no assistant reply — the turn simply ends (code-driven, not the LLM).
+  stopExecution = async () => {
+    this._clearContinuationPending();
+    this._messages = [
+      ...this._messages,
+      { role: ROLE.USER, content: 'User decided not to continue further.' },
+    ];
+    this._update();
+    const room = await this._getRoom();
+    saveMessages(room, this._messages, this._sessionId);
   };
 
   // Prune prior-turn non-gated tool reads to bound payload size, mirroring the

--- a/nx2/blocks/chat/chat.js
+++ b/nx2/blocks/chat/chat.js
@@ -520,6 +520,17 @@ class NxChat extends LitElement {
     await this._onFilesSelected(accepted);
   }
 
+  // All assistant text across the turn, concatenated in order, so :::task-item directives
+  // emitted across separate messages/steps can all be found and merged into the plan card
+  // (mergeTaskItemsFromText keys by label, last status wins). Includes the in-progress
+  // streaming message (appended to `messages` by onUpdate), so status updates live-render.
+  get _taskText() {
+    return (this.messages ?? [])
+      .filter((m) => m.role === ROLE.ASSISTANT && typeof m.content === 'string')
+      .map((m) => m.content)
+      .join('\n') || null;
+  }
+
   render() {
     const { view } = this._context ?? {};
     const prompts = (this._prompts ?? [])
@@ -565,7 +576,12 @@ class NxChat extends LitElement {
             return renderUiArtifact(msg.uiArtifact, (p) => this._sendPrompt(p, { autoSend: true }));
           }
           if (msg.toolCard) return renderToolCard(msg.toolCard);
-          return renderMessage(msg, this.toolCards);
+          return renderMessage(msg, this.toolCards, {
+            streamingText: this._taskText,
+            onApprove: (id, approved, always) => (
+              this._controller.approveToolCall(id, approved, always)
+            ),
+          });
         })}
         ${this.thinking && !this.messages?.at(-1)?.streaming && !this.pendingInteraction
         ? html`<div class="chat-thinking">Thinking...</div>` : nothing}
@@ -586,6 +602,8 @@ class NxChat extends LitElement {
           .onDeclineQuestion=${() => this._controller.declineQuestion()}
           .onApprovePlan=${() => this._controller.respondToPlanApproval('approve')}
           .onRejectPlan=${(feedback) => this._controller.respondToPlanApproval('reject', feedback)}
+          .onContinue=${() => this._controller.continueExecution()}
+          .onStop=${() => this._controller.stopExecution()}
         ></nx-chat-interaction>
         <form class="chat-form" autocomplete="off" @submit=${this._submit}
           @dragenter=${this._onDragEnter}

--- a/nx2/blocks/chat/constants.js
+++ b/nx2/blocks/chat/constants.js
@@ -33,6 +33,9 @@ const AGENT_EVENT = {
   // Result of an executed tool.
   TOOL_OUTPUT_AVAILABLE: 'tool-output-available',
   TOOL_OUTPUT_ERROR: 'tool-output-error',
+  // Transient (UI-only, never persisted) part emitted after a continuation-gated tool
+  // finishes, so the user can review results and decide whether the agent continues.
+  CONTINUATION: 'data-continuation',
 };
 
 /**
@@ -69,6 +72,9 @@ const TOOL_NAME = {
   CONTENT_MOVE: 'content_move',
   CONTENT_UPDATE: 'content_update',
   CONTENT_UPLOAD: 'content_upload',
+  ENTER_PLAN_MODE: 'enter_plan_mode',
+  EXIT_PLAN_MODE: 'exit_plan_mode',
+  EVALUATE_PAGE: 'evaluate_page',
 };
 
 /**
@@ -101,6 +107,29 @@ const ROLE = {
 };
 
 /**
+ * Directive fence types that map to rich interactive renderer components.
+ * These are emitted by da-agent inside :::type ... ::: fences in text-delta events.
+ */
+const DIRECTIVE_TYPE = {
+  PLAN: 'plan',
+  TASK_LIST: 'task-list',
+  TASK_ITEM: 'task-item',
+  GOVERNANCE_EVALUATION: 'governance-evaluation',
+};
+
+/**
+ * Task status values shared across plan/task-list/task-item components.
+ * Matches values sent in :::plan / :::task-list / :::task-item directive payloads.
+ */
+const TASK_STATUS = {
+  PENDING: 'pending',
+  RUNNING: 'running',
+  DONE: 'done',
+};
+
+const PLAN_RUN_EVENT = 'nx-plan-run';
+
+/**
  * DOM CustomEvent names for <nx-chat>'s boundary with the outside world — part of
  * chat's public surface, see docs/chat-ui-component.md ("Events in"/"Events out").
  */
@@ -118,9 +147,12 @@ export {
   ADD_MENU_ITEMS,
   AGENT_EVENT,
   CHAT_EVENT,
+  DIRECTIVE_TYPE,
   MENU_OPTIONS,
   PART_TYPE,
+  PLAN_RUN_EVENT,
   ROLE,
+  TASK_STATUS,
   TOOL_INPUT,
   TOOL_NAME,
   TOOL_SCOPE,

--- a/nx2/blocks/chat/interaction/interaction.js
+++ b/nx2/blocks/chat/interaction/interaction.js
@@ -1,6 +1,6 @@
 import { LitElement, nothing } from 'da-lit';
 import { loadStyle } from '../../../utils/utils.js';
-import { renderApprovalCard } from '../renderers/card-renderers.js';
+import { renderApprovalCard, renderContinuationCard } from '../renderers/card-renderers.js';
 import { renderQuestionCard, renderPlanApprovalCard } from '../ao/ao-renderers.js';
 
 const styles = await loadStyle(import.meta.url);
@@ -48,6 +48,16 @@ class NxChatInteraction extends LitElement {
   }
 
   _onKeydown = (e) => {
+    if (this.pending?.type === 'continuation') {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.onStop?.();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        this.onContinue?.();
+      }
+      return;
+    }
     if (this.pending?.type !== 'approval') return;
     const { toolCallId } = this.pending;
     if (e.key === 'Escape') {
@@ -133,6 +143,10 @@ class NxChatInteraction extends LitElement {
         onApprove: () => this._approvePlan(),
         onReject: () => this._rejectPlan(),
       });
+    }
+
+    if (pending.type === 'continuation') {
+      return renderContinuationCard(() => this.onContinue?.(), () => this.onStop?.());
     }
 
     return nothing;

--- a/nx2/blocks/chat/messages/campaign-plan-card.css
+++ b/nx2/blocks/chat/messages/campaign-plan-card.css
@@ -1,0 +1,83 @@
+/* Shared card shell, header, type-label/icon, chevron, and title live in messages.css. */
+
+:host {
+  display: block;
+}
+
+.plan-card {
+  gap: var(--s2-spacing-200);
+}
+
+.plan-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-200);
+  cursor: pointer;
+  list-style: none;
+}
+
+/* ── Body / description area ── */
+
+.plan-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+  padding: var(--s2-spacing-200) var(--s2-spacing-300);
+}
+
+.plan-type-icon {
+  mask-image: url("/img/icons/s2-icon-aichat-20-n.svg");
+}
+
+.plan-description {
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-700);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.plan-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-75);
+  flex-shrink: 0;
+}
+
+.plan-chevron-icon {
+  color: var(--s2-gray-700);
+}
+
+.plan-card[open] .plan-tasks-collapsed {
+  display: none;
+}
+
+/* ── Task area ── */
+
+.plan-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-200);
+  padding: var(--s2-spacing-200);
+  margin: 0 var(--s2-spacing-300) var(--s2-spacing-200);
+  background-color: var(--s2-gray-50, #f8f8f8);
+  border-radius: var(--s2-corner-radius-500);
+  border: 1px solid var(--s2-gray-200, #e1e1e1);
+}
+
+.plan-tasks-header {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  margin-bottom: var(--s2-spacing-50);
+}
+
+.plan-tasks-progress {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-task-row {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-200);
+}

--- a/nx2/blocks/chat/messages/campaign-plan-card.js
+++ b/nx2/blocks/chat/messages/campaign-plan-card.js
@@ -1,0 +1,130 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+import { getConfig } from '../../../scripts/nx.js';
+import { PLAN_RUN_EVENT, TASK_STATUS } from '../constants.js';
+import './task-item.js';
+
+const shared = await loadStyle(new URL('./messages.css', import.meta.url).href);
+const buttons = await loadStyle(new URL('../../../styles/buttons.css', import.meta.url).href);
+const styles = await loadStyle(import.meta.url);
+const { codeBase } = getConfig();
+
+const icon = (name, className) => html`<svg class=${className} viewBox="0 0 20 20" aria-hidden="true"><use href="${codeBase}/img/icons/${name}.svg#icon"></use></svg>`;
+
+/**
+ * <nx-campaign-plan-card> — Content Generation Plan card.
+ *
+ * Properties:
+ *   plan {Object}
+ *     title       {string}   Plan title
+ *     description {string}   Short description / subtitle
+ *     tasks       {Array<{ id, label, status }>}
+ *
+ * Events dispatched (bubbles + composed):
+ *   nx-plan-run — user clicked Run
+ */
+class NxCampaignPlanCard extends LitElement {
+  static properties = {
+    plan: { attribute: false },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [shared, buttons, styles];
+  }
+
+  _dispatch(eventName) {
+    this.dispatchEvent(new CustomEvent(eventName, {
+      bubbles: true, composed: true, detail: { plan: this.plan },
+    }));
+  }
+
+  _findRunningTask(tasks) {
+    const runningIdx = tasks.findIndex((t) => t.status === TASK_STATUS.RUNNING);
+    return runningIdx >= 0 ? { task: tasks[runningIdx], current: runningIdx + 1 } : null;
+  }
+
+  _renderTasksFull(tasks) {
+    return html`
+      <div class="plan-tasks">
+        <div class="plan-tasks-header">${tasks.length} Tasks to execute</div>
+        ${tasks.map((task) => html`
+          <div class="plan-task-row">
+            <nx-task-item
+              status=${task.status ?? TASK_STATUS.PENDING}
+              label=${task.label ?? ''}
+            ></nx-task-item>
+          </div>
+        `)}
+      </div>
+    `;
+  }
+
+  _renderTasksCollapsed(runningTask, current, total) {
+    return html`
+      <div class="plan-tasks plan-tasks-collapsed">
+        <span class="plan-tasks-progress">${current}/${total}</span>
+        <div class="plan-task-row">
+          <nx-task-item
+            truncate
+            status=${TASK_STATUS.RUNNING}
+            label=${runningTask.label ?? ''}
+          ></nx-task-item>
+        </div>
+      </div>
+    `;
+  }
+
+  render() {
+    const plan = this.plan ?? {};
+    const { title = '', description = '', tasks = [] } = plan;
+
+    const running = this._findRunningTask(tasks);
+    const isRunning = running !== null;
+    const isAllDone = tasks.length > 0 && tasks.every((t) => t.status === TASK_STATUS.DONE);
+    const isDone = !isRunning && isAllDone;
+    let runBtnLabel = 'Run';
+    if (isRunning) runBtnLabel = 'Running...';
+    else if (isDone) runBtnLabel = 'Done';
+    const runBtnClass = `${isRunning ? 'nx-btn-secondary' : 'nx-btn-primary'} plan-btn-run`;
+
+    return html`
+      <details class="msg-card plan-card" open>
+        <summary class="plan-summary">
+          <div class="msg-card-header">
+            <span class="msg-type-label">
+              <span class="msg-type-icon plan-type-icon" aria-hidden="true"></span>
+              Content Generation Plan
+            </span>
+            <div class="plan-header-actions">
+              <button
+                type="button"
+                class=${runBtnClass}
+                ?disabled=${isRunning || isDone}
+                @click=${(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!isRunning && !isDone) this._dispatch(PLAN_RUN_EVENT);
+  }}
+              >${runBtnLabel}</button>
+              ${icon('s2-icon-chevrondown-20-n', 'msg-chevron plan-chevron-icon')}
+            </div>
+          </div>
+
+          <div class="plan-body">
+            <h3 class="msg-title">${title}</h3>
+            ${description ? html`<p class="plan-description">${description}</p>` : nothing}
+          </div>
+
+          ${isRunning
+    ? this._renderTasksCollapsed(running.task, running.current, tasks.length)
+    : nothing}
+        </summary>
+
+        ${this._renderTasksFull(tasks)}
+      </details>
+    `;
+  }
+}
+
+customElements.define('nx-campaign-plan-card', NxCampaignPlanCard);

--- a/nx2/blocks/chat/messages/governance-evaluation-card-data.js
+++ b/nx2/blocks/chat/messages/governance-evaluation-card-data.js
@@ -1,0 +1,29 @@
+function groupChecksByCategory(evaluations) {
+  const groups = new Map();
+  (evaluations ?? []).forEach((check) => {
+    const categoryId = check.category_id ?? 'uncategorized';
+    const categoryName = check.category ?? 'Uncategorized';
+    if (!groups.has(categoryId)) groups.set(categoryId, { categoryId, categoryName, checks: [] });
+    groups.get(categoryId).checks.push(check);
+  });
+  return [...groups.values()];
+}
+
+function sectionSummary(section) {
+  const successful = section?.successful_checks ?? 0;
+  const failed = section?.failed_checks ?? 0;
+  const notApplicable = section?.not_applicable_checks ?? 0;
+  const error = section?.error_checks ?? 0;
+  const denominator = successful + failed;
+  const percent = denominator ? Math.round((successful / denominator) * 100) : 0;
+  return {
+    successful,
+    failed,
+    notApplicable,
+    error,
+    total: successful + failed + notApplicable + error,
+    percent,
+  };
+}
+
+export { groupChecksByCategory, sectionSummary };

--- a/nx2/blocks/chat/messages/governance-evaluation-card.css
+++ b/nx2/blocks/chat/messages/governance-evaluation-card.css
@@ -1,0 +1,400 @@
+/*
+ * Shared card shell, header, type-label, type-icon base, chevron (+ rotate),
+ * title, and spinner live in messages.css.
+ */
+
+:host {
+  display: block;
+}
+
+/* ── Header ── */
+
+.ge-header {
+  cursor: pointer;
+  list-style: none;
+}
+
+.ge-type-icon {
+  mask-image: url("/img/icons/s2-icon-checkmarkcircle-20-n.svg");
+}
+
+.ge-type-icon-error {
+  mask-image: url("/img/icons/s2-icon-alertdiamondorange-20-n.svg");
+}
+
+/* ── Body ── */
+
+.ge-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-200);
+  padding: var(--s2-spacing-200) var(--s2-spacing-300) var(--s2-spacing-300);
+}
+
+.ge-body.ge-loading {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--s2-spacing-200);
+}
+
+.ge-loading-text {
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-600);
+}
+
+.ge-body.ge-error {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--s2-spacing-200);
+}
+
+.ge-error-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--s2-red-700, #c9292b);
+}
+
+.ge-error-text {
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-800);
+}
+
+.ge-page-url {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  margin: 0;
+  word-break: break-all;
+}
+
+/* ── Summary / progress bar (reused at card, text-section, and image-section level) ── */
+
+.ge-summary-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.ge-passed-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-50);
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-green-800, #1b7a3e);
+  font-weight: 500;
+}
+
+.ge-progress-bar {
+  display: block;
+  width: 100%;
+  height: 6px;
+  border: none;
+  border-radius: 3px;
+  overflow: hidden;
+  margin: var(--s2-spacing-100) 0 var(--s2-spacing-200);
+  appearance: none;
+  background: var(--s2-gray-200, #e1e1e1);
+}
+
+.ge-progress-bar::-webkit-progress-bar {
+  background: var(--s2-gray-200, #e1e1e1);
+  border-radius: 3px;
+}
+
+.ge-progress-bar::-webkit-progress-value {
+  background: var(--s2-green-700, #268e49);
+  border-radius: 3px;
+}
+
+.ge-progress-bar::-moz-progress-bar {
+  background: var(--s2-green-700, #268e49);
+  border-radius: 3px;
+}
+
+/* ── Sections (text evaluation / per-image evaluation) ── */
+
+.ge-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+  padding-top: var(--s2-spacing-200);
+  border-top: 1px solid var(--s2-gray-200, #e1e1e1);
+}
+
+.ge-section-title {
+  font-size: var(--s2-body-size-s);
+  font-weight: 600;
+  color: var(--s2-gray-900);
+  margin: 0;
+}
+
+.ge-section-empty {
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-600);
+  margin: 0;
+  font-style: italic;
+}
+
+/* ── Image group (umbrella "Image evaluation") ── */
+
+.ge-group-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--s2-spacing-200);
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  box-sizing: border-box;
+  border-radius: var(--s2-corner-radius-300);
+  list-style: none;
+
+  &:hover {
+    background: var(--s2-gray-75);
+  }
+}
+
+.ge-group-title-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-25, 2px);
+  flex: 1;
+}
+
+.ge-group-meta {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+}
+
+.ge-group-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-100);
+  flex-shrink: 0;
+}
+
+.ge-group-chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--s2-gray-600);
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.ge-image-group[open] .ge-group-chevron {
+  transform: rotate(180deg);
+}
+
+.ge-image-group .ge-progress-bar {
+  margin: var(--s2-spacing-100) 0 0;
+}
+
+.ge-image-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-300);
+  margin-top: var(--s2-spacing-200);
+}
+
+.ge-image-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+}
+
+.ge-image-list > .ge-image-section + .ge-image-section {
+  padding-top: var(--s2-spacing-300);
+  border-top: 1px solid var(--s2-gray-200, #e1e1e1);
+}
+
+/* ── Image section header ── */
+
+.ge-image-header {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-200);
+}
+
+.ge-image-thumb {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: var(--s2-corner-radius-300);
+  border: 1px solid var(--s2-gray-200, #e1e1e1);
+  background: var(--s2-gray-100);
+}
+
+.ge-align-badge {
+  font-size: var(--s2-body-size-xs);
+  font-weight: 500;
+  padding: var(--s2-spacing-50) var(--s2-spacing-100);
+  border-radius: var(--s2-corner-radius-200, 4px);
+}
+
+.ge-align-badge-pass {
+  color: var(--s2-green-800, #1b7a3e);
+  background: var(--s2-green-100, #e3f5e9);
+}
+
+.ge-align-badge-fail {
+  color: var(--s2-red-700, #c9292b);
+  background: var(--s2-red-100, #fbe4e4);
+}
+
+/* ── Categories ── */
+
+.ge-categories {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-50);
+  background-color: var(--s2-gray-50, #f8f8f8);
+  border-radius: var(--s2-corner-radius-500);
+  border: 1px solid var(--s2-gray-200, #e1e1e1);
+  overflow: hidden;
+}
+
+.ge-category {
+  border-bottom: 1px solid var(--s2-gray-200, #e1e1e1);
+  min-height: var(--s2-spacing-700);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.ge-cat-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--s2-spacing-400) var(--s2-spacing-300);
+  background: transparent;
+  cursor: pointer;
+  gap: var(--s2-spacing-100);
+  text-align: left;
+  box-sizing: border-box;
+  list-style: none;
+
+  &:hover {
+    background: var(--s2-gray-75);
+  }
+}
+
+.ge-cat-name {
+  flex: 1;
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-800);
+  font-weight: 500;
+}
+
+.ge-cat-summary {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  white-space: nowrap;
+}
+
+.ge-cat-chevron {
+  width: 14px;
+  height: 14px;
+  color: var(--s2-gray-600);
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.ge-category[open] .ge-cat-chevron {
+  transform: rotate(180deg);
+}
+
+/* ── Check rows ── */
+
+.ge-checks {
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--s2-spacing-200) var(--s2-spacing-200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-75);
+}
+
+.ge-check-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.ge-check-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: var(--s2-spacing-100);
+  padding: var(--s2-spacing-50) 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  box-sizing: border-box;
+  list-style: none;
+
+  &:hover {
+    background: var(--s2-gray-75);
+  }
+}
+
+.ge-check-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.ge-check-yes {
+  color: var(--s2-green-700, #268e49);
+}
+
+.ge-check-no {
+  color: var(--s2-red-700, #c9292b);
+}
+
+.ge-check-na {
+  color: var(--s2-gray-500, #909090);
+}
+
+.ge-check-error {
+  color: var(--s2-orange-700, #b9530f);
+}
+
+.ge-check-label {
+  flex: 1;
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-700);
+}
+
+.ge-check-chevron {
+  width: 12px;
+  height: 12px;
+  color: var(--s2-gray-500);
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.ge-check-item[open] .ge-check-chevron {
+  transform: rotate(180deg);
+}
+
+.ge-check-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+  padding: 0 0 var(--s2-spacing-100) var(--s2-spacing-400);
+}
+
+.ge-check-detail-block {
+  margin: 0;
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-700);
+  line-height: 1.5;
+}
+
+.ge-check-detail-label {
+  display: block;
+  font-weight: 600;
+  color: var(--s2-gray-800);
+  margin-bottom: var(--s2-spacing-25, 2px);
+}

--- a/nx2/blocks/chat/messages/governance-evaluation-card.js
+++ b/nx2/blocks/chat/messages/governance-evaluation-card.js
@@ -1,0 +1,240 @@
+import { LitElement, html, nothing } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+import { getConfig } from '../../../scripts/nx.js';
+import { groupChecksByCategory, sectionSummary } from './governance-evaluation-card-data.js';
+
+const shared = await loadStyle(new URL('./messages.css', import.meta.url).href);
+const styles = await loadStyle(import.meta.url);
+const { codeBase } = getConfig();
+
+const ICON_NAMES = {
+  chevron: 's2-icon-chevrondown-20-n',
+  check: 's2-icon-checkmark-20-n',
+  close: 's2-icon-close-20-n',
+  warning: 's2-icon-alertdiamond-20-n',
+  na: 's2-icon-circle-20-n',
+};
+
+const icon = (name, className) => html`<svg class=${className} viewBox="0 0 20 20" aria-hidden="true"><use href="${codeBase}/img/icons/${ICON_NAMES[name]}.svg#icon"></use></svg>`;
+
+class NxGovernanceEvaluationCard extends LitElement {
+  static properties = {
+    evaluation: { attribute: false },
+    loading: { type: Boolean },
+    error: { attribute: false },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [shared, styles];
+  }
+
+  _renderCheckIcon(check) {
+    if (check.error) return icon('warning', 'ge-check-icon ge-check-error');
+    if (check.alignment === 'YES') return icon('check', 'ge-check-icon ge-check-yes');
+    if (check.alignment === 'NO') return icon('close', 'ge-check-icon ge-check-no');
+    return icon('na', 'ge-check-icon ge-check-na');
+  }
+
+  _renderSummaryBar(summary) {
+    return html`
+      <span class="ge-summary-row">
+        <span class="ge-passed-badge">${summary.successful}/${summary.successful + summary.failed} passed</span>
+      </span>
+      <progress class="ge-progress-bar" value=${summary.percent} max="100">${summary.percent}%</progress>
+    `;
+  }
+
+  _renderCheckRow(check) {
+    return html`
+      <details class="ge-check-item" ?open=${check.alignment === 'NO'}>
+        <summary class="ge-check-row">
+          ${this._renderCheckIcon(check)}
+          <span class="ge-check-label">${check.check_title}</span>
+          ${icon('chevron', 'ge-check-chevron')}
+        </summary>
+        <div class="ge-check-detail">
+          ${check.reasoning ? html`
+            <p class="ge-check-detail-block">
+              <span class="ge-check-detail-label">Reasoning</span>
+              ${check.reasoning}
+            </p>
+          ` : nothing}
+          ${check.suggestions ? html`
+            <p class="ge-check-detail-block ge-check-suggestion">
+              <span class="ge-check-detail-label">Suggestion</span>
+              ${check.suggestions}
+            </p>
+          ` : nothing}
+        </div>
+      </details>
+    `;
+  }
+
+  _renderCategory(category) {
+    const { categoryName, checks } = category;
+    const aligned = checks.filter((c) => c.alignment === 'YES').length;
+
+    return html`
+      <details class="ge-category">
+        <summary class="ge-cat-header">
+          <span class="ge-cat-name">${categoryName}</span>
+          <span class="ge-cat-summary">${aligned}/${checks.length} aligned</span>
+          ${icon('chevron', 'ge-cat-chevron')}
+        </summary>
+        <div class="ge-checks">
+          ${checks.map((check) => this._renderCheckRow(check))}
+        </div>
+      </details>
+    `;
+  }
+
+  _renderCategories(evaluations) {
+    const groups = groupChecksByCategory(evaluations);
+    return html`
+      <div class="ge-categories">
+        ${groups.map((category) => this._renderCategory(category))}
+      </div>
+    `;
+  }
+
+  _renderTextSection(textEvaluation) {
+    const evaluations = textEvaluation?.evaluations ?? [];
+    return html`
+      <div class="ge-section ge-text-section">
+        <h4 class="ge-section-title">Text evaluation</h4>
+        ${evaluations.length ? html`
+          ${this._renderSummaryBar(sectionSummary(textEvaluation))}
+          ${this._renderCategories(evaluations)}
+        ` : html`<p class="ge-section-empty">No text evaluation available.</p>`}
+      </div>
+    `;
+  }
+
+  _renderImageGroup(imageEvaluations) {
+    if (!imageEvaluations.length) return nothing;
+    const count = imageEvaluations.length;
+    const aggregate = imageEvaluations.reduce((acc, img) => {
+      const summary = sectionSummary(img);
+      return {
+        successful: acc.successful + summary.successful,
+        failed: acc.failed + summary.failed,
+      };
+    }, { successful: 0, failed: 0 });
+    const imageSummary = sectionSummary({
+      successful_checks: aggregate.successful,
+      failed_checks: aggregate.failed,
+    });
+
+    return html`
+      <details class="ge-section ge-image-group">
+        <summary class="ge-group-header">
+          <span class="ge-group-title-col">
+            <span class="ge-section-title">Image evaluations</span>
+            <span class="ge-group-meta">${count} image${count === 1 ? '' : 's'} evaluated</span>
+          </span>
+          <span class="ge-group-header-right">
+            <span class="ge-passed-badge">${imageSummary.successful}/${imageSummary.successful + imageSummary.failed} passed</span>
+            ${icon('chevron', 'ge-group-chevron')}
+          </span>
+        </summary>
+        <progress class="ge-progress-bar" value=${imageSummary.percent} max="100">${imageSummary.percent}%</progress>
+        <div class="ge-image-list">
+          ${imageEvaluations.map((img) => this._renderImageSection(img))}
+        </div>
+      </details>
+    `;
+  }
+
+  _renderImageSection(imageEvaluation) {
+    const { source, overall_aligned: overallAligned, evaluations = [] } = imageEvaluation;
+    const badgeClass = `ge-align-badge ${overallAligned ? 'ge-align-badge-pass' : 'ge-align-badge-fail'}`;
+    return html`
+      <div class="ge-image-section">
+        <div class="ge-image-header">
+          <img class="ge-image-thumb" src=${source} alt="" />
+          <span class=${badgeClass}>${overallAligned ? 'Aligned' : 'Not aligned'}</span>
+        </div>
+        ${evaluations.length ? html`
+          ${this._renderSummaryBar(sectionSummary(imageEvaluation))}
+          ${this._renderCategories(evaluations)}
+        ` : html`<p class="ge-section-empty">No checks available for this image.</p>`}
+      </div>
+    `;
+  }
+
+  render() {
+    if (this.error) {
+      return html`
+        <div class="msg-card ge-card">
+          <div class="msg-card-header ge-header">
+            <span class="msg-type-label">
+              <span class="msg-type-icon ge-type-icon ge-type-icon-error" aria-hidden="true"></span>
+              Governance Page Evaluation
+            </span>
+          </div>
+          <div class="ge-body ge-error">
+            ${icon('warning', 'ge-error-icon')}
+            <span class="ge-error-text">${this.error}</span>
+          </div>
+        </div>
+      `;
+    }
+
+    if (this.loading) {
+      return html`
+        <div class="msg-card ge-card">
+          <div class="msg-card-header ge-header">
+            <span class="msg-type-label">
+              <span class="msg-type-icon ge-type-icon" aria-hidden="true"></span>
+              Governance Page Evaluation
+            </span>
+          </div>
+          <div class="ge-body ge-loading">
+            <span class="msg-spinner" aria-hidden="true"></span>
+            <span class="ge-loading-text">Evaluating page…</span>
+          </div>
+        </div>
+      `;
+    }
+
+    const evaluation = this.evaluation ?? {};
+    const {
+      brand_name: brandName = '', pageUrl = '', text_evaluation: textEvaluation, image_evaluations: imageEvaluations = [],
+    } = evaluation;
+
+    const sections = [textEvaluation, ...imageEvaluations].filter(Boolean);
+    const aggregate = sections.reduce((acc, section) => {
+      const summary = sectionSummary(section);
+      return {
+        successful: acc.successful + summary.successful,
+        failed: acc.failed + summary.failed,
+      };
+    }, { successful: 0, failed: 0 });
+    const aggregateSummary = sectionSummary({
+      successful_checks: aggregate.successful,
+      failed_checks: aggregate.failed,
+    });
+
+    return html`
+      <details class="msg-card ge-card" open>
+        <summary class="msg-card-header ge-header">
+          <span class="msg-type-label">
+            <span class="msg-type-icon ge-type-icon" aria-hidden="true"></span>
+            Governance Page Evaluation
+          </span>
+          ${icon('chevron', 'msg-chevron ge-chevron-icon')}
+        </summary>
+        <div class="ge-body">
+          <h3 class="msg-title">${brandName || 'Brand evaluation'}</h3>
+          ${pageUrl ? html`<p class="ge-page-url">${pageUrl}</p>` : nothing}
+          ${this._renderSummaryBar(aggregateSummary)}
+          ${this._renderTextSection(textEvaluation)}
+          ${this._renderImageGroup(imageEvaluations)}
+        </div>
+      </details>
+    `;
+  }
+}
+
+customElements.define('nx-governance-evaluation-card', NxGovernanceEvaluationCard);

--- a/nx2/blocks/chat/messages/messages.css
+++ b/nx2/blocks/chat/messages/messages.css
@@ -1,0 +1,93 @@
+/*
+ * Shared styles for chat message components (cards, task list).
+ * Adopted alongside each component's own stylesheet via
+ * `adoptedStyleSheets = [shared, styles]`, so per-component rules win on conflicts.
+ * Holds the patterns duplicated across campaign-plan-card, governance-evaluation-card,
+ * task-item, and task-list. Feature-scoped — not part of the shared style guide.
+ */
+
+:host {
+  font-family: var(--s2-font-family);
+}
+
+/* ── Card shell ── */
+
+.msg-card {
+  background: var(--s2-gray-25);
+  border-radius: var(--s2-corner-radius-400);
+  box-shadow: 0 1px 4px 0 color-mix(in srgb, var(--s2-gray-800) 12%, transparent);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--s2-spacing-200);
+  margin-bottom: var(--s2-spacing-75);
+}
+
+/* ── Header strip (48px, border-bottom) ── */
+
+.msg-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 48px;
+  padding: var(--s2-spacing-200);
+  border-bottom: 1px solid var(--s2-gray-200, #e1e1e1);
+  box-sizing: border-box;
+}
+
+.msg-type-label {
+  font-size: var(--s2-body-size-xs);
+  color: var(--s2-gray-600);
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-75);
+}
+
+.msg-type-icon {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  flex-shrink: 0;
+  background-color: currentcolor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+}
+
+.msg-chevron {
+  width: 16px;
+  height: 16px;
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+[open] .msg-chevron {
+  transform: rotate(180deg);
+}
+
+/* ── Title ── */
+
+.msg-title {
+  font-size: var(--s2-font-size-200, 18px);
+  font-weight: 700;
+  line-height: var(--s2-line-height-200, 1.3);
+  color: var(--s2-gray-900);
+  margin: 0;
+}
+
+/* ── Spinner ── */
+
+.msg-spinner {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--s2-gray-300);
+  border-top-color: var(--s2-gray-700);
+  box-sizing: border-box;
+  animation: msg-spin 0.8s linear infinite;
+}
+
+@keyframes msg-spin {
+  to { transform: rotate(360deg); }
+}

--- a/nx2/blocks/chat/messages/task-item.css
+++ b/nx2/blocks/chat/messages/task-item.css
@@ -1,0 +1,65 @@
+:host {
+  display: flex;
+  align-items: center;
+  gap: var(--s2-spacing-200);
+  font-size: var(--s2-body-size-s);
+  color: var(--s2-gray-800);
+  min-width: 0;
+}
+
+.task-icon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Pending: dashed circle */
+.task-icon-pending {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1.5px dashed var(--s2-gray-500);
+  box-sizing: border-box;
+}
+
+/* Done: filled checkmark circle */
+.task-icon-done {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: var(--s2-gray-800);
+  box-sizing: border-box;
+  position: relative;
+}
+
+.task-icon-done::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: var(--s2-gray-25);
+  mask-image: url("/img/icons/s2-icon-checkmark-20-n.svg");
+  mask-size: 65%;
+  mask-repeat: no-repeat;
+  mask-position: center;
+}
+
+.task-label {
+  flex: 1;
+  min-width: 0;
+}
+
+/* truncate mode — applied when the `truncate` attribute is present */
+:host([truncate]) .task-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-label-done {
+  color: var(--s2-gray-500);
+  text-decoration: line-through;
+}
+

--- a/nx2/blocks/chat/messages/task-item.js
+++ b/nx2/blocks/chat/messages/task-item.js
@@ -1,0 +1,50 @@
+import { LitElement, html } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+import { TASK_STATUS } from '../constants.js';
+
+const shared = await loadStyle(new URL('./messages.css', import.meta.url).href);
+const styles = await loadStyle(import.meta.url);
+
+/**
+ * <nx-task-item> — single task row with icon + label.
+ *
+ * Attributes / properties:
+ *   status  {string}  'pending' | 'running' | 'done'
+ *   label   {string}  Task description text
+ */
+class NxTaskItem extends LitElement {
+  static properties = {
+    status: { type: String },
+    label: { type: String },
+    /** When present, label is clamped to a single line with ellipsis. */
+    truncate: { type: Boolean, reflect: true },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [shared, styles];
+  }
+
+  _renderIcon() {
+    const { status = TASK_STATUS.PENDING } = this;
+    if (status === TASK_STATUS.RUNNING) {
+      return html`<span class="task-icon"><span class="msg-spinner" aria-hidden="true"></span></span>`;
+    }
+    if (status === TASK_STATUS.DONE) {
+      return html`<span class="task-icon"><span class="task-icon-done" aria-label="Completed"></span></span>`;
+    }
+    return html`<span class="task-icon"><span class="task-icon-pending" aria-hidden="true"></span></span>`;
+  }
+
+  render() {
+    const { status = TASK_STATUS.PENDING, label = '' } = this;
+    const isDone = status === TASK_STATUS.DONE;
+
+    return html`
+      ${this._renderIcon()}
+      <span class="task-label ${isDone ? 'task-label-done' : ''}">${label}</span>
+    `;
+  }
+}
+
+customElements.define('nx-task-item', NxTaskItem);

--- a/nx2/blocks/chat/messages/task-list.css
+++ b/nx2/blocks/chat/messages/task-list.css
@@ -1,0 +1,9 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2-spacing-100);
+}
+
+nx-task-item {
+  display: flex;
+}

--- a/nx2/blocks/chat/messages/task-list.js
+++ b/nx2/blocks/chat/messages/task-list.js
@@ -1,0 +1,40 @@
+import { LitElement, html } from 'da-lit';
+import { loadStyle } from '../../../utils/utils.js';
+import { TASK_STATUS } from '../constants.js';
+import './task-item.js';
+
+const shared = await loadStyle(new URL('./messages.css', import.meta.url).href);
+const styles = await loadStyle(import.meta.url);
+
+/**
+ * <nx-task-list> — flat list of task items without a card wrapper.
+ * Used when the agent streams a task list outside of a full campaign plan.
+ *
+ * Properties:
+ *   tasks {Array<{ id, label, status }>}
+ */
+class NxTaskList extends LitElement {
+  static properties = {
+    tasks: { attribute: false },
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [shared, styles];
+  }
+
+  render() {
+    const tasks = this.tasks ?? [];
+    return html`
+      ${tasks.map((task) => html`
+        <nx-task-item
+          truncate
+          status=${task.status ?? TASK_STATUS.PENDING}
+          label=${task.label ?? ''}
+        ></nx-task-item>
+      `)}
+    `;
+  }
+}
+
+customElements.define('nx-task-list', NxTaskList);

--- a/nx2/blocks/chat/renderers/card-renderers.js
+++ b/nx2/blocks/chat/renderers/card-renderers.js
@@ -40,6 +40,28 @@ export function renderToolCard(card) {
  * @param {{ toolCallId: string, toolName: string, summary: string|null }|null} pending
  * @param {(toolCallId: string, approved: boolean, always?: boolean) => void} onApprove
  */
+/**
+ * Post-execution continuation gate: a tool has finished and the agent paused for the user
+ * to review its result before continuing. Backend-neutral (only da-agent produces it today).
+ * @param {() => void} onContinue
+ * @param {() => void} onStop
+ */
+export function renderContinuationCard(onContinue, onStop) {
+  return html`
+    <div class="approval-actions">
+      <span class="approval-tool-name">Review the results before continuing</span>
+      <div class="approval-buttons">
+        <button type="button" class="secondary-btn" @click=${() => onStop()}>
+          <span>Stop</span><kbd>Esc</kbd>
+        </button>
+        <button type="button" class="action-btn" @click=${() => onContinue()}>
+          <span>Continue</span><kbd>↵</kbd>
+        </button>
+      </div>
+    </div>
+  `;
+}
+
 export function renderApprovalCard(pending, onApprove) {
   if (!pending) return nothing;
   const { toolCallId, toolName, summary } = pending;

--- a/nx2/blocks/chat/renderers/renderers.js
+++ b/nx2/blocks/chat/renderers/renderers.js
@@ -1,11 +1,18 @@
 import { html, nothing } from 'da-lit';
 import {
-  PART_TYPE, ROLE, TOOL_INPUT, TOOL_STATE,
+  DIRECTIVE_TYPE, PART_TYPE, ROLE, TOOL_INPUT, TOOL_NAME, TOOL_STATE,
 } from '../constants.js';
 import { getConfig } from '../../../scripts/nx.js';
 import { parseDirectives } from '../utils/parse.js';
+import {
+  parseDirectiveJSON, parseToolOutput, mergeTaskItemsFromText, mergeTaskItemsIntoPlan,
+} from '../utils/directives.js';
 import { pillIconName } from '../utils/icons.js';
 import { linkifyBareUrls, sanitizeLinks } from '../utils/links.js';
+import { mcpToolName } from '../utils/tool-name.js';
+import '../messages/campaign-plan-card.js';
+import '../messages/governance-evaluation-card.js';
+import '../messages/task-list.js';
 
 const { codeBase } = getConfig();
 
@@ -17,14 +24,49 @@ function toDOM(hast) {
   return hastToDom(sanitizeLinks(linkifyBareUrls(hast)), { fragment: true });
 }
 
+function renderPlanDirective(content) {
+  const plan = parseDirectiveJSON(content);
+  if (!plan) return html`<div class="directive directive-plan"></div>`;
+  return html`<nx-campaign-plan-card .plan=${plan}></nx-campaign-plan-card>`;
+}
+
+function renderTaskListDirective(content) {
+  const data = parseDirectiveJSON(content);
+  if (!data) return html`<div class="directive directive-task-list"></div>`;
+  return html`<nx-task-list .tasks=${data.tasks ?? []}></nx-task-list>`;
+}
+
+function renderGovernanceEvaluationDirective(content) {
+  const evaluation = parseDirectiveJSON(content);
+  if (!evaluation) return html`<div class="directive directive-governance-evaluation"></div>`;
+  return html`<nx-governance-evaluation-card .evaluation=${evaluation}></nx-governance-evaluation-card>`;
+}
+
 function renderMessageContent(text) {
   if (!text) return nothing;
 
-  return parseDirectives(text).map(({ kind, type, content }) => {
+  // Fold standalone :::task-item directives into a preceding :::plan payload (if any) so
+  // task status renders inside the plan card rather than as loose fragments.
+  const directives = mergeTaskItemsIntoPlan(parseDirectives(text));
+
+  const items = directives.map(({ kind, type, content }) => {
+    if (kind === 'directive') {
+      if (type === DIRECTIVE_TYPE.PLAN) return renderPlanDirective(content);
+      if (type === DIRECTIVE_TYPE.TASK_LIST) return renderTaskListDirective(content);
+      // task-item directives drive plan/exit_plan card status; never render standalone.
+      if (type === DIRECTIVE_TYPE.TASK_ITEM) return nothing;
+      if (type === DIRECTIVE_TYPE.GOVERNANCE_EVALUATION) {
+        return renderGovernanceEvaluationDirective(content);
+      }
+      if (!content) return nothing;
+      const dom = toDOM(mdast2hast(parser.parse(content)));
+      return html`<div class="directive directive-${type}">${dom}</div>`;
+    }
     if (!content) return nothing;
-    const dom = toDOM(mdast2hast(parser.parse(content)));
-    return kind === 'directive' ? html`<div class="directive directive-${type}">${dom}</div>` : dom;
-  });
+    return toDOM(mdast2hast(parser.parse(content)));
+  }).filter((item) => item !== nothing);
+
+  return items.length ? items : nothing;
 }
 
 function approvalSummary(input, { json = false } = {}) {
@@ -38,10 +80,47 @@ function approvalSummary(input, { json = false } = {}) {
     ?? (json ? JSON.stringify(input, null, 2) : null);
 }
 
-function renderToolCard(toolCallId, toolCards) {
+// exit_plan_mode is a single stateful card living in the message stream across its whole
+// lifecycle: awaiting approval (Run enabled → approves the tool call), then executing
+// (task statuses merged from :::task-item directives in assistant text → Running/Done).
+function renderExitPlanCard(plan, taskText, onRun) {
+  const merged = mergeTaskItemsFromText(plan, taskText);
+  return html`<nx-campaign-plan-card .plan=${merged} @nx-plan-run=${onRun}></nx-campaign-plan-card>`;
+}
+
+function renderToolCard(toolCallId, toolCards, { streamingText, onApprove } = {}) {
   const card = toolCards?.get(toolCallId);
-  if (!card || card.state === TOOL_STATE.AWAITING_APPROVAL) return nothing;
-  const { toolName, state, input } = card;
+  if (!card) return nothing;
+  const {
+    toolName, state, input, output,
+  } = card;
+  const shortToolName = mcpToolName(toolName);
+
+  // exit_plan_mode renders its plan card in every state (including AWAITING_APPROVAL),
+  // with Run wired to approve the tool call — so it is not gated by the bottom approval UI.
+  if (shortToolName === TOOL_NAME.EXIT_PLAN_MODE) {
+    return renderExitPlanCard(input, streamingText, () => onApprove?.(toolCallId, true));
+  }
+
+  // Every other tool: approval is surfaced by <nx-chat-interaction> at the bottom, so the
+  // in-stream card stays hidden until the tool has actually run.
+  if (state === TOOL_STATE.AWAITING_APPROVAL) return nothing;
+
+  if (shortToolName === TOOL_NAME.EVALUATE_PAGE) {
+    // evaluate_page runs without pre-execution approval; only OUTPUT_AVAILABLE/OUTPUT_ERROR
+    // carry a real report. Before then, show the card in a loading state.
+    const isError = state === TOOL_STATE.OUTPUT_ERROR;
+    const parsedOutput = parseToolOutput(output);
+    const errorMessage = isError
+      ? (typeof parsedOutput?.error === 'string' && parsedOutput.error) || 'Page evaluation failed.'
+      : undefined;
+    return html`<nx-governance-evaluation-card
+      .evaluation=${parsedOutput}
+      .loading=${state !== TOOL_STATE.OUTPUT_AVAILABLE && state !== TOOL_STATE.OUTPUT_ERROR}
+      .error=${errorMessage}
+    ></nx-governance-evaluation-card>`;
+  }
+
   const detail = approvalSummary(input, { json: true });
   const failed = state === TOOL_STATE.OUTPUT_ERROR || state === TOOL_STATE.REJECTED;
   const status = failed ? html`<span class="tool-card-status">${state}</span>` : nothing;
@@ -75,12 +154,17 @@ function renderApprovalCard(pending, onApprove) {
   `;
 }
 
-function renderAssistantMessage(msg, toolCards) {
+function renderAssistantMessage(msg, toolCards, opts) {
   if (Array.isArray(msg.content)) {
     return html`${msg.content.map((part) => (part.type === PART_TYPE.TOOL
-      ? renderToolCard(part.toolCallId, toolCards)
+      ? renderToolCard(part.toolCallId, toolCards, opts)
       : nothing))}`;
   }
+
+  // A message that is only :::task-item directives (merged into a plan card elsewhere)
+  // renders as nothing — skip the empty bubble + copy button.
+  const content = renderMessageContent(msg.content);
+  if (content === nothing) return nothing;
 
   const copy = msg.streaming ? nothing : html`<button class="message-action-copy" @click=${() => navigator.clipboard.writeText(msg.content)} aria-label="Copy">
       <svg class="icon-paste" viewBox="0 0 20 20" aria-hidden="true"><use href="${codeBase}/img/icons/s2-icon-paste-20-n.svg#icon"></use></svg>
@@ -89,7 +173,7 @@ function renderAssistantMessage(msg, toolCards) {
 
   return html`
     <div class="message message-assistant">
-      <div class="message-content">${renderMessageContent(msg.content)}</div>
+      <div class="message-content">${content}</div>
       ${copy}
     </div>
   `;
@@ -134,10 +218,10 @@ function renderUserMessage(msg) {
   `;
 }
 
-function renderMessage(msg, toolCards) {
+function renderMessage(msg, toolCards, opts) {
   if (msg.role === ROLE.TOOL) return nothing;
   return msg.role === ROLE.ASSISTANT
-    ? renderAssistantMessage(msg, toolCards)
+    ? renderAssistantMessage(msg, toolCards, opts)
     : renderUserMessage(msg);
 }
 

--- a/nx2/blocks/chat/utils/directives.js
+++ b/nx2/blocks/chat/utils/directives.js
@@ -1,0 +1,66 @@
+import { DIRECTIVE_TYPE } from '../constants.js';
+import { parseDirectives } from './parse.js';
+
+export function parseDirectiveJSON(content) {
+  try {
+    return JSON.parse(content.trim());
+  } catch {
+    return null;
+  }
+}
+
+export function parseToolOutput(output) {
+  if (typeof output !== 'string') return output;
+  return parseDirectiveJSON(output);
+}
+
+function buildTaskStatusMap(directives) {
+  const updates = new Map();
+  for (const d of directives) {
+    if (d.kind === 'directive' && d.type === DIRECTIVE_TYPE.TASK_ITEM) {
+      const data = parseDirectiveJSON(d.content);
+      if (data?.label) updates.set(data.label, data.status);
+    }
+  }
+  return updates;
+}
+
+export function mergeTaskItemsFromText(plan, streamingText) {
+  if (!streamingText || !plan?.tasks?.length) return plan;
+  const updates = buildTaskStatusMap(parseDirectives(streamingText));
+  if (!updates.size) return plan;
+  return {
+    ...plan,
+    tasks: plan.tasks.map((t) => ({ ...t, status: updates.get(t.label) ?? t.status })),
+  };
+}
+
+export function mergeTaskItemsIntoPlan(directives) {
+  const planIdx = directives.findIndex((d) => d.kind === 'directive' && d.type === DIRECTIVE_TYPE.PLAN);
+  if (planIdx < 0) return directives;
+
+  const updates = buildTaskStatusMap(directives.slice(planIdx + 1));
+
+  if (!updates.size) return directives;
+
+  const planData = parseDirectiveJSON(directives[planIdx].content);
+  if (!planData?.tasks) return directives;
+
+  const merged = directives.map((d, i) => {
+    if (i === planIdx) {
+      return {
+        ...d,
+        content: JSON.stringify({
+          ...planData,
+          tasks: planData.tasks.map((t) => ({ ...t, status: updates.get(t.label) ?? t.status })),
+        }),
+      };
+    }
+    if (i > planIdx && d.kind === 'directive' && d.type === DIRECTIVE_TYPE.TASK_ITEM) {
+      return null;
+    }
+    return d;
+  });
+
+  return merged.filter(Boolean);
+}

--- a/nx2/blocks/chat/utils/stream.js
+++ b/nx2/blocks/chat/utils/stream.js
@@ -31,6 +31,14 @@ function processEvent(event, streaming, callbacks) {
       type: EVENT.TOOL_APPROVAL_REQUEST,
       toolCallId: event.toolCallId,
     });
+  } else if (event.type === EVENT.CONTINUATION) {
+    // Transient, UI-only: surface a continuation prompt for the (already DONE) tool card.
+    // Not added to message history — the tool result is already persisted on its own.
+    onTool?.({
+      type: EVENT.CONTINUATION,
+      toolCallId: event.data?.toolCallId,
+      toolName: event.data?.toolName,
+    });
   } else if (event.type === EVENT.TOOL_OUTPUT_AVAILABLE) {
     const raw = event.output ?? event.result;
     const isError = raw && typeof raw === 'object' && 'error' in raw;

--- a/nx2/blocks/chat/utils/tool-name.js
+++ b/nx2/blocks/chat/utils/tool-name.js
@@ -1,0 +1,11 @@
+/**
+ * MCP-backed tools are announced by da-agent under their fully-qualified
+ * `mcp__<server>__<tool>` identifier rather than a short name. Resolving to
+ * the short name here keeps renderer comparisons stable across MCP server
+ * renames instead of hardcoding a specific server segment.
+ */
+export function mcpToolName(toolName) {
+  if (!toolName?.startsWith('mcp__')) return toolName;
+  const separatorIndex = toolName.lastIndexOf('__');
+  return separatorIndex === -1 ? toolName : toolName.slice(separatorIndex + 2);
+}

--- a/test/nx2/blocks/chat/chat-backend.test.js
+++ b/test/nx2/blocks/chat/chat-backend.test.js
@@ -66,6 +66,42 @@ describe('ChatBackend normalization — da-agent', () => {
 
     expect(updates.at(-1).pendingInteraction.summary).to.equal(null);
   });
+
+  it('does NOT surface exit_plan_mode as a generic approval (its plan card owns approval)', () => {
+    const { backend, updates } = makeBackend(false);
+    const toolCards = new Map([
+      ['p1', { toolName: 'exit_plan_mode', input: { title: 'X' }, state: TOOL_STATE.AWAITING_APPROVAL }],
+    ]);
+
+    emit(backend, { toolCards });
+
+    expect(updates.at(-1).pendingInteraction).to.equal(null);
+  });
+
+  it('derives a continuation pendingInteraction from a continuation-pending tool card', () => {
+    const { backend, updates } = makeBackend(false);
+    const toolCards = new Map([
+      ['e1', { toolName: 'evaluate_page', state: TOOL_STATE.OUTPUT_AVAILABLE, continuationPending: true }],
+    ]);
+
+    emit(backend, { toolCards });
+
+    expect(updates.at(-1).pendingInteraction).to.deep.equal({ type: 'continuation', toolCallId: 'e1' });
+  });
+
+  it('proxies continueExecution/stopExecution to the wrapped controller', () => {
+    const { backend } = makeBackend(false);
+    let continued = false;
+    let stopped = false;
+    backend._controller.continueExecution = () => { continued = true; };
+    backend._controller.stopExecution = () => { stopped = true; };
+
+    backend.continueExecution();
+    backend.stopExecution();
+
+    expect(continued).to.equal(true);
+    expect(stopped).to.equal(true);
+  });
 });
 
 describe('ChatBackend normalization — AO', () => {

--- a/test/nx2/blocks/chat/chat-controller.test.js
+++ b/test/nx2/blocks/chat/chat-controller.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import ChatController, { migrateHistory } from '../../../../nx2/blocks/chat/chat-controller.js';
-import { TOOL_STATE } from '../../../../nx2/blocks/chat/constants.js';
+import { TOOL_STATE, AGENT_EVENT, ROLE } from '../../../../nx2/blocks/chat/constants.js';
 
 const TURN = 'turn-current';
 const OTHER_TURN = 'turn-previous';
@@ -226,5 +226,36 @@ describe('chat-controller _pageContextForAgent', () => {
     const controller = new ChatController({ onUpdate() {}, onToolDone() {} });
     controller.setContext({ path: '/foo' });
     expect(controller._pageContextForAgent()).to.equal(undefined);
+  });
+});
+
+describe('chat-controller continuation gate', () => {
+  const evalMsg = () => toolMsg({
+    toolCallId: 'e1', toolName: 'evaluate_page', input: {}, state: TOOL_STATE.OUTPUT_AVAILABLE, output: {},
+  });
+
+  it('flags the tool card as continuationPending on a CONTINUATION event', () => {
+    const controller = makeController();
+    controller._messages = [evalMsg()];
+    controller._onToolEvent({ type: AGENT_EVENT.CONTINUATION, toolCallId: 'e1' });
+    expect(controller._deriveToolCards().get('e1').continuationPending).to.equal(true);
+  });
+
+  it('ignores a CONTINUATION event for an unknown tool call', () => {
+    const controller = makeController();
+    controller._messages = [];
+    expect(() => controller._onToolEvent({ type: AGENT_EVENT.CONTINUATION, toolCallId: 'nope' })).to.not.throw();
+    expect(controller._continuationPendingIds?.has('nope') ?? false).to.equal(false);
+  });
+
+  it('stopExecution records a user message and clears the pending flag', async () => {
+    const controller = makeController();
+    controller._getRoom = async () => 'continuation-test-room';
+    controller._sessionId = 's1';
+    controller._messages = [evalMsg()];
+    controller._onToolEvent({ type: AGENT_EVENT.CONTINUATION, toolCallId: 'e1' });
+    await controller.stopExecution();
+    expect(controller._deriveToolCards().get('e1').continuationPending).to.equal(false);
+    expect(controller._messages.at(-1).role).to.equal(ROLE.USER);
   });
 });

--- a/test/nx2/blocks/chat/messages/governance-evaluation-card-data.test.js
+++ b/test/nx2/blocks/chat/messages/governance-evaluation-card-data.test.js
@@ -1,0 +1,95 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  groupChecksByCategory,
+  sectionSummary,
+} from '../../../../../nx2/blocks/chat/messages/governance-evaluation-card-data.js';
+
+// ─── groupChecksByCategory ──────────────────────────────────────────────────
+
+describe('groupChecksByCategory', () => {
+  it('groups checks under their category, preserving first-seen order', () => {
+    const evaluations = [
+      {
+        check_id: '1', check_title: 'A', alignment: 'YES', category_id: 'cat-1', category: 'Voice',
+      },
+      {
+        check_id: '2', check_title: 'B', alignment: 'NO', category_id: 'cat-2', category: 'SEO',
+      },
+      {
+        check_id: '3', check_title: 'C', alignment: 'YES', category_id: 'cat-1', category: 'Voice',
+      },
+    ];
+
+    const groups = groupChecksByCategory(evaluations);
+
+    expect(groups).to.have.lengthOf(2);
+    expect(groups[0]).to.deep.equal({
+      categoryId: 'cat-1',
+      categoryName: 'Voice',
+      checks: [evaluations[0], evaluations[2]],
+    });
+    expect(groups[1]).to.deep.equal({
+      categoryId: 'cat-2',
+      categoryName: 'SEO',
+      checks: [evaluations[1]],
+    });
+  });
+
+  it('falls back to an Uncategorized bucket when category fields are missing', () => {
+    const evaluations = [{ check_id: '1', check_title: 'A', alignment: 'YES' }];
+
+    const groups = groupChecksByCategory(evaluations);
+
+    expect(groups).to.deep.equal([
+      { categoryId: 'uncategorized', categoryName: 'Uncategorized', checks: evaluations },
+    ]);
+  });
+
+  it('returns an empty array when given no evaluations', () => {
+    expect(groupChecksByCategory([])).to.deep.equal([]);
+    expect(groupChecksByCategory(undefined)).to.deep.equal([]);
+    expect(groupChecksByCategory(null)).to.deep.equal([]);
+  });
+});
+
+// ─── sectionSummary ─────────────────────────────────────────────────────────
+
+describe('sectionSummary', () => {
+  it('builds counts and percent from the section rollup fields', () => {
+    const section = {
+      successful_checks: 3,
+      failed_checks: 1,
+      not_applicable_checks: 2,
+      error_checks: 0,
+    };
+
+    expect(sectionSummary(section)).to.deep.equal({
+      successful: 3,
+      failed: 1,
+      notApplicable: 2,
+      error: 0,
+      total: 6,
+      percent: 75,
+    });
+  });
+
+  it('returns 0 percent when there are no successful or failed checks', () => {
+    const section = {
+      successful_checks: 0, failed_checks: 0, not_applicable_checks: 1, error_checks: 0,
+    };
+
+    expect(sectionSummary(section).percent).to.equal(0);
+  });
+
+  it('treats missing rollup fields as zero', () => {
+    expect(sectionSummary({})).to.deep.equal({
+      successful: 0, failed: 0, notApplicable: 0, error: 0, total: 0, percent: 0,
+    });
+  });
+
+  it('treats a missing section as all zeros', () => {
+    expect(sectionSummary(undefined)).to.deep.equal({
+      successful: 0, failed: 0, notApplicable: 0, error: 0, total: 0, percent: 0,
+    });
+  });
+});

--- a/test/nx2/blocks/chat/messages/governance-evaluation-card.test.js
+++ b/test/nx2/blocks/chat/messages/governance-evaluation-card.test.js
@@ -1,0 +1,439 @@
+import { expect } from '@esm-bundle/chai';
+import '../../../../../nx2/blocks/chat/messages/governance-evaluation-card.js';
+
+const TEXT_EVALUATION = {
+  evaluations: [
+    {
+      check_id: '1', check_title: 'Sophisticated Voice', alignment: 'YES', category_id: 'cat-1', category: 'Voice',
+    },
+    {
+      check_id: '2', check_title: 'Naming & Lexicon', alignment: 'YES', category_id: 'cat-1', category: 'Voice',
+    },
+    {
+      check_id: '3', check_title: 'No Shouty Caps', alignment: 'NO', category_id: 'cat-2', category: 'CTA',
+    },
+  ],
+  successful_checks: 2,
+  failed_checks: 1,
+  not_applicable_checks: 0,
+  error_checks: 0,
+};
+
+const IMAGE_EVALUATIONS = [
+  {
+    source: 'https://example.com/img1.png',
+    overall_aligned: true,
+    evaluations: [
+      {
+        check_id: 'i1', check_title: 'Color Palette', alignment: 'YES', category_id: 'cat-3', category: 'Visual',
+      },
+      {
+        check_id: 'i2', check_title: 'Packaging', alignment: 'NA', category_id: 'cat-3', category: 'Visual',
+      },
+    ],
+    successful_checks: 1,
+    failed_checks: 0,
+    not_applicable_checks: 1,
+    error_checks: 0,
+  },
+  {
+    source: 'https://example.com/img2.png',
+    overall_aligned: false,
+    evaluations: [
+      {
+        check_id: 'i3', check_title: 'Color Palette', alignment: 'NO', category_id: 'cat-3', category: 'Visual',
+      },
+    ],
+    successful_checks: 0,
+    failed_checks: 1,
+    not_applicable_checks: 0,
+    error_checks: 0,
+  },
+];
+
+function fullEvaluation(overrides = {}) {
+  return {
+    pageUrl: 'https://example.com/index',
+    brand_name: 'Frescopa Coffee',
+    text_evaluation: TEXT_EVALUATION,
+    image_evaluations: IMAGE_EVALUATIONS,
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+function makeCard(evaluation) {
+  const el = document.createElement('nx-governance-evaluation-card');
+  el.evaluation = evaluation;
+  document.body.appendChild(el);
+  return el;
+}
+
+function cleanup(el) {
+  el?.remove();
+}
+
+// ─── header & card-level collapse ──────────────────────────────────────────
+
+describe('nx-governance-evaluation-card header', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  it('renders the type label and title/subtitle', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.msg-type-label').textContent).to.contain('Governance Page Evaluation');
+    expect(card.shadowRoot.querySelector('.msg-title').textContent).to.contain('Frescopa Coffee');
+    expect(card.shadowRoot.querySelector('.ge-page-url').textContent).to.contain('https://example.com/index');
+  });
+
+  it('collapses the body when the header chevron is clicked', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    const details = card.shadowRoot.querySelector('details.ge-card');
+    expect(details.open).to.be.true;
+
+    card.shadowRoot.querySelector('.ge-header').click();
+    expect(details.open).to.be.false;
+  });
+
+  it('renders an aggregate summary combining text and image checks', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-summary-row').textContent).to.contain('3/5 passed');
+  });
+
+  it('does not throw and still renders a header when evaluation is entirely missing', async () => {
+    const el = document.createElement('nx-governance-evaluation-card');
+    document.body.appendChild(el);
+    card = el;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-header')).to.exist;
+  });
+});
+
+// ─── loading state ──────────────────────────────────────────────────────────
+
+describe('nx-governance-evaluation-card loading state', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  it('shows a spinner and no scorecard while loading, with no evaluation yet', async () => {
+    const el = document.createElement('nx-governance-evaluation-card');
+    el.loading = true;
+    document.body.appendChild(el);
+    card = el;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-loading')).to.exist;
+    expect(card.shadowRoot.querySelector('.msg-spinner')).to.exist;
+    expect(card.shadowRoot.querySelector('.ge-summary-row')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.ge-passed-badge')).to.not.exist;
+  });
+
+  it('does not show the spinner once loading is false, even with a falsy/unparseable evaluation', async () => {
+    card = makeCard(null);
+    card.loading = false;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-loading')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.msg-spinner')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.ge-header')).to.exist;
+  });
+});
+
+// ─── error state ─────────────────────────────────────────────────────────
+
+describe('nx-governance-evaluation-card error state', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  it('shows the error message and no scorecard/spinner when error is set', async () => {
+    const el = document.createElement('nx-governance-evaluation-card');
+    el.error = 'Page evaluation failed.';
+    document.body.appendChild(el);
+    card = el;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-error-text').textContent).to.contain('Page evaluation failed.');
+    expect(card.shadowRoot.querySelector('.ge-loading')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.ge-summary-row')).to.not.exist;
+  });
+
+  it('takes precedence over loading when both are set', async () => {
+    const el = document.createElement('nx-governance-evaluation-card');
+    el.error = 'Page evaluation failed.';
+    el.loading = true;
+    document.body.appendChild(el);
+    card = el;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-error-text')).to.exist;
+    expect(card.shadowRoot.querySelector('.ge-loading')).to.not.exist;
+  });
+
+  it('does not show the error state once error is cleared', async () => {
+    card = makeCard(fullEvaluation());
+    card.error = undefined;
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-error-text')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.ge-header')).to.exist;
+  });
+});
+
+// ─── text evaluation section ───────────────────────────────────────────────
+
+describe('nx-governance-evaluation-card text section', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  it('groups checks into one accordion category per distinct category', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    const textSection = card.shadowRoot.querySelector('.ge-text-section');
+    expect(textSection.querySelectorAll('.ge-category')).to.have.lengthOf(2);
+  });
+
+  it('keeps checks hidden until their category is opened', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    const textSection = card.shadowRoot.querySelector('.ge-text-section');
+    const category = textSection.querySelector('.ge-category');
+    expect(category.open).to.be.false;
+
+    textSection.querySelector('.ge-cat-header').click();
+    expect(category.open).to.be.true;
+    expect(category.querySelectorAll('.ge-check-row')).to.have.lengthOf(2);
+  });
+
+  it('shows a neutral placeholder when text_evaluation is missing', async () => {
+    card = makeCard(fullEvaluation({ text_evaluation: null }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-text-section .ge-category')).to.not.exist;
+    expect(card.shadowRoot.querySelector('.ge-text-section .ge-section-empty')).to.exist;
+  });
+
+  it('shows a neutral placeholder when text_evaluation has no evaluations', async () => {
+    card = makeCard(fullEvaluation({ text_evaluation: { evaluations: [] } }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-text-section .ge-section-empty')).to.exist;
+  });
+});
+
+// ─── image evaluation sections ──────────────────────────────────────────────
+
+describe('nx-governance-evaluation-card image sections', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  async function openImageGroup() {
+    card.shadowRoot.querySelector('.ge-image-group .ge-group-header').click();
+    await card.updateComplete;
+  }
+
+  it('collapses the image group by default, showing count and passing rate in the header', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+
+    const group = card.shadowRoot.querySelector('.ge-image-group');
+    expect(group).to.exist;
+    expect(group.open).to.be.false;
+
+    expect(group.querySelector('.ge-group-meta').textContent).to.contain('2 images evaluated');
+    expect(group.querySelector('.ge-group-header .ge-passed-badge').textContent).to.contain('1/2 passed');
+  });
+
+  it('reads "1 image evaluated" (singular) with a single image', async () => {
+    card = makeCard(fullEvaluation({ image_evaluations: [IMAGE_EVALUATIONS[0]] }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-group-meta').textContent).to.contain('1 image evaluated');
+  });
+
+  it('reveals the image list when the header is clicked and hides it again on a second click', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+
+    const group = card.shadowRoot.querySelector('.ge-image-group');
+    await openImageGroup();
+    expect(group.open).to.be.true;
+
+    await openImageGroup();
+    expect(group.open).to.be.false;
+  });
+
+  it('renders one section per image evaluation with a thumbnail and alignment badge', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    await openImageGroup();
+    const sections = card.shadowRoot.querySelectorAll('.ge-image-section');
+    expect(sections).to.have.lengthOf(2);
+
+    const [first, second] = sections;
+    expect(first.querySelector('.ge-image-thumb').getAttribute('src')).to.equal('https://example.com/img1.png');
+    expect(first.querySelector('.ge-align-badge').classList.contains('ge-align-badge-pass')).to.be.true;
+    expect(second.querySelector('.ge-align-badge').classList.contains('ge-align-badge-fail')).to.be.true;
+  });
+
+  it('groups image sections under an "Image evaluations" heading', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    const group = card.shadowRoot.querySelector('.ge-image-group');
+    expect(group).to.exist;
+    expect(group.querySelector('.ge-section-title').textContent).to.equal('Image evaluations');
+
+    const titles = [...card.shadowRoot.querySelectorAll('.ge-section-title')].map((el) => el.textContent);
+    expect(titles).to.deep.equal(['Text evaluation', 'Image evaluations']);
+  });
+
+  it('renders no image group when image_evaluations is empty', async () => {
+    card = makeCard(fullEvaluation({ image_evaluations: [] }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelector('.ge-image-group')).to.not.exist;
+  });
+
+  it('renders no image sections when image_evaluations is missing', async () => {
+    card = makeCard(fullEvaluation({ image_evaluations: undefined }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelectorAll('.ge-image-section')).to.have.lengthOf(0);
+  });
+
+  it('renders no image sections when image_evaluations is empty', async () => {
+    card = makeCard(fullEvaluation({ image_evaluations: [] }));
+    await card.updateComplete;
+    expect(card.shadowRoot.querySelectorAll('.ge-image-section')).to.have.lengthOf(0);
+  });
+
+  it('keeps category open-state independent between images sharing the same category name', async () => {
+    card = makeCard(fullEvaluation());
+    await card.updateComplete;
+    await openImageGroup();
+    const [first, second] = card.shadowRoot.querySelectorAll('.ge-image-section');
+
+    first.querySelector('.ge-cat-header').click();
+
+    expect(first.querySelector('.ge-category').open).to.be.true;
+    expect(second.querySelector('.ge-category').open).to.be.false;
+  });
+});
+
+// ─── check row alignment rendering ──────────────────────────────────────────
+
+describe('nx-governance-evaluation-card check alignment icons', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  it('renders a distinct icon class per alignment value, and an error state when check.error is set', async () => {
+    const evaluation = fullEvaluation({
+      text_evaluation: {
+        evaluations: [
+          {
+            check_id: '1', check_title: 'Yes check', alignment: 'YES', category_id: 'c', category: 'C',
+          },
+          {
+            check_id: '2', check_title: 'No check', alignment: 'NO', category_id: 'c', category: 'C',
+          },
+          {
+            check_id: '3', check_title: 'NA check', alignment: 'NA', category_id: 'c', category: 'C',
+          },
+          {
+            check_id: '4', check_title: 'Error check', alignment: null, error: 'timed out', category_id: 'c', category: 'C',
+          },
+        ],
+        successful_checks: 1,
+        failed_checks: 1,
+        not_applicable_checks: 1,
+        error_checks: 1,
+      },
+      image_evaluations: [],
+    });
+    card = makeCard(evaluation);
+    await card.updateComplete;
+
+    card.shadowRoot.querySelector('.ge-text-section .ge-cat-header').click();
+    await card.updateComplete;
+
+    const rows = card.shadowRoot.querySelectorAll('.ge-text-section .ge-check-row');
+    expect(rows[0].querySelector('.ge-check-yes')).to.exist;
+    expect(rows[1].querySelector('.ge-check-no')).to.exist;
+    expect(rows[2].querySelector('.ge-check-na')).to.exist;
+    expect(rows[3].querySelector('.ge-check-error')).to.exist;
+  });
+});
+
+// ─── check reasoning & suggestions ─────────────────────────────────────────
+
+describe('nx-governance-evaluation-card check reasoning & suggestions', () => {
+  let card;
+  afterEach(() => cleanup(card));
+
+  function evaluationWithChecks(checks) {
+    return fullEvaluation({
+      text_evaluation: {
+        evaluations: checks,
+        successful_checks: checks.filter((c) => c.alignment === 'YES').length,
+        failed_checks: checks.filter((c) => c.alignment === 'NO').length,
+        not_applicable_checks: checks.filter((c) => c.alignment === 'NA').length,
+        error_checks: 0,
+      },
+      image_evaluations: [],
+    });
+  }
+
+  it('auto-expands failed checks and shows both reasoning and suggestion', async () => {
+    card = makeCard(evaluationWithChecks([
+      {
+        check_id: '1', check_title: 'No Shouty Caps', alignment: 'NO', category_id: 'c', category: 'C', reasoning: 'Uses all caps.', suggestions: 'Use title case.',
+      },
+    ]));
+    await card.updateComplete;
+
+    card.shadowRoot.querySelector('.ge-text-section .ge-cat-header').click();
+
+    const checkItem = card.shadowRoot.querySelector('.ge-check-item');
+    expect(checkItem.open).to.be.true;
+    const detail = checkItem.querySelector('.ge-check-detail');
+    expect(detail.textContent).to.contain('Uses all caps.');
+    expect(detail.textContent).to.contain('Use title case.');
+    expect(detail.querySelector('.ge-check-suggestion')).to.exist;
+  });
+
+  it('keeps passing checks collapsed by default, showing reasoning without a suggestion once expanded', async () => {
+    card = makeCard(evaluationWithChecks([
+      {
+        check_id: '1', check_title: 'Sophisticated Voice', alignment: 'YES', category_id: 'c', category: 'C', reasoning: 'Warm, sensory language throughout.', suggestions: null,
+      },
+    ]));
+    await card.updateComplete;
+
+    card.shadowRoot.querySelector('.ge-text-section .ge-cat-header').click();
+    const checkItem = card.shadowRoot.querySelector('.ge-check-item');
+    expect(checkItem.open).to.be.false;
+
+    card.shadowRoot.querySelector('.ge-text-section .ge-check-row').click();
+    expect(checkItem.open).to.be.true;
+
+    const detail = checkItem.querySelector('.ge-check-detail');
+    expect(detail.textContent).to.contain('Warm, sensory language throughout.');
+    expect(detail.querySelector('.ge-check-suggestion')).to.not.exist;
+  });
+
+  it('toggles a single check row independently of its siblings', async () => {
+    card = makeCard(evaluationWithChecks([
+      {
+        check_id: '1', check_title: 'Check A', alignment: 'NO', category_id: 'c', category: 'C', reasoning: 'Reason A.', suggestions: 'Fix A.',
+      },
+      {
+        check_id: '2', check_title: 'Check B', alignment: 'NO', category_id: 'c', category: 'C', reasoning: 'Reason B.', suggestions: 'Fix B.',
+      },
+    ]));
+    await card.updateComplete;
+
+    card.shadowRoot.querySelector('.ge-text-section .ge-cat-header').click();
+
+    const items = card.shadowRoot.querySelectorAll('.ge-text-section .ge-check-item');
+    expect(items).to.have.lengthOf(2);
+    expect(items[0].open).to.be.true;
+    expect(items[1].open).to.be.true;
+
+    items[0].querySelector('.ge-check-row').click();
+
+    expect(items[0].open).to.be.false;
+    expect(items[1].open).to.be.true;
+  });
+});

--- a/test/nx2/blocks/chat/renderers/renderers.test.js
+++ b/test/nx2/blocks/chat/renderers/renderers.test.js
@@ -1,11 +1,20 @@
 import { expect } from '@esm-bundle/chai';
 import { render } from 'da-lit';
 import { renderMessage } from '../../../../../nx2/blocks/chat/renderers/renderers.js';
+import { PART_TYPE, TOOL_STATE } from '../../../../../nx2/blocks/chat/constants.js';
 
 // Render an assistant message and return the mounted container for DOM assertions.
 function renderAssistant(content) {
   const host = document.createElement('div');
   render(renderMessage({ role: 'assistant', content }), host);
+  return host;
+}
+
+// Render a single-tool assistant message through the da-agent tool-card path.
+function renderTool(toolCallId, toolCards, opts) {
+  const host = document.createElement('div');
+  const msg = { role: 'assistant', content: [{ type: PART_TYPE.TOOL, toolCallId }] };
+  render(renderMessage(msg, toolCards, opts), host);
   return host;
 }
 
@@ -59,5 +68,67 @@ describe('renderers link handling', () => {
   it('does not linkify non-http schemes', () => {
     const host = renderAssistant('Reach me at mailto:me@example.com please.');
     expect(host.querySelector('.message-content a')).to.equal(null);
+  });
+});
+
+describe('renderers da-agent tool cards', () => {
+  it('renders exit_plan_mode as a plan card even while awaiting approval', () => {
+    const toolCards = new Map([['p1', {
+      toolName: 'exit_plan_mode',
+      input: { title: 'Launch', tasks: [{ id: '1', label: 'Draft', status: 'pending' }] },
+      state: TOOL_STATE.AWAITING_APPROVAL,
+    }]]);
+    const host = renderTool('p1', toolCards, {});
+    const card = host.querySelector('nx-campaign-plan-card');
+    expect(card).to.exist;
+    expect(card.plan.title).to.equal('Launch');
+  });
+
+  it('wires the plan card Run action to approve the exit_plan_mode tool call', () => {
+    const approvals = [];
+    const toolCards = new Map([['p1', {
+      toolName: 'exit_plan_mode',
+      input: { title: 'Launch', tasks: [{ id: '1', label: 'Draft', status: 'pending' }] },
+      state: TOOL_STATE.AWAITING_APPROVAL,
+    }]]);
+    const host = renderTool('p1', toolCards, {
+      onApprove: (id, approved) => approvals.push([id, approved]),
+    });
+    const card = host.querySelector('nx-campaign-plan-card');
+    card.dispatchEvent(new CustomEvent('nx-plan-run', { bubbles: true, composed: true }));
+    expect(approvals).to.deep.equal([['p1', true]]);
+  });
+
+  it('merges :::task-item status from streaming text into the plan card', () => {
+    const toolCards = new Map([['p1', {
+      toolName: 'exit_plan_mode',
+      input: { title: 'Launch', tasks: [{ id: '1', label: 'Draft', status: 'pending' }] },
+      state: TOOL_STATE.OUTPUT_AVAILABLE,
+    }]]);
+    const streamingText = ':::task-item\n{"label":"Draft","status":"done"}\n:::';
+    const host = renderTool('p1', toolCards, { streamingText });
+    expect(host.querySelector('nx-campaign-plan-card').plan.tasks[0].status).to.equal('done');
+  });
+
+  it('renders evaluate_page output as a governance-evaluation card', () => {
+    const toolCards = new Map([['e1', {
+      toolName: 'evaluate_page',
+      input: {},
+      state: TOOL_STATE.OUTPUT_AVAILABLE,
+      output: { status: 'fail', checks: [] },
+    }]]);
+    const host = renderTool('e1', toolCards, {});
+    expect(host.querySelector('nx-governance-evaluation-card')).to.exist;
+  });
+
+  it('hides a normal tool card while it awaits approval (approval shown elsewhere)', () => {
+    const toolCards = new Map([['c1', {
+      toolName: 'content_create',
+      input: { path: '/a/b' },
+      state: TOOL_STATE.AWAITING_APPROVAL,
+    }]]);
+    const host = renderTool('c1', toolCards, {});
+    expect(host.querySelector('.tool-card')).to.equal(null);
+    expect(host.querySelector('nx-campaign-plan-card')).to.equal(null);
   });
 });

--- a/test/nx2/blocks/chat/utils/tool-name.test.js
+++ b/test/nx2/blocks/chat/utils/tool-name.test.js
@@ -1,0 +1,25 @@
+import { expect } from '@esm-bundle/chai';
+import { mcpToolName } from '../../../../../nx2/blocks/chat/utils/tool-name.js';
+
+describe('mcpToolName', () => {
+  it('strips the mcp__<server>__ prefix off an MCP-qualified tool name', () => {
+    expect(mcpToolName('mcp__server__mock_tool')).to.equal('mock_tool');
+  });
+
+  it('resolves to the same short name regardless of the server segment', () => {
+    expect(mcpToolName('mcp__some-renamed-server__mock_tool')).to.equal('mock_tool');
+  });
+
+  it('returns native (non-MCP) tool names unchanged', () => {
+    expect(mcpToolName('content_create')).to.equal('content_create');
+  });
+
+  it('preserves underscores that are part of the tool name itself', () => {
+    expect(mcpToolName('mcp__server__tool_with_underscore')).to.equal('tool_with_underscore');
+  });
+
+  it('returns undefined/null unchanged', () => {
+    expect(mcpToolName(undefined)).to.equal(undefined);
+    expect(mcpToolName(null)).to.equal(null);
+  });
+});


### PR DESCRIPTION
## Summary

Rebuilds the plan-mode assistant client (originally #522) on top of the #648
"ao support via config" architecture (`ChatBackend` facade + `<nx-chat-interaction>`
+ adapter-shaped tool cards). #522 was written against the pre-#648 `ChatController`
+ inline-approval-card design and cannot be merged mechanically — the two branches
independently implemented plan/approval with incompatible structures. **This PR
supersedes #522** and is the client counterpart to **da-agent #49** (`enter_plan_mode`
/ `exit_plan_mode`, `:::task-item` directives, and the `data-continuation` gate).

## Why

da-agent #49 shipped the server side of plan mode + the continuation gate without a
client that could render them on the #648 architecture. On `main` today, `exit_plan_mode`
shows a raw JSON approval card and `data-continuation` has no UI (it was disabled
server-side in da-agent #71 to avoid hanging the turn). This PR provides that client.

## What changed — mapped to da-agent behavior

- **Plan card** — `exit_plan_mode` (approval-gated, carries `{title, tasks[]}`) renders
  inline in the stream as `<nx-campaign-plan-card>` in every state, with **Run** wired to
  `approveToolCall`. Excluded from the generic approval popover so it isn't shown twice.
- **Task progress** — `_taskText` concatenates assistant text; `mergeTaskItemsFromText`
  merges `:::task-item` status into the plan card by label (last-wins) → Run → Running… → Done.
- **Continuation gate** — ported the backend into `chat-controller.js` (`CONTINUATION`
  event, `continuationPending`, `continueExecution`/`stopExecution`) and `stream.js`; surfaced
  as a `{type:'continuation'}` interaction; **Continue/Stop** card in `<nx-chat-interaction>`
  (Enter/Esc), via a neutral `renderContinuationCard` in `card-renderers.js`.
- **Governance card** — `evaluate_page` output → `<nx-governance-evaluation-card>`
  (loading / error / result).

Brings in #522's `messages/*` card components + CSS and `utils/directives.js` /
`utils/tool-name.js` verbatim (already unit-tested). Purely additive over `main`
(~+2.1k/−19 in the chat block); the AO path is untouched.

## Test plan

- ✅ `npm test` — 150/150 chat tests pass, including new coverage for: plan-card render +
  Run→approve, `:::task-item` status merge, governance card, continuation interaction,
  `exit_plan_mode` approval-skip, and `continue/stopExecution` proxying.
- ✅ ESLint + Stylelint clean.
- ⏳ Local E2E (frescopa): plan card renders → Run → task progress. Continuation Continue/Stop
  verified against a da-agent with the gate enabled. (Governance card needs a governance MCP
  (`GOVERNANCE_AGENT_URL`) to exercise live; covered by unit tests.)

## Risks / coordination

- **Continuation gate is currently disabled server-side** (da-agent #71 commented out
  `continuationApprovalPatterns: ['evaluate_*']`). Once this client is merged and deployed,
  **re-enable it** in da-agent so the Continue/Stop UI activates.
- AO path (`ChatControllerAO`) is unchanged; continuation is da-agent-only.

## Related

- Supersedes #522 (close as superseded)
- Client for adobe-rnd/da-agent#49
- Pairs with the temporary stabilization adobe-rnd/da-agent#71 (revert after this ships)
- Built on #648