### PR TITLE
fix: keep permissions on adapted json responses

### DIFF
--- a/nx2/utils/api.js
+++ b/nx2/utils/api.js
@@ -775,7 +775,11 @@ function normalizePath(path) {
 
 // Create a new response with a different JSON response body
 function adaptJsonResponse(resp, obj) {
-  return new Response(JSON.stringify(obj), resp);
+  const adapted = new Response(JSON.stringify(obj), resp);
+  // new Response(body, init) copies status, statusText and headers only, so the
+  // permissions daFetch attached to the original response are carried over here.
+  adapted.permissions = resp.permissions;
+  return adapted;
 }
 
 function jsonOpts(method, payload) {

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -457,6 +457,21 @@ describe('api.js', () => {
       expect(json.source.contentUrl).to.equal(`${AEM_API}/${o}/sites/${s}/source/docs/.foo/image.png`);
     });
 
+    it('source.save hlx6 keeps permissions on the response', async () => {
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const resp = await source.save({ org: o, site: s, path: '/page.html', body: '<main></main>' });
+      expect(resp.ok).to.equal(true);
+      expect(resp.permissions).to.deep.equal(['read', 'write']);
+    });
+
+    it('source.save hlx6 keeps permissions parsed from response headers', async () => {
+      restoreFetch();
+      installFetch({ headers: { 'x-da-actions': 'role=read,write,delete' } });
+      const { org: o, site: s } = makeOrgSite({ hlx6: true });
+      const resp = await source.save({ org: o, site: s, path: '/page.html', body: '<main></main>' });
+      expect(resp.permissions).to.deep.equal(['read', 'write', 'delete']);
+    });
+
     it('source.save hlx6 uses the response location header for contentUrl when present', async () => {
       restoreFetch();
       installFetch({ body: '', headers: { location: '/docs/renamed.png' } });


### PR DESCRIPTION

`adaptJsonResponse` rebuilds the response with `new Response(body, resp)`, which copies status, statusText and headers only, so the permissions `daFetch` set on the original were dropped. on hlx6 that left `source.save` returning a response without them. da-live's `initProse` then threw on `permissions.some(...)`, so creating a document did not open the editor.

the same helper runs in `config.get`, so this also restores write access to the site-config sheet on hlx6.

testing: da-live's Playwright Helix suite, pinned to this branch, is 109 passed and 0 failed. it had been 27 failed since 2026-08-07. hand-tested on da.live against a local nx2, where creating a document on a hlx6 site opens the editor with `contenteditable="true"`.
