### PR TITLE
feat: add auto-authorization config option for Smartling

### DIFF
--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -1,6 +1,7 @@
 import { Queue } from '../../../../../nx2/public/utils/tree.js';
 import { addDnt, removeDnt } from '../../dnt/dnt.js';
 import { DA_TRANSLATE } from '../../../../../nx2/utils/utils.js';
+import fetchWithRetry from '../../utils/fetchWithRetry.js';
 
 export const dnt = { addDnt };
 
@@ -46,7 +47,7 @@ function refreshTheToken(name, env, endpoint) {
     const body = JSON.stringify({ refreshToken: currRefreshToken });
     const opts = { ...BASE_OPTS, body };
 
-    const resp = await fetch(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
     if (!resp.ok) token = undefined;
     const json = await resp.json();
 
@@ -84,7 +85,7 @@ export async function connect(service) {
 
   const opts = { ...BASE_OPTS, body };
 
-  const resp = await fetch(`${endpoint}/auth-api/v2/authenticate`, opts);
+  const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate`, opts);
   if (!resp.ok) return false;
   const json = await resp.json();
   const { accessToken, refreshToken } = json?.response?.data || {};
@@ -111,7 +112,7 @@ async function uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls) {
 
     const opts = { method: 'POST', body, headers: { Authorization: `Bearer ${token}` } };
 
-    const resp = await fetch(uploadUrl, opts);
+    const resp = await fetchWithRetry(uploadUrl, opts);
     const json = await resp.json();
     results.push(json.response.code);
   }
@@ -129,7 +130,7 @@ async function createJob(endpoint, projectId, title, langs) {
   opts.headers.Authorization = `Bearer ${token}`;
 
   const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs`;
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { translationJobUid: jobUid } = json.response.data;
@@ -148,7 +149,7 @@ async function createBatch(endpoint, projectId, jobUid, urls) {
 
   const url = `${endpoint}/job-batches-api/v2/projects/${projectId}/batches`;
 
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { batchUid } = json.response.data;
@@ -159,7 +160,7 @@ async function downloadFile(opts, origin, projectId, lang, url) {
   const reqUrl = new URL(`${origin}/files-api/v2/projects/${projectId}/locales/${lang.code}/file`);
   reqUrl.searchParams.append('fileUri', url.daBasePath);
 
-  const resp = await fetch(reqUrl, opts);
+  const resp = await fetchWithRetry(reqUrl, opts);
   return resp.text();
 }
 
@@ -263,7 +264,7 @@ export async function getStatusAll({
   langs.forEach((lang) => { lang.translation.translated = 0; });
 
   for (const url of urls) {
-    const resp = await fetch(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
     const { response } = await resp.json();
     if (response.code !== 'SUCCESS') return;
     const langReports = response?.data?.contentProgressReport;

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -137,9 +137,20 @@ async function createJob(endpoint, projectId, title, langs) {
   return jobUid;
 }
 
-async function createBatch(endpoint, projectId, jobUid, urls) {
+/**
+ * Creates a job batch for the uploaded files.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} jobUid - The job to attach the batch to.
+ * @param {Object[]} urls - The urls that will be uploaded to this batch.
+ * @param {boolean} autoAuthorize - Whether Smartling should immediately
+ *  authorize the job for translation once the batch finishes processing,
+ *  instead of requiring manual authorization in Smartling's dashboard.
+ * @returns {Promise<string|null>} The new batch's id, or null on failure.
+ */
+async function createBatch(endpoint, projectId, jobUid, urls, autoAuthorize) {
   const body = JSON.stringify({
-    authorize: false,
+    authorize: autoAuthorize,
     translationJobUid: jobUid,
     fileUris: urls.map((url) => url.daBasePath),
   });
@@ -210,12 +221,28 @@ export async function saveItems({
   });
 }
 
+/**
+ * Sends a translation project's urls to Smartling for every target
+ * language: creates a job, creates a batch (optionally auto-authorized),
+ * then uploads all urls to it.
+ * @param {Object} params
+ * @param {string} params.org - The DA org.
+ * @param {string} params.site - The DA site.
+ * @param {string} params.title - The project title.
+ * @param {Object} params.options - Project options; reads/mutates
+ *  `options.service`.
+ * @param {Object[]} params.langs - Target languages; mutated in place with
+ *  `translation` status.
+ * @param {Object[]} params.urls - The urls to translate.
+ * @param {Object} params.actions - `{ sendMessage, saveState }` callbacks.
+ * @returns {Promise<void>}
+ */
 export async function sendAllLanguages({
   org, site, title, options, langs, urls, actions,
 }) {
   const { sendMessage, saveState } = actions;
 
-  const { origin, projectId } = options.service;
+  const { origin, projectId, autoAuthorize } = options.service;
   const endpoint = resolveOrigin(origin, org, site);
 
   sendMessage({ text: `Creating job in Smartling for: ${title}.` });
@@ -229,7 +256,7 @@ export async function sendAllLanguages({
   // config[`${env}.jobUid`] = jobUid;
 
   sendMessage({ text: `Creating a batch in Smartling for: ${title}.` });
-  const batchUid = await createBatch(endpoint, projectId, jobUid, urls);
+  const batchUid = await createBatch(endpoint, projectId, jobUid, urls, autoAuthorize === 'yes');
   if (!batchUid) return;
 
   // Presist to the state for future reference

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -2,6 +2,11 @@ const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_BASE_DELAY_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 30000;
 
+/**
+ * Default retry predicate: rate-limited or server-error responses.
+ * @param {number} status - The response's HTTP status code.
+ * @returns {boolean} Whether the status should trigger a retry.
+ */
 function isDefaultRetryable(status) {
   return status === 429 || status >= 500;
 }
@@ -41,6 +46,12 @@ export default async function fetchWithRetry(url, opts, config = {}) {
     isRetryable = isDefaultRetryable,
   } = config;
 
+  /**
+   * Makes one fetch attempt, retrying itself (with a delay) if the
+   * response is retryable and attempts remain.
+   * @param {number} attemptNum - Zero-based attempt count so far.
+   * @returns {Promise<Response>} The final response (ok or not).
+   */
   async function attempt(attemptNum) {
     const resp = await fetch(url, opts);
     if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -1,0 +1,60 @@
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+function isDefaultRetryable(status) {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Resolves after the given delay.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Fetches, retrying on rate-limit/transient-failure responses with
+ * exponential backoff and jitter, honoring a Retry-After header when the
+ * service provides one. Shared across loc connectors (Smartling,
+ * Lionbridge, ...) whose translation APIs enforce request-rate and/or
+ * concurrent-request limits.
+ * @param {string|URL} url - The request URL.
+ * @param {Object} opts - Fetch options.
+ * @param {Object} [config]
+ * @param {number} [config.maxRetries] - Max retry attempts after the
+ *  initial request.
+ * @param {number} [config.baseDelayMs] - Base delay before the first
+ *  retry; doubles each subsequent attempt.
+ * @param {number} [config.maxDelayMs] - Delay cap, before jitter.
+ * @param {(status: number) => boolean} [config.isRetryable] - Whether a
+ *  response status should trigger a retry. Defaults to 429 and 5xx.
+ * @returns {Promise<Response>} The final response (ok or not).
+ */
+export default async function fetchWithRetry(url, opts, config = {}) {
+  const {
+    maxRetries = DEFAULT_MAX_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    isRetryable = isDefaultRetryable,
+  } = config;
+
+  async function attempt(attemptNum) {
+    const resp = await fetch(url, opts);
+    if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;
+
+    const retryAfterSecs = Number(resp.headers.get('retry-after'));
+    const backoff = Math.min(baseDelayMs * (2 ** attemptNum), maxDelayMs);
+    const jitter = Math.random() * backoff * 0.3;
+    const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+      ? retryAfterSecs * 1000
+      : backoff + jitter;
+
+    await wait(delayMs);
+    return attempt(attemptNum + 1);
+  }
+
+  return attempt(0);
+}

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -185,4 +185,46 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(downloadCalls).to.equal(2);
     expect(urls[0].status).to.equal('success');
   });
+
+  it('does not auto-authorize the batch by default', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(false);
+  });
+
+  it('auto-authorizes the batch when translation.service.autoAuthorize is "yes"', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1', autoAuthorize: 'yes' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(true);
+  });
+
+  it('does not auto-authorize when autoAuthorize is set to anything other than "yes"', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1', autoAuthorize: 'no' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(false);
+  });
 });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -120,4 +120,69 @@ describe('smartling connector - legacy origin rewriting', () => {
     const call = calls.find((c) => c.url.includes('/files-api/v2/projects'));
     expect(call.url).to.include(`${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/locales/fr-FR/file`);
   });
+
+  it('retries a 429 from getStatusAll progress polling before succeeding', async () => {
+    let progressCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/progress')) {
+        progressCalls += 1;
+        if (progressCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response(JSON.stringify({
+          response: {
+            code: 'SUCCESS',
+            data: { contentProgressReport: [{ targetLocaleId: 'fr-FR', progress: null }] },
+          },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(progressCalls).to.equal(2);
+    expect(langs[0].translation.status).to.equal('translated');
+  });
+
+  it('retries a 429 from saveItems file download before succeeding', async () => {
+    let downloadCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/files-api/v2/projects')) {
+        downloadCalls += 1;
+        if (downloadCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response('translated content', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const lang = { code: 'fr-FR' };
+    const urls = [{ daBasePath: '/page', ext: 'html' }];
+    const saveFn = async (url) => { url.status = 'success'; };
+
+    await saveItems({
+      org, site, service, lang, urls, saveFn,
+    });
+
+    expect(downloadCalls).to.equal(2);
+    expect(urls[0].status).to.equal('success');
+  });
 });

--- a/test/loc/utils/fetchWithRetry.test.js
+++ b/test/loc/utils/fetchWithRetry.test.js
@@ -1,0 +1,99 @@
+import { expect } from '@esm-bundle/chai';
+import fetchWithRetry from '../../../nx/blocks/loc/utils/fetchWithRetry.js';
+
+let origFetch;
+
+function installFetch(handler) {
+  origFetch = window.fetch;
+  window.fetch = handler;
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+describe('fetchWithRetry', () => {
+  afterEach(() => restoreFetch());
+
+  it('returns the response immediately when it is not retryable', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(1);
+  });
+
+  it('retries a 429, honoring Retry-After, then succeeds', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('retries a 503 with exponential backoff when there is no Retry-After', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 503 });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { baseDelayMs: 5, maxDelayMs: 20 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('gives up after maxRetries and returns the last failing response', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 429, headers: { 'Retry-After': '0.001' } });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { maxRetries: 2 });
+
+    expect(resp.status).to.equal(429);
+    expect(calls).to.equal(3); // initial attempt + 2 retries
+  });
+
+  it('does not retry statuses outside the default retryable set', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 404 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(404);
+    expect(calls).to.equal(1);
+  });
+
+  it('honors a custom isRetryable predicate', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 418, headers: { 'Retry-After': '0.001' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { isRetryable: (status) => status === 418 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Summary
Smartling's `job-batches-api` already supports an `authorize` flag on batch creation — previously hardcoded to `false` in this connector, meaning every job requires manual authorization in Smartling's own dashboard before translation work starts.

Adds a new site config value, `translation.service.{env}.autoAuthorize` ("yes" to enable), read at send time and passed through to `createBatch`. When enabled, a job's content is immediately authorized for translation as soon as its batch finishes processing.

## Design choice
Site-level config rather than a per-project toggle in the Options UI: the existing custom-fields mechanism (`translation.service.custom.*`, used for Trados's Template/Notes fields) only supports dropdowns and free-text, not checkboxes, and this reads more like a fixed site-wide policy (does this org want translation to start immediately, or always go through manual review?) than something to decide per project.

## Tests
- Three new tests: default (`authorize: false`), enabled (`autoAuthorize: 'yes'` → `authorize: true`), and explicitly disabled (`autoAuthorize: 'no'` → `authorize: false`, confirming it's an exact-match check, not a truthy check on any non-empty string).
- Full `npm test` and lint pass.

## Note on branch base
Stacked on top of #657 (the Smartling rate-limit fix) rather than `main` directly, since this connector needed that fix regardless. The diff will show just this change once #657 merges.