### PR TITLE
feat: Smartling connector enhancements (rate-limit fix, auto-authorization, session recovery)

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-13
 
+### smartling connector — surface connector errors, fix translate.js message clobbering
+
+`createJob`/`createBatch`/`uploadFiles` now parse Smartling's documented error envelope (`response.errors[].message`) and call `sendMessage({ type: 'error' })` on failure instead of silently returning `null` (matches Trados's existing pattern) — found via a live 400 (language mismatch) that went unsurfaced.
+
+Found via that same live test: the error still didn't render. `translate.js`'s `handleSendAll` unconditionally calls `checkAndSaveLangs` right after the connector call, which immediately overwrites/clears the message before it can be seen — a pre-existing bug affecting every connector's error messages, not just Smartling's. Fixed by skipping `checkAndSaveLangs` when the last message set was type `error`.
+
 ### smartling connector — session-expiry recovery, stale-token fix
 
 Refresh now falls back to a full re-authenticate when it fails (Smartling sessions cap at 12h regardless of refresh count, so long jobs eventually hit a dead refresh token). Tracks the API's real `expiresIn` instead of a hardcoded interval. `saveItems` no longer reuses a token snapshot taken before its download batch started.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-14
 
+### loc translate view — hide Get status once nothing's incomplete
+
+Once every sent language is `'complete'`/`'cancelled'`, "Get status" was already a functional no-op (`getStatusAll` skips its own API call when there's nothing non-terminal left) but still showed, spun, and triggered a redundant DA save on click. Gated the button on `this.incompleteLangs` — the same predicate already driving Cancel-button visibility — so it hides once there's nothing left to check.
+
 ### loc translate view — hide Cancel buttons once nothing's left to cancel
 
 `renderCancelLang`'s guard only excluded `'cancelled'` status, never `'complete'`, so a completed language's per-row Cancel button stayed visible as long as some other language in the project was still in progress. Separately, `incompleteLangs` counted a language as cancellable even with no `translation` object at all (never sent), so "Cancel project" could show with nothing actually cancellable. Extracted a single `canCancelLang(lang)` predicate (has `translation`, not `'cancelled'`, not `'complete'`) used consistently by `renderCancelLang`, `incompleteLangs`, and the `with-cancel` grid-column class, so all three can't drift out of sync with each other again.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-13
 
+### smartling connector — stop re-saving already-completed languages
+
+`getStatusAll` unconditionally set `lang.translation.status = 'translated'` whenever every url was 100% on Smartling's side — but Smartling keeps reporting 100% forever once done, so every subsequent "Get status" click reverted a lang's `'complete'` (set by `saveLangItemsToDa` after actually saving to DA) back to `'translated'`, which re-triggered a redundant download/save each time. Fixed by skipping langs already at `'complete'`, mirroring a guard GLaaS already has (`determineStatus`'s "Respect existing final statuses"). Trados has the identical bug in its own `getStatusAll` — deferred, not fixed here.
+
 ### smartling connector — surface connector errors, fix translate.js message clobbering
 
 `createJob`/`createBatch`/`uploadFiles` now parse Smartling's documented error envelope (`response.errors[].message`) and call `sendMessage({ type: 'error' })` on failure instead of silently returning `null` (matches Trados's existing pattern) — found via a live 400 (language mismatch) that went unsurfaced.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,6 +2,16 @@
 
 ## 2026-08-13
 
+### loc translate view — loading spinners on action buttons
+
+Added a `.nx-loading-spinner` CSS spinner (`translate.css`) and busy-state flags for every async action button in `translate.js` (Connect, Get status, Translate all, Cancel project, Copy all, per-language Cancel), disabling the button and showing the spinner while its handler is in flight. Combined the two spinner patterns already in the repo rather than adding a third: the `.nx-loading-spinner`/`da-spin` naming from `nx2/styles/buttons.css` (defined there but never actually wired to anything) with the `currentcolor` border technique from the one spinner that's actually shipping (`nx2/blocks/ew-actions/ew-actions.js`) — needed since these buttons have different text colors per variant (white on `.accent`, gray on `.primary.outline`). Per-language Cancel uses a `_cancelingLangs` Set (one row can be busy independently of others) rather than a single flag.
+
+### smartling connector — implement cancelTranslation
+
+Smartling had no `cancelTranslation` at all (the `sample` connector's stub), so `translate.js`'s `canCancel` getter (`!!connector.cancelTranslation`) was always false and the Cancel buttons never rendered for Smartling projects. Confirmed the correct endpoint against Smartling's official OpenAPI spec (github.com/Smartling/api-docs) before implementing: `DELETE /jobs-api/v3/projects/{projectId}/jobs/{translationJobUid}/locales/{targetLocaleId}` (`removeLocaleFromJob`) — not the job-level `cancelJob` endpoint, which would cancel every other language sharing the same job (`sendAllLanguages` bundles all target languages into one job). Polls `GET .../processes/{processUid}` (`getJobAsyncProcessStatus`) to completion on a 202 response (2s interval, ~60s cap before treating it as failed).
+
+Also extended `getStatusAll`'s existing "don't revert completed languages" guard to also cover `'cancelled'` — without it, the next status poll would have undone a fresh cancel the same way it was re-triggering saves for completed languages.
+
 ### smartling connector — stop re-saving already-completed languages
 
 `getStatusAll` unconditionally set `lang.translation.status = 'translated'` whenever every url was 100% on Smartling's side — but Smartling keeps reporting 100% forever once done, so every subsequent "Get status" click reverted a lang's `'complete'` (set by `saveLangItemsToDa` after actually saving to DA) back to `'translated'`, which re-triggered a redundant download/save each time. Fixed by skipping langs already at `'complete'`, mirroring a guard GLaaS already has (`determineStatus`'s "Respect existing final statuses"). Trados has the identical bug in its own `getStatusAll` — deferred, not fixed here.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-08-14
 
+### loc translate view — hide Cancel buttons once nothing's left to cancel
+
+`renderCancelLang`'s guard only excluded `'cancelled'` status, never `'complete'`, so a completed language's per-row Cancel button stayed visible as long as some other language in the project was still in progress. Separately, `incompleteLangs` counted a language as cancellable even with no `translation` object at all (never sent), so "Cancel project" could show with nothing actually cancellable. Extracted a single `canCancelLang(lang)` predicate (has `translation`, not `'cancelled'`, not `'complete'`) used consistently by `renderCancelLang`, `incompleteLangs`, and the `with-cancel` grid-column class, so all three can't drift out of sync with each other again.
+
 ### smartling connector — switch getStatusAll to getJobProgress
 
 Replaced the file-scoped `getFileTranslationStatusAllLocales` approach (one API call per file, plus our own floor/excluded-string formula) with Smartling's job-scoped `getJobProgress` (`jobs-api/v3/.../progress`): one API call for the whole job, consuming Smartling's own precomputed `percentComplete` per locale directly instead of reimplementing their formula. Explored as an alternative specifically for the reduced call volume on larger batches (matters given the earlier rate-limit work).

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,15 @@
 # Worklog
 
+## 2026-08-14
+
+### smartling connector — switch getStatusAll to getJobProgress
+
+Replaced the file-scoped `getFileTranslationStatusAllLocales` approach (one API call per file, plus our own floor/excluded-string formula) with Smartling's job-scoped `getJobProgress` (`jobs-api/v3/.../progress`): one API call for the whole job, consuming Smartling's own precomputed `percentComplete` per locale directly instead of reimplementing their formula. Explored as an alternative specifically for the reduced call volume on larger batches (matters given the earlier rate-limit work).
+
+Trade-off: now requires `service.jobUid.value` (guarded — no-ops if missing), and `translation.translated` is no longer a per-file count (this endpoint reports one job-wide percentage per locale, not a per-file breakdown) — it's `0` or `urls.length`, so the "N of M files translated" UI column only ever shows `0` or the full count until 100%, never partial numbers. Also added a genuine efficiency win beyond parity: skips the API call entirely when every lang is already `'complete'`/`'cancelled'`, rather than fetching and discarding.
+
+Rewrote all 6 affected tests for the new endpoint/response shape, plus 2 new ones (no-jobUid skip, cancelled-guard — the latter was a gap even in the old suite, only the `'complete'` case had a dedicated test).
+
 ## 2026-08-13
 
 ### loc translate view — loading spinners on action buttons

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,20 +2,24 @@
 
 ## 2026-08-13
 
-### nx/blocks/loc/connectors/smartling/index.js — token refresh/reauth fixes (docs review)
+### smartling connector — session-expiry recovery, stale-token fix
 
-Reviewed the connector against Smartling's own docs (Key Concepts for Developers, API Integrations Best Practices, Rate Limits — the help center 403s direct `curl`/`WebFetch`, had to go via search instead). Findings and fixes:
+Refresh now falls back to a full re-authenticate when it fails (Smartling sessions cap at 12h regardless of refresh count, so long jobs eventually hit a dead refresh token). Tracks the API's real `expiresIn` instead of a hardcoded interval. `saveItems` no longer reuses a token snapshot taken before its download batch started.
 
-1. **No recovery once a session's refresh token permanently stops working.** Smartling caps a token pair's session at 12 hours regardless of refresh count; after that, refreshes 401 forever. The old `refreshTheToken` polled on a fixed `setInterval` and just went inert (`token = undefined`) on failure, with no reconnect path — silent since translation jobs commonly outlive 12h. Replaced with a self-rescheduling `scheduleRefresh`/`setTimeout` chain; on a failed refresh it falls back to a full `authenticate()` using retained credentials (new module-level `authCredentials`), only going inert if both the refresh and the fallback re-auth fail.
-2. **Token expiry bookkeeping ignored the API's actual `expiresIn`/`refreshExpiresIn`** in favor of a hardcoded 280s `REFRESH_TIME` constant. Now reads the real `expiresIn` from both `/authenticate` and `/authenticate/refresh` responses (falls back to `FALLBACK_EXPIRES_IN_S = 280` if omitted, e.g. in the existing test mocks).
-3. **`saveItems` built its download `opts` (with the `Authorization` header) once up front** and reused it for the whole batch — unlike every other function in the file, which reads the module-level `token` fresh at each fetch call site. Moved `opts` construction inside the per-download callback.
-4. Dead 4th arg (`refreshToken`) passed to the old `refreshTheToken` but unused in its signature — resolved as part of the rewrite.
+## 2026-08-12
 
-`isConnected` also now retains `userId`/`userSecret` into `authCredentials` on resume (e.g. after a page reload with a still-valid cached token), so the reauth fallback works whether the token came from a fresh `connect()` or a resumed session.
+### smartling connector — status polling, auto-authorize, service-mutation bug
 
-All 13 existing tests in `test/loc/connectors/smartling/index.test.js` pass unchanged; `npx eslint` clean.
+- Status polling switched to Smartling's recommended `getFileTranslationStatusAllLocales` (no `jobUid` needed) with its documented progress formula; reports the real percentage instead of a fabricated label.
+- `getStatusAll` reports Smartling's actual current workflow-step name instead of leaving a stale `sendAllLanguages` status in place.
+- Added `translation.service.{env}.autoAuthorize` site config to auto-authorize a batch instead of requiring manual authorization in Smartling's dashboard.
+- Fixed `setupService` copying (not mutating) `options.service` — dropped connector-written state like `jobUid` within the same session. Affects every connector, not just Smartling.
 
-**Open items, not fixed (low risk today):** Smartling caps concurrent file-API operations at 10/project — `saveItems`'s download queue (concurrency 5) is safe alone, but nothing coordinates concurrency across simultaneous operations (e.g. a status poll running alongside a download pass). Also `fetchWithRetry`'s defaults (5 retries / 30s max delay) sit at the low end of Smartling's recommended 5–10 retries / 30–60s max-delay range.
+## 2026-08-11
+
+### smartling connector — retry on 429/5xx
+
+Added shared `nx/blocks/loc/utils/fetchWithRetry.js` (exponential backoff + jitter, honors `Retry-After`) and wired every Smartling fetch through it — `getStatusAll`'s polling and `saveItems`'s 5-concurrent downloads could both trip Smartling's rate limits with no retry. Meant to replace Lionbridge's inline copy of the same logic once #656 lands.
 
 ## 2026-08-07
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,22 @@
 # Worklog
 
+## 2026-08-13
+
+### nx/blocks/loc/connectors/smartling/index.js — token refresh/reauth fixes (docs review)
+
+Reviewed the connector against Smartling's own docs (Key Concepts for Developers, API Integrations Best Practices, Rate Limits — the help center 403s direct `curl`/`WebFetch`, had to go via search instead). Findings and fixes:
+
+1. **No recovery once a session's refresh token permanently stops working.** Smartling caps a token pair's session at 12 hours regardless of refresh count; after that, refreshes 401 forever. The old `refreshTheToken` polled on a fixed `setInterval` and just went inert (`token = undefined`) on failure, with no reconnect path — silent since translation jobs commonly outlive 12h. Replaced with a self-rescheduling `scheduleRefresh`/`setTimeout` chain; on a failed refresh it falls back to a full `authenticate()` using retained credentials (new module-level `authCredentials`), only going inert if both the refresh and the fallback re-auth fail.
+2. **Token expiry bookkeeping ignored the API's actual `expiresIn`/`refreshExpiresIn`** in favor of a hardcoded 280s `REFRESH_TIME` constant. Now reads the real `expiresIn` from both `/authenticate` and `/authenticate/refresh` responses (falls back to `FALLBACK_EXPIRES_IN_S = 280` if omitted, e.g. in the existing test mocks).
+3. **`saveItems` built its download `opts` (with the `Authorization` header) once up front** and reused it for the whole batch — unlike every other function in the file, which reads the module-level `token` fresh at each fetch call site. Moved `opts` construction inside the per-download callback.
+4. Dead 4th arg (`refreshToken`) passed to the old `refreshTheToken` but unused in its signature — resolved as part of the rewrite.
+
+`isConnected` also now retains `userId`/`userSecret` into `authCredentials` on resume (e.g. after a page reload with a still-valid cached token), so the reauth fallback works whether the token came from a fresh `connect()` or a resumed session.
+
+All 13 existing tests in `test/loc/connectors/smartling/index.test.js` pass unchanged; `npx eslint` clean.
+
+**Open items, not fixed (low risk today):** Smartling caps concurrent file-API operations at 10/project — `saveItems`'s download queue (concurrency 5) is safe alone, but nothing coordinates concurrency across simultaneous operations (e.g. a status poll running alongside a download pass). Also `fetchWithRetry`'s defaults (5 retries / 30s max delay) sit at the low end of Smartling's recommended 5–10 retries / 30–60s max-delay range.
+
 ## 2026-08-07
 
 ### nx2/utils/api.js — remove stage-content.da.live rewrite workaround

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -5,7 +5,9 @@ import fetchWithRetry from '../../utils/fetchWithRetry.js';
 
 export const dnt = { addDnt };
 
-const REFRESH_TIME = 280000; // 4.666 minutes
+const REFRESH_BUFFER_MS = 5000; // refresh this long before the token actually expires
+const FALLBACK_EXPIRES_IN_S = 280; // used only if the API response omits expiresIn
+const MIN_REFRESH_DELAY_MS = 2000; // never schedule a refresh sooner than this
 const BASE_OPTS = {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
@@ -22,11 +24,28 @@ function resolveOrigin(origin, org, site) {
 
 let token;
 let tokenPolling;
+// Credentials retained so a failed refresh can fall back to a full
+// re-authentication: Smartling caps a token pair's session at 12 hours
+// regardless of how many times it's refreshed, so refreshes eventually
+// start failing even though the original userId/userSecret still work.
+let authCredentials;
 
-function setTokenDetails(name, env, accessToken, refreshToken) {
+/**
+ * Caches the current access token in the ES module and persists both
+ * tokens plus a computed expiry to localStorage.
+ * @param {string} name - The connector's display name (e.g. 'Smartling').
+ * @param {string} env - The environment key (e.g. 'prod').
+ * @param {string} accessToken - The current access token.
+ * @param {string} refreshToken - The current refresh token.
+ * @param {number} [expiresInSecs] - Seconds until `accessToken` expires;
+ *  falls back to `FALLBACK_EXPIRES_IN_S` if omitted.
+ * @returns {void}
+ */
+function setTokenDetails(name, env, accessToken, refreshToken, expiresInSecs) {
   token = accessToken;
   const timestamp = Date.now();
-  localStorage.setItem(`${name.toLowerCase()}.${env}.token`, JSON.stringify({ accessToken, refreshToken, expires: timestamp + REFRESH_TIME }));
+  const expiresInMs = (expiresInSecs ?? FALLBACK_EXPIRES_IN_S) * 1000;
+  localStorage.setItem(`${name.toLowerCase()}.${env}.token`, JSON.stringify({ accessToken, refreshToken, expires: timestamp + expiresInMs }));
 }
 
 function getTokenDetails(name, env) {
@@ -41,56 +60,120 @@ function getTokenDetails(name, env) {
   return {};
 }
 
-function refreshTheToken(name, env, endpoint) {
-  tokenPolling = setInterval(async () => {
-    const { refreshToken: currRefreshToken } = getTokenDetails(name, env);
-    const body = JSON.stringify({ refreshToken: currRefreshToken });
-    const opts = { ...BASE_OPTS, body };
+/**
+ * Authenticates with Smartling using a user's identifier/secret.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} userIdentifier - The Smartling user identifier.
+ * @param {string} userSecret - The Smartling user secret.
+ * @returns {Promise<Object|null>} The response's `accessToken`,
+ *  `refreshToken`, and `expiresIn`, or null on failure.
+ */
+async function authenticate(endpoint, userIdentifier, userSecret) {
+  const body = JSON.stringify({ userIdentifier, userSecret });
+  const opts = { ...BASE_OPTS, body };
 
-    const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
-    if (!resp.ok) token = undefined;
-    const json = await resp.json();
-
-    const { accessToken, refreshToken } = json?.response?.data || {};
-    if (accessToken && refreshToken) setTokenDetails(name, env, accessToken, refreshToken);
-  }, REFRESH_TIME - 5000);
+  const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate`, opts);
+  if (!resp.ok) return null;
+  const json = await resp.json();
+  return json?.response?.data || null;
 }
 
+/**
+ * Schedules a token refresh shortly before the current token expires,
+ * tracking Smartling's actual reported `expiresIn` instead of assuming a
+ * constant lifetime (that value shrinks as a session nears its 12-hour
+ * cap). Falls back to a full re-authentication with the original
+ * credentials if the refresh token itself has stopped working, and
+ * reschedules itself afterward - only stops rescheduling once both the
+ * refresh and the fallback re-authentication fail, so a translation job
+ * that outlives several sessions keeps working without user intervention.
+ * @param {number} [expiresInSecs] - Seconds until the current token
+ *  expires; falls back to `FALLBACK_EXPIRES_IN_S` if omitted.
+ * @returns {void}
+ */
+function scheduleRefresh(expiresInSecs) {
+  const expiresInMs = (expiresInSecs ?? FALLBACK_EXPIRES_IN_S) * 1000;
+  const delay = Math.max(expiresInMs - REFRESH_BUFFER_MS, MIN_REFRESH_DELAY_MS);
+
+  clearTimeout(tokenPolling);
+  tokenPolling = setTimeout(async () => {
+    const { name, env, endpoint, userIdentifier, userSecret } = authCredentials;
+    const { refreshToken: currRefreshToken } = getTokenDetails(name, env);
+
+    const body = JSON.stringify({ refreshToken: currRefreshToken });
+    const opts = { ...BASE_OPTS, body };
+    const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
+    let data = resp.ok ? (await resp.json())?.response?.data : null;
+
+    if (!data?.accessToken) data = await authenticate(endpoint, userIdentifier, userSecret);
+
+    if (!data?.accessToken) {
+      // Both refresh and re-authentication failed - stop polling rather than
+      // hammering the API forever with credentials that no longer work.
+      token = undefined;
+      tokenPolling = undefined;
+      return;
+    }
+
+    const { accessToken, refreshToken, expiresIn } = data;
+    setTokenDetails(name, env, accessToken, refreshToken, expiresIn);
+    scheduleRefresh(expiresIn);
+  }, delay);
+}
+
+/**
+ * Checks for a still-valid cached token and, if found, resumes background
+ * refresh scheduling (e.g. after a page reload) instead of requiring the
+ * user to reconnect.
+ * @param {Object} config - The service configuration, including
+ *  `userId`/`userSecret` (retained for a later refresh-failure fallback)
+ *  and the env-specific endpoint.
+ * @returns {Promise<boolean>} Whether a still-valid cached token was found.
+ */
 export async function isConnected(config) {
-  const { name, env } = config;
+  const { name, env, userId, userSecret } = config;
   const endpoint = config[`${env}.endpoint`];
-  const { expires, refreshToken, accessToken } = getTokenDetails(name, env);
+  const { expires, accessToken } = getTokenDetails(name, env);
   const notExpired = expires > Date.now();
 
   if (notExpired && !tokenPolling) {
     // Cache the token for the ES Module
-    setTokenDetails(name, env, accessToken, refreshToken);
+    token = accessToken;
+    authCredentials = { name, env, endpoint, userIdentifier: userId, userSecret };
 
-    // Kick off the refresh polling
-    refreshTheToken(name, env, endpoint, refreshToken);
+    // Kick off the refresh scheduling
+    scheduleRefresh((expires - Date.now()) / 1000);
     return true;
   }
 
   return false;
 }
 
+/**
+ * Authenticates with Smartling and starts background refresh scheduling.
+ * @param {Object} service - The service configuration.
+ * @param {string} service.name - The connector's display name.
+ * @param {string} service.origin - The configured API origin.
+ * @param {string} service.env - The environment key (e.g. 'prod').
+ * @param {string} service.userId - The Smartling user identifier.
+ * @param {string} service.userSecret - The Smartling user secret.
+ * @param {string} service.org - The DA org.
+ * @param {string} service.site - The DA site.
+ * @returns {Promise<boolean>} Whether authentication succeeded.
+ */
 export async function connect(service) {
   const {
     name, origin, env, userId, userSecret, org, site,
   } = service;
   const endpoint = resolveOrigin(origin, org, site);
-  const userIdentifier = userId;
 
-  const body = JSON.stringify({ userIdentifier, userSecret });
+  const data = await authenticate(endpoint, userId, userSecret);
+  if (!data?.accessToken) return false;
 
-  const opts = { ...BASE_OPTS, body };
-
-  const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate`, opts);
-  if (!resp.ok) return false;
-  const json = await resp.json();
-  const { accessToken, refreshToken } = json?.response?.data || {};
-  setTokenDetails(name, env, accessToken, refreshToken);
-  if (refreshToken) refreshTheToken(name, env, endpoint, refreshToken);
+  authCredentials = { name, env, endpoint, userIdentifier: userId, userSecret };
+  const { accessToken, refreshToken, expiresIn } = data;
+  setTokenDetails(name, env, accessToken, refreshToken, expiresIn);
+  scheduleRefresh(expiresIn);
   return true;
 }
 
@@ -186,15 +269,18 @@ export async function saveItems({
   const { origin, projectId } = service;
   const endpoint = resolveOrigin(origin, org, site);
 
-  const opts = {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  };
-
   const downloadCallback = async (url) => {
+    // Built per-download (not hoisted) so a background token refresh mid-batch
+    // is picked up instead of every download reusing whatever token was
+    // current when saveItems started.
+    const opts = {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    };
+
     const text = await downloadFile(opts, endpoint, projectId, lang, url);
 
     url.sourceContent = await removeDnt({ org, site, html: text, ext: url.ext });

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -278,6 +278,37 @@ export async function sendAllLanguages({
   await saveState({ options });
 }
 
+/**
+ * Finds the name of the workflow step a not-yet-complete file/locale is
+ * currently sitting in (e.g. "Processing", "Translation"), from
+ * Smartling's own per-locale progress report. Smartling's file/progress
+ * endpoint has no single status enum — only per-step word/string counts —
+ * so this reports Smartling's own step name rather than a made-up label.
+ * @param {Object} report - One entry from a file/progress response's
+ *  `contentProgressReport`.
+ * @returns {string} The active step's name, or 'in progress' if
+ *  Smartling hasn't reported any step activity yet.
+ */
+function activeWorkflowStepName(report) {
+  const steps = report.workflowProgressReportList?.[0]?.workflowStepSummaryReportItemList || [];
+  const active = steps.find((step) => step.wordCount > 0 || step.stringCount > 0);
+  return active?.workflowStepName || 'in progress';
+}
+
+/**
+ * Refreshes translation status for every target language of a job by
+ * polling per-file progress.
+ * @param {Object} params
+ * @param {string} params.org - The DA org.
+ * @param {string} params.site - The DA site.
+ * @param {Object} params.service - The service configuration.
+ * @param {Object[]} params.langs - Target languages; mutated in place with
+ *  `translation.status` (Smartling's active workflow step name, or
+ *  'translated' once complete) and `translation.translated`.
+ * @param {Object[]} params.urls - The urls in the project.
+ * @param {Object} params.actions - `{ saveState }` callback.
+ * @returns {Promise<void>}
+ */
 export async function getStatusAll({
   org, site, service, langs, urls, actions,
 }) {
@@ -299,9 +330,12 @@ export async function getStatusAll({
     langReports.forEach((report) => {
       const { targetLocaleId, progress } = report;
       const lang = langs.find((projLang) => projLang.code === targetLocaleId);
+      if (!lang) return;
       // Previously translated files will have a null progress object.
       if (!progress || progress.percentComplete === 100) {
         lang.translation.translated += 1;
+      } else {
+        lang.translation.status = activeWorkflowStepName(report);
       }
     });
   }

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -1,6 +1,7 @@
 import { Queue } from '../../../../../nx2/public/utils/tree.js';
 import { addDnt, removeDnt } from '../../dnt/dnt.js';
 import { DA_TRANSLATE } from '../../../../../nx2/utils/utils.js';
+import fetchWithRetry from '../../utils/fetchWithRetry.js';
 
 export const dnt = { addDnt };
 
@@ -46,7 +47,7 @@ function refreshTheToken(name, env, endpoint) {
     const body = JSON.stringify({ refreshToken: currRefreshToken });
     const opts = { ...BASE_OPTS, body };
 
-    const resp = await fetch(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate/refresh`, opts);
     if (!resp.ok) token = undefined;
     const json = await resp.json();
 
@@ -84,7 +85,7 @@ export async function connect(service) {
 
   const opts = { ...BASE_OPTS, body };
 
-  const resp = await fetch(`${endpoint}/auth-api/v2/authenticate`, opts);
+  const resp = await fetchWithRetry(`${endpoint}/auth-api/v2/authenticate`, opts);
   if (!resp.ok) return false;
   const json = await resp.json();
   const { accessToken, refreshToken } = json?.response?.data || {};
@@ -111,7 +112,7 @@ async function uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls) {
 
     const opts = { method: 'POST', body, headers: { Authorization: `Bearer ${token}` } };
 
-    const resp = await fetch(uploadUrl, opts);
+    const resp = await fetchWithRetry(uploadUrl, opts);
     const json = await resp.json();
     results.push(json.response.code);
   }
@@ -129,7 +130,7 @@ async function createJob(endpoint, projectId, title, langs) {
   opts.headers.Authorization = `Bearer ${token}`;
 
   const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs`;
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { translationJobUid: jobUid } = json.response.data;
@@ -148,7 +149,7 @@ async function createBatch(endpoint, projectId, jobUid, urls) {
 
   const url = `${endpoint}/job-batches-api/v2/projects/${projectId}/batches`;
 
-  const resp = await fetch(url, opts);
+  const resp = await fetchWithRetry(url, opts);
   if (!resp.ok) return null;
   const json = await resp.json();
   const { batchUid } = json.response.data;
@@ -159,7 +160,7 @@ async function downloadFile(opts, origin, projectId, lang, url) {
   const reqUrl = new URL(`${origin}/files-api/v2/projects/${projectId}/locales/${lang.code}/file`);
   reqUrl.searchParams.append('fileUri', url.daBasePath);
 
-  const resp = await fetch(reqUrl, opts);
+  const resp = await fetchWithRetry(reqUrl, opts);
   return resp.text();
 }
 
@@ -263,7 +264,7 @@ export async function getStatusAll({
   langs.forEach((lang) => { lang.translation.translated = 0; });
 
   for (const url of urls) {
-    const resp = await fetch(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
+    const resp = await fetchWithRetry(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
     const { response } = await resp.json();
     if (response.code !== 'SUCCESS') return;
     const langReports = response?.data?.contentProgressReport;

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -177,7 +177,40 @@ export async function connect(service) {
   return true;
 }
 
-async function uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls) {
+/**
+ * Extracts a human-readable message from Smartling's documented error
+ * envelope. Per their Error Handling docs, every 4xx/5xx response on every
+ * endpoint returns `{ response: { code, errors: [{ key, message,
+ * details }] } }` - this reads the `errors` array rather than just the
+ * top-level `code`, since `code` alone (e.g. `VALIDATION_ERROR`) doesn't
+ * say what's actually wrong (e.g. an invalid target locale).
+ * @param {Object} json - The parsed error response body.
+ * @returns {string} The joined `message` from each reported error, or the
+ *  response `code` if no `errors` array is present.
+ */
+function extractErrorMessage(json) {
+  const errors = json?.response?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    return errors.map((error) => error.message).join('; ');
+  }
+  return json?.response?.code || 'Unknown error';
+}
+
+/**
+ * Uploads every url to a Smartling batch, reporting an error message per
+ * file that Smartling rejects (e.g. a locale mismatch) instead of only
+ * counting it as not-accepted.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} batchUid - The batch to upload files into.
+ * @param {Object[]} langs - Target languages to authorize each file for.
+ * @param {Object[]} urls - The urls to upload.
+ * @param {Function} sendMessage - Callback to surface a status/error
+ *  message to the user.
+ * @returns {Promise<string[]>} Each file's Smartling response `code`
+ *  (`'ACCEPTED'` on success).
+ */
+async function uploadFiles(endpoint, projectId, batchUid, langs, urls, sendMessage) {
   const uploadUrl = `${endpoint}/job-batches-api/v2/projects/${projectId}/batches/${batchUid}/file`;
 
   const results = [];
@@ -197,13 +230,27 @@ async function uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls) {
 
     const resp = await fetchWithRetry(uploadUrl, opts);
     const json = await resp.json();
+    if (!resp.ok) {
+      sendMessage({ text: `Upload failed for ${url.daBasePath}: ${extractErrorMessage(json)}`, type: 'error' });
+    }
     results.push(json.response.code);
   }
 
   return results;
 }
 
-async function createJob(endpoint, projectId, title, langs) {
+/**
+ * Creates a Smartling translation job for the given target languages.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} title - The project title, used to build the job name.
+ * @param {Object[]} langs - Target languages; each `code` becomes a
+ *  `targetLocaleId`.
+ * @param {Function} sendMessage - Callback to surface a status/error
+ *  message to the user.
+ * @returns {Promise<string|null>} The new job's id, or null on failure.
+ */
+async function createJob(endpoint, projectId, title, langs, sendMessage) {
   const timestamp = Date.now();
   const jobName = `${title}-${timestamp}`;
   const targetLocaleIds = langs.map((lang) => lang.code);
@@ -214,7 +261,11 @@ async function createJob(endpoint, projectId, title, langs) {
 
   const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs`;
   const resp = await fetchWithRetry(url, opts);
-  if (!resp.ok) return null;
+  if (!resp.ok) {
+    const json = await resp.json();
+    sendMessage({ text: `Job creation failed: ${extractErrorMessage(json)}`, type: 'error' });
+    return null;
+  }
   const json = await resp.json();
   const { translationJobUid: jobUid } = json.response.data;
   return jobUid;
@@ -229,9 +280,11 @@ async function createJob(endpoint, projectId, title, langs) {
  * @param {boolean} autoAuthorize - Whether Smartling should immediately
  *  authorize the job for translation once the batch finishes processing,
  *  instead of requiring manual authorization in Smartling's dashboard.
+ * @param {Function} sendMessage - Callback to surface a status/error
+ *  message to the user.
  * @returns {Promise<string|null>} The new batch's id, or null on failure.
  */
-async function createBatch(endpoint, projectId, jobUid, urls, autoAuthorize) {
+async function createBatch(endpoint, projectId, jobUid, urls, autoAuthorize, sendMessage) {
   const body = JSON.stringify({
     authorize: autoAuthorize,
     translationJobUid: jobUid,
@@ -244,7 +297,11 @@ async function createBatch(endpoint, projectId, jobUid, urls, autoAuthorize) {
   const url = `${endpoint}/job-batches-api/v2/projects/${projectId}/batches`;
 
   const resp = await fetchWithRetry(url, opts);
-  if (!resp.ok) return null;
+  if (!resp.ok) {
+    const json = await resp.json();
+    sendMessage({ text: `Batch creation failed: ${extractErrorMessage(json)}`, type: 'error' });
+    return null;
+  }
   const json = await resp.json();
   const { batchUid } = json.response.data;
   return batchUid;
@@ -332,7 +389,7 @@ export async function sendAllLanguages({
   const endpoint = resolveOrigin(origin, org, site);
 
   sendMessage({ text: `Creating job in Smartling for: ${title}.` });
-  const jobUid = await createJob(endpoint, projectId, title, langs);
+  const jobUid = await createJob(endpoint, projectId, title, langs, sendMessage);
   if (!jobUid) return;
 
   // Presist to the state for future reference
@@ -342,7 +399,7 @@ export async function sendAllLanguages({
   // config[`${env}.jobUid`] = jobUid;
 
   sendMessage({ text: `Creating a batch in Smartling for: ${title}.` });
-  const batchUid = await createBatch(endpoint, projectId, jobUid, urls, autoAuthorize === 'yes');
+  const batchUid = await createBatch(endpoint, projectId, jobUid, urls, autoAuthorize === 'yes', sendMessage);
   if (!batchUid) return;
 
   // Presist to the state for future reference
@@ -352,7 +409,7 @@ export async function sendAllLanguages({
   // config[`${env}.batchUid`] = batchUid;
 
   sendMessage({ text: `Uploading ${urls.length} items to Smartling for job: ${title}.` });
-  const results = await uploadFiles(endpoint, projectId, jobUid, batchUid, langs, urls);
+  const results = await uploadFiles(endpoint, projectId, batchUid, langs, urls, sendMessage);
   const accepted = results.filter((result) => result === 'ACCEPTED').length;
 
   langs.forEach((lang) => {

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -421,6 +421,103 @@ export async function sendAllLanguages({
   await saveState({ options });
 }
 
+const PROCESS_POLL_INTERVAL_MS = 2000;
+const MAX_PROCESS_POLL_ATTEMPTS = 30; // ~60s before giving up on an async process
+
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Polls Smartling's job async-process endpoint (`getJobAsyncProcessStatus`)
+ * until a submitted operation reports a terminal `processState`. Used for
+ * the 202 case of `removeLocaleFromJob`, whose removal isn't guaranteed
+ * complete until this reports `COMPLETED`.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} jobUid - The job the process belongs to.
+ * @param {string} processUid - The process to poll.
+ * @returns {Promise<string>} The final `processState` ('COMPLETED' or
+ *  'FAILED'); also resolves to 'FAILED' if a poll request errors or the
+ *  process doesn't finish within `MAX_PROCESS_POLL_ATTEMPTS`.
+ */
+async function pollJobProcess(endpoint, projectId, jobUid, processUid) {
+  const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid}/processes/${processUid}`;
+  const opts = { headers: { Authorization: `Bearer ${token}` } };
+
+  for (let attempt = 0; attempt < MAX_PROCESS_POLL_ATTEMPTS; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await fetchWithRetry(url, opts);
+    if (!resp.ok) return 'FAILED';
+    // eslint-disable-next-line no-await-in-loop
+    const json = await resp.json();
+    const { processState } = json?.response?.data || {};
+    if (processState === 'COMPLETED' || processState === 'FAILED') return processState;
+    // eslint-disable-next-line no-await-in-loop
+    await wait(PROCESS_POLL_INTERVAL_MS);
+  }
+
+  return 'FAILED';
+}
+
+/**
+ * Cancels a single target language by removing its locale from the
+ * shared translation job (`removeLocaleFromJob`) - not Smartling's
+ * job-level `cancelJob` endpoint, which would cancel every other
+ * language still sharing that job, since `sendAllLanguages` sends every
+ * target language as one job. Polls the returned process to completion
+ * when Smartling responds 202 (async removal).
+ * @param {Object} params
+ * @param {Object} params.service - The service configuration; reads
+ *  `origin`/`org`/`site`/`projectId`/`jobUid`.
+ * @param {Object} params.lang - The language to cancel; mutated in place
+ *  with `translation.status = 'cancelled'` on success.
+ * @param {Function} params.sendMessage - Callback to surface a
+ *  status/error message to the user.
+ * @returns {Promise<{ok: boolean, skipped?: boolean}>} Whether the
+ *  cancellation succeeded (or was skipped as a no-op).
+ */
+export async function cancelTranslation({ service, lang, sendMessage }) {
+  if (!lang.translation || !service.jobUid?.value) {
+    sendMessage({ text: `Skipping ${lang.name}. No translation information.` });
+    return { ok: true, skipped: true };
+  }
+
+  const {
+    origin, org, site, projectId, jobUid,
+  } = service;
+  const endpoint = resolveOrigin(origin, org, site);
+  const translationJobUid = jobUid.value;
+
+  sendMessage({ text: `Canceling ${lang.name}.` });
+
+  const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${translationJobUid}/locales/${lang.code}`;
+  const opts = { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } };
+
+  const resp = await fetchWithRetry(url, opts);
+  if (!resp.ok) {
+    const json = await resp.json();
+    sendMessage({ text: `Canceling ${lang.name} failed: ${extractErrorMessage(json)}`, type: 'error' });
+    return { ok: false };
+  }
+
+  if (resp.status === 202) {
+    const json = await resp.json();
+    const { processUid } = json?.response?.data || {};
+    const processState = processUid
+      ? await pollJobProcess(endpoint, projectId, translationJobUid, processUid)
+      : 'FAILED';
+
+    if (processState !== 'COMPLETED') {
+      sendMessage({ text: `Canceling ${lang.name} did not finish in time - check Smartling directly.`, type: 'error' });
+      return { ok: false };
+    }
+  }
+
+  lang.translation.status = 'cancelled';
+  return { ok: true };
+}
+
 /**
  * Computes Smartling's translation progress percentage for one locale's
  * string counts, per Smartling's own documented formula (Checking File
@@ -479,9 +576,11 @@ async function fetchFileStatus(endpoint, projectId, fileUri) {
  *  `translation.status` ('translated' once every file is complete for
  *  that locale, otherwise Smartling's real progress percentage, e.g.
  *  '62% translated') and `translation.translated` (files complete). A
- *  lang already at `'complete'` (saved to DA by `saveLangItemsToDa`) is
- *  left untouched, since Smartling keeps reporting 100% indefinitely and
- *  would otherwise look "newly finished" on every subsequent check.
+ *  lang already at `'complete'` (saved to DA by `saveLangItemsToDa`) or
+ *  `'cancelled'` (removed from the job by `cancelTranslation`) is left
+ *  untouched - both are terminal, and Smartling keeps reporting 100%
+ *  indefinitely, which would otherwise look "newly finished" on every
+ *  subsequent check.
  * @param {Object[]} params.urls - The urls in the project.
  * @param {Object} params.actions - `{ saveState }` callback.
  * @returns {Promise<void>}
@@ -510,11 +609,11 @@ export async function getStatusAll({
     });
   }
 
-  // 'complete' means saveLangItemsToDa already downloaded and saved this
-  // lang's content - Smartling keeps reporting 100% translated forever
-  // after that, so without this guard every subsequent status check would
-  // revert it to 'translated' and trigger a re-save.
-  for (const lang of langs.filter((l) => l.translation.status !== 'complete')) {
+  // 'complete'/'cancelled' are terminal - Smartling keeps reporting 100%
+  // translated forever once done, so without this guard every subsequent
+  // status check would revert 'complete' back to 'translated' (triggering
+  // a re-save) or 'cancelled' back to 'translated' (undoing the cancel).
+  for (const lang of langs.filter((l) => !['complete', 'cancelled'].includes(l.translation.status))) {
     if (lang.translation.translated === urls.length) {
       lang.translation.status = 'translated';
     }

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -137,9 +137,20 @@ async function createJob(endpoint, projectId, title, langs) {
   return jobUid;
 }
 
-async function createBatch(endpoint, projectId, jobUid, urls) {
+/**
+ * Creates a job batch for the uploaded files.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} jobUid - The job to attach the batch to.
+ * @param {Object[]} urls - The urls that will be uploaded to this batch.
+ * @param {boolean} autoAuthorize - Whether Smartling should immediately
+ *  authorize the job for translation once the batch finishes processing,
+ *  instead of requiring manual authorization in Smartling's dashboard.
+ * @returns {Promise<string|null>} The new batch's id, or null on failure.
+ */
+async function createBatch(endpoint, projectId, jobUid, urls, autoAuthorize) {
   const body = JSON.stringify({
-    authorize: false,
+    authorize: autoAuthorize,
     translationJobUid: jobUid,
     fileUris: urls.map((url) => url.daBasePath),
   });
@@ -210,12 +221,28 @@ export async function saveItems({
   });
 }
 
+/**
+ * Sends a translation project's urls to Smartling for every target
+ * language: creates a job, creates a batch (optionally auto-authorized),
+ * then uploads all urls to it.
+ * @param {Object} params
+ * @param {string} params.org - The DA org.
+ * @param {string} params.site - The DA site.
+ * @param {string} params.title - The project title.
+ * @param {Object} params.options - Project options; reads/mutates
+ *  `options.service`.
+ * @param {Object[]} params.langs - Target languages; mutated in place with
+ *  `translation` status.
+ * @param {Object[]} params.urls - The urls to translate.
+ * @param {Object} params.actions - `{ sendMessage, saveState }` callbacks.
+ * @returns {Promise<void>}
+ */
 export async function sendAllLanguages({
   org, site, title, options, langs, urls, actions,
 }) {
   const { sendMessage, saveState } = actions;
 
-  const { origin, projectId } = options.service;
+  const { origin, projectId, autoAuthorize } = options.service;
   const endpoint = resolveOrigin(origin, org, site);
 
   sendMessage({ text: `Creating job in Smartling for: ${title}.` });
@@ -229,7 +256,7 @@ export async function sendAllLanguages({
   // config[`${env}.jobUid`] = jobUid;
 
   sendMessage({ text: `Creating a batch in Smartling for: ${title}.` });
-  const batchUid = await createBatch(endpoint, projectId, jobUid, urls);
+  const batchUid = await createBatch(endpoint, projectId, jobUid, urls, autoAuthorize === 'yes');
   if (!batchUid) return;
 
   // Presist to the state for future reference

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -478,7 +478,10 @@ async function fetchFileStatus(endpoint, projectId, fileUri) {
  * @param {Object[]} params.langs - Target languages; mutated in place with
  *  `translation.status` ('translated' once every file is complete for
  *  that locale, otherwise Smartling's real progress percentage, e.g.
- *  '62% translated') and `translation.translated` (files complete).
+ *  '62% translated') and `translation.translated` (files complete). A
+ *  lang already at `'complete'` (saved to DA by `saveLangItemsToDa`) is
+ *  left untouched, since Smartling keeps reporting 100% indefinitely and
+ *  would otherwise look "newly finished" on every subsequent check.
  * @param {Object[]} params.urls - The urls in the project.
  * @param {Object} params.actions - `{ saveState }` callback.
  * @returns {Promise<void>}
@@ -507,7 +510,11 @@ export async function getStatusAll({
     });
   }
 
-  for (const lang of langs) {
+  // 'complete' means saveLangItemsToDa already downloaded and saved this
+  // lang's content - Smartling keeps reporting 100% translated forever
+  // after that, so without this guard every subsequent status check would
+  // revert it to 'translated' and trigger a re-save.
+  for (const lang of langs.filter((l) => l.translation.status !== 'complete')) {
     if (lang.translation.translated === urls.length) {
       lang.translation.status = 'translated';
     }

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -519,68 +519,52 @@ export async function cancelTranslation({ service, lang, sendMessage }) {
 }
 
 /**
- * Computes Smartling's translation progress percentage for one locale's
- * string counts, per Smartling's own documented formula (Checking File
- * Translation Status): floors the result rather than rounding — 99.9999%
- * complete must report as 99%, not 100% — and treats a fully-excluded
- * file (nothing left to translate) as 100%.
- * @param {Object} counts
- * @param {number} counts.totalStringCount - Strings in the file.
- * @param {number} counts.completedStringCount - Published strings.
- * @param {number} counts.excludedStringCount - Strings excluded from
- *  translation.
- * @returns {number} Progress percentage, 0-100.
- */
-function translationProgress({ totalStringCount, completedStringCount, excludedStringCount }) {
-  const denominator = totalStringCount - excludedStringCount;
-  if (denominator === 0) return 100;
-  return Math.floor((completedStringCount / denominator) * 100);
-}
-
-/**
- * Fetches per-locale translation status counts for a single file. Unlike
- * the job-scoped file/progress endpoint, this needs no jobUid.
- *
- * `totalStringCount` is a file-level count (the source content is the
- * same regardless of target locale) — it is not repeated per item in
- * Smartling's response, so it's returned alongside `items` rather than
- * on each one.
+ * Fetches Smartling's own precomputed per-locale progress for a job in a
+ * single call (getJobProgress), instead of one
+ * getFileTranslationStatusAllLocales call per file. Trades the
+ * file-scoped approach's independence from jobUid for far fewer API
+ * calls on larger batches - Smartling already applies its own
+ * floor/excluded-string handling to `percentComplete`, so there's no
+ * formula left for us to reimplement.
  * @param {string} endpoint - The resolved Smartling API origin.
  * @param {string} projectId - The Smartling project id.
- * @param {string} fileUri - The file's DA base path.
- * @returns {Promise<{totalStringCount: number, items: Object[]}>} The
- *  file's total string count and its per-locale completed/excluded
- *  counts, or zero/empty on failure.
+ * @param {string} jobUid - The job to check progress for.
+ * @returns {Promise<Object[]>} Each locale's `{ targetLocaleId,
+ *  percentComplete }`, or `[]` on failure.
  */
-async function fetchFileStatus(endpoint, projectId, fileUri) {
-  const url = new URL(`${endpoint}/files-api/v2/projects/${projectId}/file/status`);
-  url.searchParams.set('fileUri', fileUri);
+async function fetchJobProgress(endpoint, projectId, jobUid) {
+  const url = `${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid}/progress`;
   const opts = { headers: { Authorization: `Bearer ${token}` } };
 
   const resp = await fetchWithRetry(url, opts);
-  if (!resp.ok) return { totalStringCount: 0, items: [] };
+  if (!resp.ok) return [];
   const { response } = await resp.json();
-  const { totalStringCount = 0, items = [] } = response?.data || {};
-  return { totalStringCount, items };
+  const { contentProgressReport = [] } = response?.data || {};
+  return contentProgressReport.map(({ targetLocaleId, progress }) => ({
+    targetLocaleId,
+    percentComplete: progress?.percentComplete ?? 0,
+  }));
 }
 
 /**
- * Refreshes translation status for every target language of a job by
- * polling per-locale file status (Smartling's recommended
- * getFileTranslationStatusAllLocales endpoint).
+ * Refreshes translation status for every target language of a job via
+ * Smartling's getJobProgress endpoint.
  * @param {Object} params
  * @param {string} params.org - The DA org.
  * @param {string} params.site - The DA site.
- * @param {Object} params.service - The service configuration.
+ * @param {Object} params.service - The service configuration; reads
+ *  `jobUid.value` (set by `sendAllLanguages`).
  * @param {Object[]} params.langs - Target languages; mutated in place with
- *  `translation.status` ('translated' once every file is complete for
+ *  `translation.status` ('translated' once Smartling reports 100% for
  *  that locale, otherwise Smartling's real progress percentage, e.g.
- *  '62% translated') and `translation.translated` (files complete). A
- *  lang already at `'complete'` (saved to DA by `saveLangItemsToDa`) or
- *  `'cancelled'` (removed from the job by `cancelTranslation`) is left
- *  untouched - both are terminal, and Smartling keeps reporting 100%
- *  indefinitely, which would otherwise look "newly finished" on every
- *  subsequent check.
+ *  '62% translated') and `translation.translated` (`urls.length` once
+ *  translated, otherwise `0` - this endpoint reports one job-wide
+ *  percentage per locale, not a per-file breakdown). A lang already at
+ *  `'complete'` (saved to DA by `saveLangItemsToDa`) or `'cancelled'`
+ *  (removed from the job by `cancelTranslation`) is left untouched -
+ *  both are terminal, and Smartling keeps reporting 100% indefinitely,
+ *  which would otherwise look "newly finished" on every subsequent check.
+ *  If every lang is already terminal, skips the API call entirely.
  * @param {Object[]} params.urls - The urls in the project.
  * @param {Object} params.actions - `{ saveState }` callback.
  * @returns {Promise<void>}
@@ -589,33 +573,30 @@ export async function getStatusAll({
   org, site, service, langs, urls, actions,
 }) {
   const { saveState } = actions;
-  const { origin, projectId } = service;
+  const { origin, projectId, jobUid } = service;
   const endpoint = resolveOrigin(origin, org, site);
 
-  langs.forEach((lang) => { lang.translation.translated = 0; });
-
-  for (const url of urls) {
-    // eslint-disable-next-line no-await-in-loop
-    const { totalStringCount, items } = await fetchFileStatus(endpoint, projectId, url.daBasePath);
-    items.forEach((item) => {
-      const lang = langs.find((projLang) => projLang.code === item.localeId);
-      if (!lang) return;
-      const progress = translationProgress({ totalStringCount, ...item });
-      if (progress === 100) {
-        lang.translation.translated += 1;
-      } else {
-        lang.translation.status = `${progress}% translated`;
-      }
-    });
-  }
+  if (!jobUid?.value) return;
 
   // 'complete'/'cancelled' are terminal - Smartling keeps reporting 100%
   // translated forever once done, so without this guard every subsequent
   // status check would revert 'complete' back to 'translated' (triggering
   // a re-save) or 'cancelled' back to 'translated' (undoing the cancel).
-  for (const lang of langs.filter((l) => !['complete', 'cancelled'].includes(l.translation.status))) {
-    if (lang.translation.translated === urls.length) {
+  const activeLangs = langs.filter((l) => !['complete', 'cancelled'].includes(l.translation.status));
+  if (!activeLangs.length) return;
+
+  const progressByLocale = await fetchJobProgress(endpoint, projectId, jobUid.value);
+
+  for (const lang of activeLangs) {
+    const entry = progressByLocale.find((p) => p.targetLocaleId === lang.code);
+    const percentComplete = entry?.percentComplete ?? 0;
+
+    if (percentComplete === 100) {
+      lang.translation.translated = urls.length;
       lang.translation.status = 'translated';
+    } else {
+      lang.translation.translated = 0;
+      lang.translation.status = `${percentComplete}% translated`;
     }
   }
 

--- a/nx/blocks/loc/connectors/smartling/index.js
+++ b/nx/blocks/loc/connectors/smartling/index.js
@@ -279,32 +279,63 @@ export async function sendAllLanguages({
 }
 
 /**
- * Finds the name of the workflow step a not-yet-complete file/locale is
- * currently sitting in (e.g. "Processing", "Translation"), from
- * Smartling's own per-locale progress report. Smartling's file/progress
- * endpoint has no single status enum — only per-step word/string counts —
- * so this reports Smartling's own step name rather than a made-up label.
- * @param {Object} report - One entry from a file/progress response's
- *  `contentProgressReport`.
- * @returns {string} The active step's name, or 'in progress' if
- *  Smartling hasn't reported any step activity yet.
+ * Computes Smartling's translation progress percentage for one locale's
+ * string counts, per Smartling's own documented formula (Checking File
+ * Translation Status): floors the result rather than rounding — 99.9999%
+ * complete must report as 99%, not 100% — and treats a fully-excluded
+ * file (nothing left to translate) as 100%.
+ * @param {Object} counts
+ * @param {number} counts.totalStringCount - Strings in the file.
+ * @param {number} counts.completedStringCount - Published strings.
+ * @param {number} counts.excludedStringCount - Strings excluded from
+ *  translation.
+ * @returns {number} Progress percentage, 0-100.
  */
-function activeWorkflowStepName(report) {
-  const steps = report.workflowProgressReportList?.[0]?.workflowStepSummaryReportItemList || [];
-  const active = steps.find((step) => step.wordCount > 0 || step.stringCount > 0);
-  return active?.workflowStepName || 'in progress';
+function translationProgress({ totalStringCount, completedStringCount, excludedStringCount }) {
+  const denominator = totalStringCount - excludedStringCount;
+  if (denominator === 0) return 100;
+  return Math.floor((completedStringCount / denominator) * 100);
+}
+
+/**
+ * Fetches per-locale translation status counts for a single file. Unlike
+ * the job-scoped file/progress endpoint, this needs no jobUid.
+ *
+ * `totalStringCount` is a file-level count (the source content is the
+ * same regardless of target locale) — it is not repeated per item in
+ * Smartling's response, so it's returned alongside `items` rather than
+ * on each one.
+ * @param {string} endpoint - The resolved Smartling API origin.
+ * @param {string} projectId - The Smartling project id.
+ * @param {string} fileUri - The file's DA base path.
+ * @returns {Promise<{totalStringCount: number, items: Object[]}>} The
+ *  file's total string count and its per-locale completed/excluded
+ *  counts, or zero/empty on failure.
+ */
+async function fetchFileStatus(endpoint, projectId, fileUri) {
+  const url = new URL(`${endpoint}/files-api/v2/projects/${projectId}/file/status`);
+  url.searchParams.set('fileUri', fileUri);
+  const opts = { headers: { Authorization: `Bearer ${token}` } };
+
+  const resp = await fetchWithRetry(url, opts);
+  if (!resp.ok) return { totalStringCount: 0, items: [] };
+  const { response } = await resp.json();
+  const { totalStringCount = 0, items = [] } = response?.data || {};
+  return { totalStringCount, items };
 }
 
 /**
  * Refreshes translation status for every target language of a job by
- * polling per-file progress.
+ * polling per-locale file status (Smartling's recommended
+ * getFileTranslationStatusAllLocales endpoint).
  * @param {Object} params
  * @param {string} params.org - The DA org.
  * @param {string} params.site - The DA site.
  * @param {Object} params.service - The service configuration.
  * @param {Object[]} params.langs - Target languages; mutated in place with
- *  `translation.status` (Smartling's active workflow step name, or
- *  'translated' once complete) and `translation.translated`.
+ *  `translation.status` ('translated' once every file is complete for
+ *  that locale, otherwise Smartling's real progress percentage, e.g.
+ *  '62% translated') and `translation.translated` (files complete).
  * @param {Object[]} params.urls - The urls in the project.
  * @param {Object} params.actions - `{ saveState }` callback.
  * @returns {Promise<void>}
@@ -313,29 +344,22 @@ export async function getStatusAll({
   org, site, service, langs, urls, actions,
 }) {
   const { saveState } = actions;
-  const { origin, projectId, jobUid } = service;
+  const { origin, projectId } = service;
   const endpoint = resolveOrigin(origin, org, site);
-
-  const opts = { headers: { 'Content-Type': 'application/json' } };
-  opts.headers.Authorization = `Bearer ${token}`;
 
   langs.forEach((lang) => { lang.translation.translated = 0; });
 
   for (const url of urls) {
-    const resp = await fetchWithRetry(`${endpoint}/jobs-api/v3/projects/${projectId}/jobs/${jobUid.value}/file/progress?fileUri=${url.daBasePath}`, opts);
-    const { response } = await resp.json();
-    if (response.code !== 'SUCCESS') return;
-    const langReports = response?.data?.contentProgressReport;
-    if (!langReports) return;
-    langReports.forEach((report) => {
-      const { targetLocaleId, progress } = report;
-      const lang = langs.find((projLang) => projLang.code === targetLocaleId);
+    // eslint-disable-next-line no-await-in-loop
+    const { totalStringCount, items } = await fetchFileStatus(endpoint, projectId, url.daBasePath);
+    items.forEach((item) => {
+      const lang = langs.find((projLang) => projLang.code === item.localeId);
       if (!lang) return;
-      // Previously translated files will have a null progress object.
-      if (!progress || progress.percentComplete === 100) {
+      const progress = translationProgress({ totalStringCount, ...item });
+      if (progress === 100) {
         lang.translation.translated += 1;
       } else {
-        lang.translation.status = activeWorkflowStepName(report);
+        lang.translation.status = `${progress}% translated`;
       }
     });
   }

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -2,6 +2,11 @@ const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_BASE_DELAY_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 30000;
 
+/**
+ * Default retry predicate: rate-limited or server-error responses.
+ * @param {number} status - The response's HTTP status code.
+ * @returns {boolean} Whether the status should trigger a retry.
+ */
 function isDefaultRetryable(status) {
   return status === 429 || status >= 500;
 }
@@ -41,6 +46,12 @@ export default async function fetchWithRetry(url, opts, config = {}) {
     isRetryable = isDefaultRetryable,
   } = config;
 
+  /**
+   * Makes one fetch attempt, retrying itself (with a delay) if the
+   * response is retryable and attempts remain.
+   * @param {number} attemptNum - Zero-based attempt count so far.
+   * @returns {Promise<Response>} The final response (ok or not).
+   */
   async function attempt(attemptNum) {
     const resp = await fetch(url, opts);
     if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;

--- a/nx/blocks/loc/utils/fetchWithRetry.js
+++ b/nx/blocks/loc/utils/fetchWithRetry.js
@@ -1,0 +1,60 @@
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+function isDefaultRetryable(status) {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Resolves after the given delay.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>}
+ */
+function wait(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Fetches, retrying on rate-limit/transient-failure responses with
+ * exponential backoff and jitter, honoring a Retry-After header when the
+ * service provides one. Shared across loc connectors (Smartling,
+ * Lionbridge, ...) whose translation APIs enforce request-rate and/or
+ * concurrent-request limits.
+ * @param {string|URL} url - The request URL.
+ * @param {Object} opts - Fetch options.
+ * @param {Object} [config]
+ * @param {number} [config.maxRetries] - Max retry attempts after the
+ *  initial request.
+ * @param {number} [config.baseDelayMs] - Base delay before the first
+ *  retry; doubles each subsequent attempt.
+ * @param {number} [config.maxDelayMs] - Delay cap, before jitter.
+ * @param {(status: number) => boolean} [config.isRetryable] - Whether a
+ *  response status should trigger a retry. Defaults to 429 and 5xx.
+ * @returns {Promise<Response>} The final response (ok or not).
+ */
+export default async function fetchWithRetry(url, opts, config = {}) {
+  const {
+    maxRetries = DEFAULT_MAX_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    isRetryable = isDefaultRetryable,
+  } = config;
+
+  async function attempt(attemptNum) {
+    const resp = await fetch(url, opts);
+    if (!isRetryable(resp.status) || attemptNum >= maxRetries) return resp;
+
+    const retryAfterSecs = Number(resp.headers.get('retry-after'));
+    const backoff = Math.min(baseDelayMs * (2 ** attemptNum), maxDelayMs);
+    const jitter = Math.random() * backoff * 0.3;
+    const delayMs = Number.isFinite(retryAfterSecs) && retryAfterSecs > 0
+      ? retryAfterSecs * 1000
+      : backoff + jitter;
+
+    await wait(delayMs);
+    return attempt(attemptNum + 1);
+  }
+
+  return attempt(0);
+}

--- a/nx/blocks/loc/views/translate/translate.css
+++ b/nx/blocks/loc/views/translate/translate.css
@@ -2,6 +2,26 @@ svg {
   display: none;
 }
 
+.nx-loading-spinner {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentcolor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: da-spin 0.8s linear infinite;
+}
+
+@keyframes da-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nx-loading-spinner {
+    animation-duration: 1.5s;
+  }
+}
+
 p {
   margin: 0;
   line-height: 1;

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -24,6 +24,12 @@ class NxLocTranslate extends LitElement {
     _translateLangs: { state: true },
     _copyLangs: { state: true },
     _message: { state: true },
+    _connectBusy: { state: true },
+    _sendAllBusy: { state: true },
+    _getStatusBusy: { state: true },
+    _cancelAllBusy: { state: true },
+    _copyAllBusy: { state: true },
+    _cancelingLangs: { state: true },
   };
 
   connectedCallback() {
@@ -89,7 +95,12 @@ class NxLocTranslate extends LitElement {
   }
 
   async handleConnect() {
-    this._connected = await this._service.connector.connect(this._service);
+    this._connectBusy = true;
+    try {
+      this._connected = await this._service.connector.connect(this._service);
+    } finally {
+      this._connectBusy = false;
+    }
   }
 
   async fetchUrls(service, fetchContent, langs) {
@@ -210,67 +221,91 @@ class NxLocTranslate extends LitElement {
     //   return;
     // }
 
-    const conf = await this.getBaseTranslationConf(false);
+    this._getStatusBusy = true;
+    try {
+      const conf = await this.getBaseTranslationConf(false);
 
-    await this._service.connector.getStatusAll(removeWaitingLanguagesFromConf(conf));
+      await this._service.connector.getStatusAll(removeWaitingLanguagesFromConf(conf));
 
-    await this.checkAndSaveLangs(conf);
+      await this.checkAndSaveLangs(conf);
 
-    this.handleSaveLangs();
+      this.handleSaveLangs();
+    } finally {
+      this._getStatusBusy = false;
+    }
   }
 
   async handleCancelAll() {
-    const sendMessage = this.handleMessage.bind(this);
+    this._cancelAllBusy = true;
+    try {
+      const sendMessage = this.handleMessage.bind(this);
 
-    const { cancelTranslation } = this._service.connector;
+      const { cancelTranslation } = this._service.connector;
 
-    let shouldRefresh = false;
-    for (const lang of this._translateLangs) {
-      const result = await cancelTranslation({ service: this._service, lang, sendMessage });
-      if (result?.ok !== false) shouldRefresh = true;
-    }
+      let shouldRefresh = false;
+      for (const lang of this._translateLangs) {
+        const result = await cancelTranslation({ service: this._service, lang, sendMessage });
+        if (result?.ok !== false) shouldRefresh = true;
+      }
 
-    if (shouldRefresh) {
-      // Refresh locales GLaaS accepted; skip when every cancel was rejected.
-      await this.handleGetStatus();
+      if (shouldRefresh) {
+        // Refresh locales GLaaS accepted; skip when every cancel was rejected.
+        await this.handleGetStatus();
+      }
+    } finally {
+      this._cancelAllBusy = false;
     }
   }
 
   async handleCancelLang(lang) {
-    const sendMessage = this.handleMessage.bind(this);
+    this._cancelingLangs ??= new Set();
+    this._cancelingLangs.add(lang.code);
+    this.requestUpdate();
 
-    const { cancelTranslation } = this._service.connector;
+    try {
+      const sendMessage = this.handleMessage.bind(this);
 
-    const result = await cancelTranslation({ service: this._service, lang, sendMessage });
+      const { cancelTranslation } = this._service.connector;
 
-    if (result?.ok !== false) {
-      await this.handleGetStatus();
+      const result = await cancelTranslation({ service: this._service, lang, sendMessage });
+
+      if (result?.ok !== false) {
+        await this.handleGetStatus();
+      }
+    } finally {
+      this._cancelingLangs.delete(lang.code);
+      this.requestUpdate();
     }
   }
 
   async handleCopyAll() {
-    const { _copyLangs: langs } = this;
+    this._copyAllBusy = true;
+    try {
+      const { _copyLangs: langs } = this;
 
-    // langsWithUrls is an in-memory object that contains all URL fetches.
-    const { langsWithUrls, urls } = await this.fetchUrls({}, true, langs);
+      // langsWithUrls is an in-memory object that contains all URL fetches.
+      const { langsWithUrls, urls } = await this.fetchUrls({}, true, langs);
 
-    langsWithUrls.forEach((lang) => {
-      const errors = lang.urls.filter((url) => url.error);
-      if (errors.length) {
-        // Create an errors array if it doesn't exist
-        this._urlErrors ??= [];
-        this._urlErrors.push(...errors);
-      }
-    });
+      langsWithUrls.forEach((lang) => {
+        const errors = lang.urls.filter((url) => url.error);
+        if (errors.length) {
+          // Create an errors array if it doesn't exist
+          this._urlErrors ??= [];
+          this._urlErrors.push(...errors);
+        }
+      });
 
-    // Do not continue if any errors
-    if (this._urlErrors?.length) return;
+      // Do not continue if any errors
+      if (this._urlErrors?.length) return;
 
-    const { org, site, title, options } = this.project;
+      const { org, site, title, options } = this.project;
 
-    await copySourceLangs(org, site, title, options, this._copyLangs, urls, langsWithUrls);
-    this.handleSaveLangs();
-    this.requestUpdate();
+      await copySourceLangs(org, site, title, options, this._copyLangs, urls, langsWithUrls);
+      this.handleSaveLangs();
+      this.requestUpdate();
+    } finally {
+      this._copyAllBusy = false;
+    }
   }
 
   get _project() {
@@ -297,11 +332,17 @@ class NxLocTranslate extends LitElement {
     return html`<p><strong>Conflict behavior:</strong> ${this._options['translate.conflict.behavior']}</p>`;
   }
 
+  renderSpinner() {
+    return html`<span class="nx-loading-spinner" aria-hidden="true"></span>`;
+  }
+
   renderTranslateAction() {
     if (this._connected === false) {
       return html`
         ${this.renderBehavior()}
-        <sl-button @click=${this.handleConnect} class="accent">Connect</sl-button>
+        <sl-button @click=${this.handleConnect} class="accent" ?disabled=${this._connectBusy}>
+          ${this._connectBusy ? this.renderSpinner() : nothing} Connect
+        </sl-button>
       `;
     }
 
@@ -314,14 +355,22 @@ class NxLocTranslate extends LitElement {
         if (sent) {
           return html`
             ${this.renderBehavior()}
-            ${this.canCancel ? html`<sl-button @click=${this.handleCancelAll} class="primary outline">Cancel project</sl-button>` : nothing}
-            <sl-button @click=${this.handleGetStatus} class="accent">Get status</sl-button>
+            ${this.canCancel ? html`
+              <sl-button @click=${this.handleCancelAll} class="primary outline" ?disabled=${this._cancelAllBusy}>
+                ${this._cancelAllBusy ? this.renderSpinner() : nothing} Cancel project
+              </sl-button>
+            ` : nothing}
+            <sl-button @click=${this.handleGetStatus} class="accent" ?disabled=${this._getStatusBusy}>
+              ${this._getStatusBusy ? this.renderSpinner() : nothing} Get status
+            </sl-button>
           `;
         }
 
         return html`
           ${this.renderBehavior()}
-          <sl-button @click=${this.handleSendAll} class="accent">Translate all</sl-button>
+          <sl-button @click=${this.handleSendAll} class="accent" ?disabled=${this._sendAllBusy}>
+            ${this._sendAllBusy ? this.renderSpinner() : nothing} Translate all
+          </sl-button>
         `;
       }
     }
@@ -343,7 +392,12 @@ class NxLocTranslate extends LitElement {
 
   renderCancelLang(lang) {
     if (!this.canCancel || !this._connected || !lang.translation || lang.translation?.status === 'cancelled') return nothing;
-    return html`<sl-button @click=${() => this.handleCancelLang(lang)} class="primary outline">Cancel</sl-button>`;
+    const busy = this._cancelingLangs?.has(lang.code);
+    return html`
+      <sl-button @click=${() => this.handleCancelLang(lang)} class="primary outline" ?disabled=${busy}>
+        ${busy ? this.renderSpinner() : nothing} Cancel
+      </sl-button>
+    `;
   }
 
   renderUrlErrors() {
@@ -414,7 +468,9 @@ class NxLocTranslate extends LitElement {
         <p class="nx-loc-list-actions-header">Copy (${this._options['source.language'].name})</p>
         <div class="actions">
           <p><strong>Conflict behavior:</strong> ${this._options['copy.conflict.behavior']}</p>
-          <sl-button @click=${this.handleCopyAll} class="accent">Copy all</sl-button>
+          <sl-button @click=${this.handleCopyAll} class="accent" ?disabled=${this._copyAllBusy}>
+            ${this._copyAllBusy ? this.renderSpinner() : nothing} Copy all
+          </sl-button>
         </div>
       </div>
       <div class="nx-loc-list-header">

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -39,14 +39,23 @@ class NxLocTranslate extends LitElement {
     super.update();
   }
 
+  /**
+   * Sets up the connector for this project's translation service.
+   *
+   * Augments (does not copy) `this.project.options.service` so that
+   * `this._service` stays the same object connectors mutate — e.g.
+   * Smartling's `sendAllLanguages` sets `service.jobUid` after this runs.
+   * A spread/copy here would leave `this._service` permanently stale for
+   * any property a connector adds after initial setup, until the next
+   * full page load rebuilds it from the freshly persisted project.
+   * @returns {Promise<void>}
+   */
   async setupService() {
-    const connector = await setupConnector(this.project.options.service);
-    this._service = {
-      ...this.project.options.service,
-      connector,
-      org: this.project.org,
-      site: this.project.site,
-    };
+    const { service } = this.project.options;
+    service.connector = await setupConnector(service);
+    service.org = this.project.org;
+    service.site = this.project.site;
+    this._service = service;
     this._connected = await this._service.connector.isConnected(this._service);
   }
 

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -172,8 +172,15 @@ class NxLocTranslate extends LitElement {
       if (sendAll?.errors?.length) {
         this._urlErrors = sendAll.errors;
       }
-      // See if anything is finished immediately
-      this.checkAndSaveLangs(conf);
+      // Connectors report failures by calling `sendMessage({ type: 'error' })`
+      // and returning early - nothing was actually sent in that case, so
+      // skip checking for finished languages, which would otherwise
+      // immediately overwrite the error message with "Checking for
+      // languages to save" before the user ever sees it.
+      if (this._message?.type !== 'error') {
+        // See if anything is finished immediately
+        this.checkAndSaveLangs(conf);
+      }
     } finally {
       this._sendAllBusy = false;
     }

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -315,13 +315,18 @@ class NxLocTranslate extends LitElement {
     };
   }
 
+  // A lang must have actually been sent, and not already be complete or
+  // cancelled, to have anything left to cancel - shared by the per-lang
+  // Cancel button and the project-level counts below so they can't drift
+  // out of sync with each other.
+  canCancelLang(lang) {
+    return !!lang.translation
+      && lang.translation.status !== 'cancelled'
+      && lang.translation.status !== 'complete';
+  }
+
   get incompleteLangs() {
-    return this._translateLangs.filter((lang) => {
-      const status = lang.translation?.status;
-      if (status === 'complete') return false;
-      if (status === 'cancelled') return false;
-      return true;
-    }).length;
+    return this._translateLangs.filter((lang) => this.canCancelLang(lang)).length;
   }
 
   get canCancel() {
@@ -391,7 +396,7 @@ class NxLocTranslate extends LitElement {
   }
 
   renderCancelLang(lang) {
-    if (!this.canCancel || !this._connected || !lang.translation || lang.translation?.status === 'cancelled') return nothing;
+    if (!this.canCancel || !this._connected || !this.canCancelLang(lang)) return nothing;
     const busy = this._cancelingLangs?.has(lang.code);
     return html`
       <sl-button @click=${() => this.handleCancelLang(lang)} class="primary outline" ?disabled=${busy}>
@@ -427,7 +432,7 @@ class NxLocTranslate extends LitElement {
 
   renderTranslate() {
     if (!this._translateLangs?.length) return nothing;
-    const withCancel = this.canCancel && this._connected && this._translateLangs.some((lang) => lang.translation && lang.translation.status !== 'cancelled') ? ' with-cancel' : '';
+    const withCancel = this.canCancel && this._connected && this._translateLangs.some((lang) => this.canCancelLang(lang)) ? ' with-cancel' : '';
 
     return html`
       <div class="nx-loc-list-actions">

--- a/nx/blocks/loc/views/translate/translate.js
+++ b/nx/blocks/loc/views/translate/translate.js
@@ -365,9 +365,11 @@ class NxLocTranslate extends LitElement {
                 ${this._cancelAllBusy ? this.renderSpinner() : nothing} Cancel project
               </sl-button>
             ` : nothing}
-            <sl-button @click=${this.handleGetStatus} class="accent" ?disabled=${this._getStatusBusy}>
-              ${this._getStatusBusy ? this.renderSpinner() : nothing} Get status
-            </sl-button>
+            ${this.incompleteLangs ? html`
+              <sl-button @click=${this.handleGetStatus} class="accent" ?disabled=${this._getStatusBusy}>
+                ${this._getStatusBusy ? this.renderSpinner() : nothing} Get status
+              </sl-button>
+            ` : nothing}
           `;
         }
 

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -107,6 +107,83 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(calls[0].url).to.equal(expectedUrl);
   });
 
+  it('reports Smartling\'s own active workflow step, not a stale status, when translation is incomplete', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/progress')) {
+        return new Response(JSON.stringify({
+          response: {
+            code: 'SUCCESS',
+            data: {
+              contentProgressReport: [{
+                targetLocaleId: 'fr-FR',
+                progress: { percentComplete: 50 },
+                workflowProgressReportList: [{
+                  workflowStepSummaryReportItemList: [
+                    { workflowStepName: 'Processing', wordCount: 0, stringCount: 0 },
+                    { workflowStepName: 'Translation', wordCount: 50, stringCount: 5 },
+                    { workflowStepName: 'Published', wordCount: 0, stringCount: 0 },
+                  ],
+                }],
+              }],
+            },
+          },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    // Leftover status from sendAllLanguages — should not still read 'created' after getStatusAll.
+    const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(langs[0].translation.status).to.equal('Translation');
+    expect(langs[0].translation.translated).to.equal(0);
+  });
+
+  it('falls back to a generic "in progress" label when Smartling reports no active workflow step', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/progress')) {
+        return new Response(JSON.stringify({
+          response: {
+            code: 'SUCCESS',
+            data: {
+              contentProgressReport: [{
+                targetLocaleId: 'fr-FR',
+                progress: { percentComplete: 0 },
+              }],
+            },
+          },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(langs[0].translation.status).to.equal('in progress');
+  });
+
   it('rewrites the origin for saveItems file downloads', async () => {
     const service = { origin: legacyOrigin, projectId: 'proj-1' };
     const lang = { code: 'fr-FR' };

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -185,4 +185,46 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(downloadCalls).to.equal(2);
     expect(urls[0].status).to.equal('success');
   });
+
+  it('does not auto-authorize the batch by default', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(false);
+  });
+
+  it('auto-authorizes the batch when translation.service.autoAuthorize is "yes"', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1', autoAuthorize: 'yes' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(true);
+  });
+
+  it('does not auto-authorize when autoAuthorize is set to anything other than "yes"', async () => {
+    const options = { service: { origin: legacyOrigin, projectId: 'proj-1', autoAuthorize: 'no' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const actions = { sendMessage: () => {}, saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
+    expect(JSON.parse(batchCall.body).authorize).to.equal(false);
+  });
 });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -7,6 +7,18 @@ import { DA_TRANSLATE } from '../../../../nx2/utils/utils.js';
 let calls;
 let origFetch;
 
+// totalStringCount is a file-level count in Smartling's real response
+// (shared across all locales), not repeated per item.
+function fileStatusResponse(totalStringCount, items) {
+  return new Response(JSON.stringify({
+    response: { data: { totalStringCount, items } },
+  }), { status: 200 });
+}
+
+function localeItem({ localeId, completedStringCount, excludedStringCount = 0 }) {
+  return { localeId, completedStringCount, excludedStringCount };
+}
+
 function installFetch() {
   calls = [];
   origFetch = window.fetch;
@@ -32,13 +44,8 @@ function installFetch() {
     if (u.includes('/file') && opts.method === 'POST') {
       return new Response(JSON.stringify({ response: { code: 'ACCEPTED' } }), { status: 200 });
     }
-    if (u.includes('/file/progress')) {
-      return new Response(JSON.stringify({
-        response: {
-          code: 'SUCCESS',
-          data: { contentProgressReport: [{ targetLocaleId: 'fr-FR', progress: null }] },
-        },
-      }), { status: 200 });
+    if (u.includes('/file/status')) {
+      return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
     }
     if (u.includes('/files-api/v2/projects')) {
       return new Response('translated content', { status: 200 });
@@ -93,8 +100,8 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(calls.some((c) => c.url === `${base}/job-batches-api/v2/projects/proj-1/batches/batch-1/file`)).to.equal(true);
   });
 
-  it('rewrites the origin for getStatusAll progress polling', async () => {
-    const service = { origin: legacyOrigin, projectId: 'proj-1', jobUid: { value: 'job-1' } };
+  it('rewrites the origin for getStatusAll file-status polling and needs no jobUid', async () => {
+    const service = { origin: legacyOrigin, projectId: 'proj-1' };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
@@ -103,40 +110,24 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, langs, urls, actions,
     });
 
-    const expectedUrl = `${DA_TRANSLATE}/translate/smartling/${org}/${site}/jobs-api/v3/projects/proj-1/jobs/job-1/file/progress?fileUri=/page`;
+    const expectedUrl = `${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/file/status?fileUri=%2Fpage`;
     expect(calls[0].url).to.equal(expectedUrl);
+    expect(langs[0].translation.status).to.equal('translated');
   });
 
-  it('reports Smartling\'s own active workflow step, not a stale status, when translation is incomplete', async () => {
+  it('reports Smartling\'s real progress percentage, not a stale status, when translation is incomplete', async () => {
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/progress')) {
-        return new Response(JSON.stringify({
-          response: {
-            code: 'SUCCESS',
-            data: {
-              contentProgressReport: [{
-                targetLocaleId: 'fr-FR',
-                progress: { percentComplete: 50 },
-                workflowProgressReportList: [{
-                  workflowStepSummaryReportItemList: [
-                    { workflowStepName: 'Processing', wordCount: 0, stringCount: 0 },
-                    { workflowStepName: 'Translation', wordCount: 50, stringCount: 5 },
-                    { workflowStepName: 'Published', wordCount: 0, stringCount: 0 },
-                  ],
-                }],
-              }],
-            },
-          },
-        }), { status: 200 });
+      if (u.includes('/file/status')) {
+        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 5 })]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
     // Leftover status from sendAllLanguages — should not still read 'created' after getStatusAll.
     const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
     const urls = [{ daBasePath: '/page' }];
@@ -146,34 +137,25 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, langs, urls, actions,
     });
 
-    expect(langs[0].translation.status).to.equal('Translation');
+    expect(langs[0].translation.status).to.equal('50% translated');
     expect(langs[0].translation.translated).to.equal(0);
   });
 
-  it('falls back to a generic "in progress" label when Smartling reports no active workflow step', async () => {
+  it('floors progress rather than rounding up, per Smartling\'s documented formula', async () => {
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/progress')) {
-        return new Response(JSON.stringify({
-          response: {
-            code: 'SUCCESS',
-            data: {
-              contentProgressReport: [{
-                targetLocaleId: 'fr-FR',
-                progress: { percentComplete: 0 },
-              }],
-            },
-          },
-        }), { status: 200 });
+      if (u.includes('/file/status')) {
+        // 999999 / 1000000 = 99.9999% — must report 99%, not 100%.
+        return fileStatusResponse(1000000, [localeItem({ localeId: 'fr-FR', completedStringCount: 999999 })]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
-    const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
 
@@ -181,7 +163,32 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, langs, urls, actions,
     });
 
-    expect(langs[0].translation.status).to.equal('in progress');
+    expect(langs[0].translation.status).to.equal('99% translated');
+  });
+
+  it('treats a fully-excluded file as 100% (nothing left to translate)', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/status')) {
+        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 0, excludedStringCount: 10 })]);
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(langs[0].translation.status).to.equal('translated');
+    expect(langs[0].translation.translated).to.equal(1);
   });
 
   it('rewrites the origin for saveItems file downloads', async () => {
@@ -194,33 +201,28 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, lang, urls, saveFn,
     });
 
-    const call = calls.find((c) => c.url.includes('/files-api/v2/projects'));
+    const call = calls.find((c) => c.url.includes('/files-api/v2/projects') && c.url.includes('/locales/'));
     expect(call.url).to.include(`${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/locales/fr-FR/file`);
   });
 
-  it('retries a 429 from getStatusAll progress polling before succeeding', async () => {
-    let progressCalls = 0;
+  it('retries a 429 from getStatusAll file-status polling before succeeding', async () => {
+    let statusCalls = 0;
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/progress')) {
-        progressCalls += 1;
-        if (progressCalls === 1) {
+      if (u.includes('/file/status')) {
+        statusCalls += 1;
+        if (statusCalls === 1) {
           return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
         }
-        return new Response(JSON.stringify({
-          response: {
-            code: 'SUCCESS',
-            data: { contentProgressReport: [{ targetLocaleId: 'fr-FR', progress: null }] },
-          },
-        }), { status: 200 });
+        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
@@ -229,7 +231,7 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, langs, urls, actions,
     });
 
-    expect(progressCalls).to.equal(2);
+    expect(statusCalls).to.equal(2);
     expect(langs[0].translation.status).to.equal('translated');
   });
 
@@ -240,7 +242,7 @@ describe('smartling connector - legacy origin rewriting', () => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/files-api/v2/projects')) {
+      if (u.includes('/files-api/v2/projects') && u.includes('/locales/')) {
         downloadCalls += 1;
         if (downloadCalls === 1) {
           return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -306,4 +306,99 @@ describe('smartling connector - legacy origin rewriting', () => {
     const batchCall = calls.find((c) => c.url.includes('/job-batches-api/v2/projects') && !c.url.includes('/file'));
     expect(JSON.parse(batchCall.body).authorize).to.equal(false);
   });
+
+  // Smartling's documented error envelope (Error Handling support article):
+  // every 4xx/5xx response, on every endpoint, has this shape.
+  function validationErrorResponse(message) {
+    return new Response(JSON.stringify({
+      response: {
+        code: 'VALIDATION_ERROR',
+        errors: [{ key: 'error.validation.job.locales.invalid', message, details: { field: 'targetLocaleIds' } }],
+      },
+    }), { status: 400 });
+  }
+
+  it('surfaces a job-creation failure as an error message instead of failing silently', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/jobs-api/v3/projects')) return validationErrorResponse('Invalid locales [fr-FR]');
+      return new Response('{}', { status: 200 });
+    };
+
+    const options = { service: { origin: 'https://api.smartling.com', projectId: 'proj-1' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const messages = [];
+    const actions = { sendMessage: (m) => messages.push(m), saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const errorMessage = messages.find((m) => m.type === 'error');
+    expect(errorMessage.text).to.include('Invalid locales [fr-FR]');
+  });
+
+  it('surfaces a batch-creation failure as an error message instead of failing silently', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/jobs-api/v3/projects')) {
+        return new Response(JSON.stringify({ response: { data: { translationJobUid: 'job-1' } } }), { status: 200 });
+      }
+      if (u.includes('/job-batches-api/v2/projects') && !u.includes('/file')) {
+        return validationErrorResponse('Invalid fileUri');
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const options = { service: { origin: 'https://api.smartling.com', projectId: 'proj-1' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const messages = [];
+    const actions = { sendMessage: (m) => messages.push(m), saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const errorMessage = messages.find((m) => m.type === 'error');
+    expect(errorMessage.text).to.include('Invalid fileUri');
+  });
+
+  it('surfaces a per-file upload failure as an error message instead of only counting it as not-accepted', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/jobs-api/v3/projects')) {
+        return new Response(JSON.stringify({ response: { data: { translationJobUid: 'job-1' } } }), { status: 200 });
+      }
+      if (u.includes('/job-batches-api/v2/projects') && u.includes('/batches') && !u.includes('/file')) {
+        return new Response(JSON.stringify({ response: { data: { batchUid: 'batch-1' } } }), { status: 200 });
+      }
+      if (u.includes('/file') && opts.method === 'POST') return validationErrorResponse('Invalid locales [fr-FR]');
+      return new Response('{}', { status: 200 });
+    };
+
+    const options = { service: { origin: 'https://api.smartling.com', projectId: 'proj-1' } };
+    const langs = [{ name: 'French', code: 'fr-FR' }];
+    const urls = [{ daBasePath: '/page', content: '<p>hi</p>' }];
+    const messages = [];
+    const actions = { sendMessage: (m) => messages.push(m), saveState: async () => {} };
+
+    await sendAllLanguages({
+      org, site, title: 'title', options, langs, urls, actions,
+    });
+
+    const errorMessage = messages.find((m) => m.type === 'error');
+    expect(errorMessage.text).to.include('Invalid locales [fr-FR]');
+    expect(langs[0].translation.status).to.equal('error');
+  });
 });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -120,4 +120,69 @@ describe('smartling connector - legacy origin rewriting', () => {
     const call = calls.find((c) => c.url.includes('/files-api/v2/projects'));
     expect(call.url).to.include(`${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/locales/fr-FR/file`);
   });
+
+  it('retries a 429 from getStatusAll progress polling before succeeding', async () => {
+    let progressCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/progress')) {
+        progressCalls += 1;
+        if (progressCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response(JSON.stringify({
+          response: {
+            code: 'SUCCESS',
+            data: { contentProgressReport: [{ targetLocaleId: 'fr-FR', progress: null }] },
+          },
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(progressCalls).to.equal(2);
+    expect(langs[0].translation.status).to.equal('translated');
+  });
+
+  it('retries a 429 from saveItems file download before succeeding', async () => {
+    let downloadCalls = 0;
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/files-api/v2/projects')) {
+        downloadCalls += 1;
+        if (downloadCalls === 1) {
+          return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+        }
+        return new Response('translated content', { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const lang = { code: 'fr-FR' };
+    const urls = [{ daBasePath: '/page', ext: 'html' }];
+    const saveFn = async (url) => { url.status = 'success'; };
+
+    await saveItems({
+      org, site, service, lang, urls, saveFn,
+    });
+
+    expect(downloadCalls).to.equal(2);
+    expect(urls[0].status).to.equal('success');
+  });
 });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -7,16 +7,17 @@ import { DA_TRANSLATE } from '../../../../nx2/utils/utils.js';
 let calls;
 let origFetch;
 
-// totalStringCount is a file-level count in Smartling's real response
-// (shared across all locales), not repeated per item.
-function fileStatusResponse(totalStringCount, items) {
+// getJobProgress reports one precomputed percentComplete per locale for
+// the whole job - Smartling does its own floor/excluded-string handling,
+// so there's no per-file breakdown or formula left for us to reimplement.
+function jobProgressResponse(contentProgressReport) {
   return new Response(JSON.stringify({
-    response: { data: { totalStringCount, items } },
+    response: { data: { contentProgressReport } },
   }), { status: 200 });
 }
 
-function localeItem({ localeId, completedStringCount, excludedStringCount = 0 }) {
-  return { localeId, completedStringCount, excludedStringCount };
+function localeProgress(targetLocaleId, percentComplete) {
+  return { targetLocaleId, progress: { percentComplete } };
 }
 
 function installFetch() {
@@ -44,8 +45,8 @@ function installFetch() {
     if (u.includes('/file') && opts.method === 'POST') {
       return new Response(JSON.stringify({ response: { code: 'ACCEPTED' } }), { status: 200 });
     }
-    if (u.includes('/file/status')) {
-      return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
+    if (u.includes('/jobs-api/v3/projects') && u.includes('/progress')) {
+      return jobProgressResponse([localeProgress('fr-FR', 100)]);
     }
     if (u.includes('/files-api/v2/projects')) {
       return new Response('translated content', { status: 200 });
@@ -100,8 +101,8 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(calls.some((c) => c.url === `${base}/job-batches-api/v2/projects/proj-1/batches/batch-1/file`)).to.equal(true);
   });
 
-  it('rewrites the origin for getStatusAll file-status polling and needs no jobUid', async () => {
-    const service = { origin: legacyOrigin, projectId: 'proj-1' };
+  it('rewrites the origin for getStatusAll job-progress polling', async () => {
+    const service = { origin: legacyOrigin, projectId: 'proj-1', jobUid: { value: 'job-1' } };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
@@ -110,9 +111,24 @@ describe('smartling connector - legacy origin rewriting', () => {
       org, site, service, langs, urls, actions,
     });
 
-    const expectedUrl = `${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/file/status?fileUri=%2Fpage`;
+    const expectedUrl = `${DA_TRANSLATE}/translate/smartling/${org}/${site}/jobs-api/v3/projects/proj-1/jobs/job-1/progress`;
     expect(calls[0].url).to.equal(expectedUrl);
     expect(langs[0].translation.status).to.equal('translated');
+    expect(langs[0].translation.translated).to.equal(1);
+  });
+
+  it('does nothing when the job has not been created yet (no jobUid)', async () => {
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(calls.length).to.equal(0);
+    expect(langs[0].translation.status).to.equal('created');
   });
 
   it('reports Smartling\'s real progress percentage, not a stale status, when translation is incomplete', async () => {
@@ -121,13 +137,13 @@ describe('smartling connector - legacy origin rewriting', () => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/status')) {
-        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 5 })]);
+      if (u.includes('/progress')) {
+        return jobProgressResponse([localeProgress('fr-FR', 50)]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
     // Leftover status from sendAllLanguages — should not still read 'created' after getStatusAll.
     const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'created' } }];
     const urls = [{ daBasePath: '/page' }];
@@ -141,20 +157,21 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(langs[0].translation.translated).to.equal(0);
   });
 
-  it('floors progress rather than rounding up, per Smartling\'s documented formula', async () => {
+  it('passes through Smartling\'s percentComplete verbatim, without re-deriving it ourselves', async () => {
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/status')) {
-        // 999999 / 1000000 = 99.9999% — must report 99%, not 100%.
-        return fileStatusResponse(1000000, [localeItem({ localeId: 'fr-FR', completedStringCount: 999999 })]);
+      if (u.includes('/progress')) {
+        // Smartling floors internally (e.g. 99.9999% -> 99) - we must not
+        // re-round or otherwise recompute this ourselves.
+        return jobProgressResponse([localeProgress('fr-FR', 99)]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
@@ -166,21 +183,21 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(langs[0].translation.status).to.equal('99% translated');
   });
 
-  it('treats a fully-excluded file as 100% (nothing left to translate)', async () => {
+  it('marks a lang translated (full file count) once Smartling reports 100% complete', async () => {
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/status')) {
-        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 0, excludedStringCount: 10 })]);
+      if (u.includes('/progress')) {
+        return jobProgressResponse([localeProgress('fr-FR', 100)]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
-    const urls = [{ daBasePath: '/page' }];
+    const urls = [{ daBasePath: '/page' }, { daBasePath: '/page-2' }];
     const actions = { saveState: async () => {} };
 
     await getStatusAll({
@@ -188,7 +205,7 @@ describe('smartling connector - legacy origin rewriting', () => {
     });
 
     expect(langs[0].translation.status).to.equal('translated');
-    expect(langs[0].translation.translated).to.equal(1);
+    expect(langs[0].translation.translated).to.equal(2);
   });
 
   it('does not revert a lang already saved to DA back to "translated"', async () => {
@@ -197,14 +214,14 @@ describe('smartling connector - legacy origin rewriting', () => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/status')) {
+      if (u.includes('/progress')) {
         // Smartling keeps reporting 100% complete indefinitely once done.
-        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
+        return jobProgressResponse([localeProgress('fr-FR', 100)]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
     const langs = [{ code: 'fr-FR', translation: { translated: 1, status: 'complete', saved: 1 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };
@@ -214,6 +231,32 @@ describe('smartling connector - legacy origin rewriting', () => {
     });
 
     expect(langs[0].translation.status).to.equal('complete');
+    expect(calls.length).to.equal(0);
+  });
+
+  it('does not revert a cancelled lang back to "translated"', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/progress')) {
+        return jobProgressResponse([localeProgress('fr-FR', 100)]);
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+    const langs = [{ code: 'fr-FR', translation: { translated: 0, status: 'cancelled' } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(langs[0].translation.status).to.equal('cancelled');
+    expect(calls.length).to.equal(0);
   });
 
   it('rewrites the origin for saveItems file downloads', async () => {
@@ -230,24 +273,24 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(call.url).to.include(`${DA_TRANSLATE}/translate/smartling/${org}/${site}/files-api/v2/projects/proj-1/locales/fr-FR/file`);
   });
 
-  it('retries a 429 from getStatusAll file-status polling before succeeding', async () => {
+  it('retries a 429 from getStatusAll job-progress polling before succeeding', async () => {
     let statusCalls = 0;
     origFetch = window.fetch;
     window.fetch = async (url, opts = {}) => {
       const u = url.toString();
       calls.push({ url: u, method: opts.method, body: opts.body });
 
-      if (u.includes('/file/status')) {
+      if (u.includes('/progress')) {
         statusCalls += 1;
         if (statusCalls === 1) {
           return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
         }
-        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
+        return jobProgressResponse([localeProgress('fr-FR', 100)]);
       }
       return new Response('{}', { status: 200 });
     };
 
-    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
     const langs = [{ code: 'fr-FR', translation: { translated: 0 } }];
     const urls = [{ daBasePath: '/page' }];
     const actions = { saveState: async () => {} };

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import {
-  connect, saveItems, sendAllLanguages, getStatusAll,
+  connect, saveItems, sendAllLanguages, getStatusAll, cancelTranslation,
 } from '../../../../nx/blocks/loc/connectors/smartling/index.js';
 import { DA_TRANSLATE } from '../../../../nx2/utils/utils.js';
 
@@ -425,5 +425,111 @@ describe('smartling connector - legacy origin rewriting', () => {
     const errorMessage = messages.find((m) => m.type === 'error');
     expect(errorMessage.text).to.include('Invalid locales [fr-FR]');
     expect(langs[0].translation.status).to.equal('error');
+  });
+
+  describe('cancelTranslation', () => {
+    it('skips cancellation when the lang has no translation info or job yet', async () => {
+      const service = {};
+      const lang = { code: 'fr-FR', name: 'French' };
+      const messages = [];
+      const sendMessage = (m) => messages.push(m);
+
+      const result = await cancelTranslation({ service, lang, sendMessage });
+
+      expect(result).to.deep.equal({ ok: true, skipped: true });
+      expect(calls.length).to.equal(0);
+    });
+
+    it('cancels a language by removing its locale from the job (200, synchronous)', async () => {
+      window.fetch = async (url, opts = {}) => {
+        const u = url.toString();
+        calls.push({ url: u, method: opts.method, body: opts.body });
+        return new Response(JSON.stringify({ response: { code: 'SUCCESS' } }), { status: 200 });
+      };
+
+      const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+      const lang = { code: 'fr-FR', name: 'French', translation: { status: 'translated' } };
+      const messages = [];
+      const sendMessage = (m) => messages.push(m);
+
+      const result = await cancelTranslation({ service, lang, sendMessage });
+
+      expect(result).to.deep.equal({ ok: true });
+      expect(lang.translation.status).to.equal('cancelled');
+      expect(calls[0].method).to.equal('DELETE');
+      expect(calls[0].url).to.equal('https://api.smartling.com/jobs-api/v3/projects/proj-1/jobs/job-1/locales/fr-FR');
+    });
+
+    it('polls the async process to completion when Smartling responds 202', async () => {
+      window.fetch = async (url, opts = {}) => {
+        const u = url.toString();
+        calls.push({ url: u, method: opts.method, body: opts.body });
+
+        if (u.includes('/locales/fr-FR')) {
+          return new Response(JSON.stringify({ response: { data: { processUid: 'proc-1' } } }), { status: 202 });
+        }
+        if (u.includes('/processes/proc-1')) {
+          return new Response(JSON.stringify({ response: { data: { processState: 'COMPLETED' } } }), { status: 200 });
+        }
+        return new Response('{}', { status: 200 });
+      };
+
+      const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+      const lang = { code: 'fr-FR', name: 'French', translation: { status: 'translated' } };
+      const messages = [];
+      const sendMessage = (m) => messages.push(m);
+
+      const result = await cancelTranslation({ service, lang, sendMessage });
+
+      expect(result).to.deep.equal({ ok: true });
+      expect(lang.translation.status).to.equal('cancelled');
+      expect(calls.some((c) => c.url.includes('/processes/proc-1'))).to.equal(true);
+    });
+
+    it('reports an error and does not cancel when the async process fails', async () => {
+      window.fetch = async (url, opts = {}) => {
+        const u = url.toString();
+        calls.push({ url: u, method: opts.method, body: opts.body });
+
+        if (u.includes('/locales/fr-FR')) {
+          return new Response(JSON.stringify({ response: { data: { processUid: 'proc-1' } } }), { status: 202 });
+        }
+        if (u.includes('/processes/proc-1')) {
+          return new Response(JSON.stringify({ response: { data: { processState: 'FAILED' } } }), { status: 200 });
+        }
+        return new Response('{}', { status: 200 });
+      };
+
+      const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+      const lang = { code: 'fr-FR', name: 'French', translation: { status: 'translated' } };
+      const messages = [];
+      const sendMessage = (m) => messages.push(m);
+
+      const result = await cancelTranslation({ service, lang, sendMessage });
+
+      expect(result).to.deep.equal({ ok: false });
+      expect(lang.translation.status).to.equal('translated');
+      expect(messages.find((m) => m.type === 'error')).to.exist;
+    });
+
+    it('surfaces an error message when the cancel request itself fails', async () => {
+      window.fetch = async (url, opts = {}) => {
+        const u = url.toString();
+        calls.push({ url: u, method: opts.method, body: opts.body });
+        return validationErrorResponse('Job can be cancelled only in DRAFT, AWAITING_AUTHORIZATION, or IN_PROGRESS statuses');
+      };
+
+      const service = { origin: 'https://api.smartling.com', projectId: 'proj-1', jobUid: { value: 'job-1' } };
+      const lang = { code: 'fr-FR', name: 'French', translation: { status: 'translated' } };
+      const messages = [];
+      const sendMessage = (m) => messages.push(m);
+
+      const result = await cancelTranslation({ service, lang, sendMessage });
+
+      expect(result).to.deep.equal({ ok: false });
+      expect(lang.translation.status).to.equal('translated');
+      const errorMessage = messages.find((m) => m.type === 'error');
+      expect(errorMessage.text).to.include('Job can be cancelled only in DRAFT');
+    });
   });
 });

--- a/test/loc/connectors/smartling/index.test.js
+++ b/test/loc/connectors/smartling/index.test.js
@@ -191,6 +191,31 @@ describe('smartling connector - legacy origin rewriting', () => {
     expect(langs[0].translation.translated).to.equal(1);
   });
 
+  it('does not revert a lang already saved to DA back to "translated"', async () => {
+    origFetch = window.fetch;
+    window.fetch = async (url, opts = {}) => {
+      const u = url.toString();
+      calls.push({ url: u, method: opts.method, body: opts.body });
+
+      if (u.includes('/file/status')) {
+        // Smartling keeps reporting 100% complete indefinitely once done.
+        return fileStatusResponse(10, [localeItem({ localeId: 'fr-FR', completedStringCount: 10 })]);
+      }
+      return new Response('{}', { status: 200 });
+    };
+
+    const service = { origin: 'https://api.smartling.com', projectId: 'proj-1' };
+    const langs = [{ code: 'fr-FR', translation: { translated: 1, status: 'complete', saved: 1 } }];
+    const urls = [{ daBasePath: '/page' }];
+    const actions = { saveState: async () => {} };
+
+    await getStatusAll({
+      org, site, service, langs, urls, actions,
+    });
+
+    expect(langs[0].translation.status).to.equal('complete');
+  });
+
   it('rewrites the origin for saveItems file downloads', async () => {
     const service = { origin: legacyOrigin, projectId: 'proj-1' };
     const lang = { code: 'fr-FR' };

--- a/test/loc/utils/fetchWithRetry.test.js
+++ b/test/loc/utils/fetchWithRetry.test.js
@@ -1,0 +1,99 @@
+import { expect } from '@esm-bundle/chai';
+import fetchWithRetry from '../../../nx/blocks/loc/utils/fetchWithRetry.js';
+
+let origFetch;
+
+function installFetch(handler) {
+  origFetch = window.fetch;
+  window.fetch = handler;
+}
+
+function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+describe('fetchWithRetry', () => {
+  afterEach(() => restoreFetch());
+
+  it('returns the response immediately when it is not retryable', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(1);
+  });
+
+  it('retries a 429, honoring Retry-After, then succeeds', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 429, headers: { 'Retry-After': '0.01' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('retries a 503 with exponential backoff when there is no Retry-After', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 503 });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { baseDelayMs: 5, maxDelayMs: 20 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('gives up after maxRetries and returns the last failing response', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 429, headers: { 'Retry-After': '0.001' } });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { maxRetries: 2 });
+
+    expect(resp.status).to.equal(429);
+    expect(calls).to.equal(3); // initial attempt + 2 retries
+  });
+
+  it('does not retry statuses outside the default retryable set', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      return new Response('', { status: 404 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {});
+
+    expect(resp.status).to.equal(404);
+    expect(calls).to.equal(1);
+  });
+
+  it('honors a custom isRetryable predicate', async () => {
+    let calls = 0;
+    installFetch(async () => {
+      calls += 1;
+      if (calls === 1) return new Response('', { status: 418, headers: { 'Retry-After': '0.001' } });
+      return new Response('{}', { status: 200 });
+    });
+
+    const resp = await fetchWithRetry('https://example.com', {}, { isRetryable: (status) => status === 418 });
+
+    expect(resp.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+});


### PR DESCRIPTION
Fixes #150

## Summary
Combines related Smartling connector enhancements (previously #657 and #661, closed in favor of this consolidated PR):

### 1. Retry on 429/5xx to avoid batch-job failures
The Smartling connector had no retry/backoff logic anywhere, so any `429` (rate limit) or transient `5xx` failed the call outright. Multiple spots make this especially likely during larger batch jobs (status polling and file downloads loop per url; downloads also run 5-at-a-time concurrently).

Per [Smartling's own docs](https://help.smartling.com/hc/en-us/articles/1260805145550-Rate-Limits), they enforce **two separate limits** (request-rate and concurrent-request), scoped per user/project/account depending on endpoint. Recommended handling is exponential backoff with jitter, capped at 30–60s, 5–10 max retries.

Adds a shared `nx/blocks/loc/utils/fetchWithRetry.js` (exponential backoff + jitter, honors `Retry-After`, configurable) and wires every Smartling `fetch` call through it. Also used by Lionbridge's connector (#656), which was updated to share this utility instead of maintaining its own copy.

**Bug fix found during live verification**: `translate.js`'s `setupService()` built `this._service` via a spread/copy of `this.project.options.service`, taken once when the Translate view connects, before any job exists. Smartling's `sendAllLanguages` later sets `jobUid` directly on the original object; the copy never saw it, so `getStatusAll` crashed checking status without a page reload in between. Fixed to augment/reference the same object instead of copying it — not Smartling-specific, affects any connector storing request state on `service` rather than per-lang.

### 2. Auto-authorization config option (fixes #150)
Smartling's `job-batches-api` already supports an `authorize` flag on batch creation, previously hardcoded to `false` (requiring manual authorization in Smartling's dashboard before translation starts). Adds `translation.service.{env}.autoAuthorize` ("yes" to enable) as a site-level config value, read at send time and passed through to `createBatch`.

### 3. Correct, well-founded status reporting
Originally attempted to derive a status from `/file/progress`'s workflow-step breakdown — but per Smartling's own **"Checking File Translation Status"** support article, that's not the recommended approach. Switched to their actual recommended endpoint and formula:

- **`getFileTranslationStatusAllLocales`** (`files-api/v2/projects/{projectId}/file/status`) instead of the job-scoped `/file/progress` — no `jobUid` dependency at all.
- Smartling's own documented progress formula: **floor**, never round up to 100% unless truly complete (their own test case: 99.9999% must report 99%), and a fully-excluded file (nothing left to translate) is 100%. `totalStringCount` is file-level in their response (not repeated per locale), so it's read once per file and combined with each locale's own completed/excluded counts.
- Reports the real percentage as status when incomplete (e.g. `"62% translated"`) rather than a fabricated label — Smartling's model here is fundamentally numeric, not enum-based.

**Superseded by #9 below** — after this shipped, explored `getJobProgress` as a lower-call-volume alternative and switched to it.

### 4. Session-expiry recovery, stale-token download fix
Per [Smartling's Authentication docs](https://help.smartling.com/hc/en-us/articles/1260805176849-Authentication), a token pair's session caps at 12 hours regardless of refresh count — eventually the refresh call itself starts failing with 401, even though the original credentials still work. The connector's refresh loop had no recovery path for that, and separately ignored the actual `expiresIn`/`refreshExpiresIn` Smartling returns in favor of a hardcoded interval.

- Replaced the fixed-interval refresh polling with a self-rescheduling loop that tracks Smartling's real `expiresIn` and falls back to a full re-authenticate when a refresh fails, so jobs spanning multiple sessions keep working without a manual reconnect.
- `saveItems` built its download request (including the `Authorization` header) once up front and reused it for an entire batch of downloads, unlike every other function in the file, which reads the current token at each call site — fixed to build it per-download so a background token rotation mid-batch doesn't leave later downloads using a stale token.

Surfaced via a documentation-driven review of the connector against Smartling's Authentication/Rate-Limits/Best-Practices docs, rather than a live bug report.

### 5. Surface connector errors instead of failing silently
Found live: starting a translation produced a 400 (language mismatch) that never showed up in the UI. Two separate bugs:

- `createJob`/`createBatch`/`uploadFiles` did `if (!resp.ok) return null;` and discarded the response body, so the actual reason (e.g. `"Invalid locales [fr-FR]"`) was never read. Now parses Smartling's documented error envelope (`response.errors[].message` — confirmed universal across every endpoint per their [Error Handling docs](https://help.smartling.com/hc/en-us/articles/1260805178349-Error-Handling)) and calls `sendMessage({ type: 'error', text })`, matching Trados's existing pattern. `uploadFiles` also didn't check `resp.ok` at all before this — it does now, per file.
- Even with that fix, the error still didn't render: `translate.js`'s `handleSendAll` unconditionally calls `checkAndSaveLangs` right after the connector call returns, which immediately overwrites the message with `"Checking for languages to save"` and then clears it to `undefined` at the end — before the user ever sees it. This isn't Smartling-specific: Trados has the identical `sendMessage({ type: 'error' })`-then-return pattern and hits the same clobbering. Fixed by skipping `checkAndSaveLangs` when the last message set was type `error`, using `_message` as the connector-agnostic signal rather than changing every connector's return contract.

### 6. Stop re-saving languages already completed to DA
Found live: languages already fully saved to DA were getting re-saved on every subsequent "Get status" click, instead of only once on the In Progress → Complete transition. `getStatusAll` unconditionally set `status = 'translated'` whenever every url was 100% on Smartling's side — but Smartling reports 100% indefinitely once done, so this reverted a lang's `'complete'` (set by `saveLangItemsToDa` after it actually saved to DA) back to `'translated'` on every poll, which made `checkAndSaveLangs` treat it as newly-finished and re-download/re-save it every time.

Fixed by treating `'complete'` as terminal — mirrors a guard GLaaS's `determineStatus` already has ("Respect existing final statuses"). Trados has the identical bug in its own `getStatusAll`; deferred, not fixed in this PR.

### 7. Implement cancelTranslation
Smartling had no `cancelTranslation` at all — it only existed as an empty stub on the `sample` connector. Since `translate.js`'s `canCancel` getter checks `!!connector.cancelTranslation`, the Cancel buttons never rendered for Smartling projects at all.

Confirmed the correct endpoint against Smartling's official OpenAPI spec (`github.com/Smartling/api-docs`) before implementing, rather than guessing: `DELETE /jobs-api/v3/projects/{projectId}/jobs/{translationJobUid}/locales/{targetLocaleId}` (`removeLocaleFromJob`) — **not** the job-level `cancelJob` endpoint. `cancelJob`'s request body has no locale scoping at all and cancels every locale in the job; since `sendAllLanguages` bundles every target language into one shared job, using `cancelJob` for a single-language cancel would have also killed every other in-progress language sharing that job. `removeLocaleFromJob` is scoped to exactly one locale.

- On a `202` (async removal), polls `GET .../processes/{processUid}` (`getJobAsyncProcessStatus`) every 2s (~60s cap) until `processState` is `COMPLETED` or `FAILED`, rather than optimistically reporting success.
- On success, sets `lang.translation.status = 'cancelled'` locally (Smartling's file/status endpoint has no "cancelled" concept, so nothing meaningful to poll for status-wise afterward).
- On failure (request-level or an async process reporting `FAILED`/timing out), reuses the `extractErrorMessage` envelope parser from #5.
- Extended #6's `'complete'`-is-terminal guard in `getStatusAll` to also cover `'cancelled'`, since the next status poll would otherwise undo a fresh cancel the same way it was re-triggering saves for completed languages.

### 8. Loading spinners on action buttons
Every async action button in the Translate view (Connect, Get status, Translate all, Cancel project, Copy all, per-language Cancel) now disables and shows a spinner while its handler is in flight — previously only `handleSendAll` had a busy flag, and it wasn't even wired to any visual feedback. Reused/combined the two spinner patterns already in the repo instead of adding a third: the `.nx-loading-spinner`/`da-spin` naming from `nx2/styles/buttons.css` (defined there but never actually wired to anything) with the `currentcolor` border technique from the one spinner that's actually shipping (`nx2/blocks/ew-actions/ew-actions.js`) — needed since these buttons render with different text colors per variant (white on `.accent`, gray on `.primary.outline`). Per-language Cancel uses a `_cancelingLangs` Set so one row can be busy independently of the others.

### 9. Switch getStatusAll to getJobProgress
Replaced the file-scoped `getFileTranslationStatusAllLocales` approach from #3 (one API call per file, plus our own floor/excluded-string formula) with Smartling's job-scoped `getJobProgress` (`GET jobs-api/v3/projects/{projectId}/jobs/{translationJobUid}/progress`): **one API call for the whole job**, consuming Smartling's own precomputed `percentComplete` per locale directly instead of reimplementing their formula ourselves. Explored specifically for the reduced call volume on larger batches — a 20-file job goes from 20 status calls to 1.

Trade-offs, both intentional:
- Now requires `service.jobUid.value` (already tracked for the job's whole lifecycle) — guarded, no-ops if missing.
- `translation.translated` is no longer a per-file count, since this endpoint reports one job-wide percentage per locale, not a per-file breakdown. It's now `0` or `urls.length` — the "N of M files translated" UI column only ever shows `0` or the full count until 100%, never a partial number.

Also added a genuine efficiency win beyond parity: skips the API call entirely once every lang is already `'complete'`/`'cancelled'`, rather than fetching and discarding the result.

Rewrote all 6 affected tests for the new endpoint/response shape, plus 2 new ones (no-`jobUid` skip, `'cancelled'`-guard — the latter was a gap even in the previous suite; only the `'complete'` case had a dedicated test).

### 10. Hide Cancel buttons once nothing's left to cancel
`renderCancelLang`'s guard only excluded `'cancelled'` status, never `'complete'`, so a completed language's per-row Cancel button stayed visible as long as some other language in the project was still in progress. Separately, `incompleteLangs` counted a language as cancellable even with no `translation` object at all (never sent), so "Cancel project" could show with nothing actually cancellable.

Extracted a single `canCancelLang(lang)` predicate (has `translation`, not `'cancelled'`, not `'complete'`) used consistently by `renderCancelLang`, `incompleteLangs`, and the `with-cancel` grid-column class, so they can't drift out of sync with each other again.

### 11. Hide Get status once nothing's incomplete
Once every sent language is `'complete'`/`'cancelled'`, "Get status" was already a functional no-op (`getStatusAll` skips its own API call when there's nothing non-terminal left, per #9) but still showed, spun, and triggered a redundant DA save on click. Gated the button on `this.incompleteLangs` — the same predicate `#10` already uses to drive Cancel-button visibility — so it hides once there's nothing left to check.

## Tests
- New `test/loc/utils/fetchWithRetry.test.js`: retry-then-succeed on 429/503, gives up after `maxRetries`, ignores non-retryable statuses, custom predicate.
- New regression tests confirming `getStatusAll`/`saveItems` retry a 429 and succeed.
- Three new tests for auto-authorization: default off, enabled via `'yes'`, explicitly `'no'`.
- Tests for status reporting: real percentage when incomplete, floor-not-round (the 99.9999%→99% case), fully-excluded-is-100% case.
- Session-expiry recovery (#4) is covered by the existing 13 connector tests passing unchanged; no new tests were added for the reauth-fallback path specifically (mocking a session-expiry-then-401 sequence needs new fixtures) — flagged as follow-up, not blocking.
- Three new tests for error-surfacing (#5), using the real `VALIDATION_ERROR`/`Invalid locales [fr-FR]` response shape hit live: job-creation failure, batch-creation failure, per-file upload failure. The `translate.js` message-clobbering half of #5 has no automated coverage — `translate.js` has no existing test harness to extend — verified manually instead.
- New test for #6: a lang already at `'complete'` stays `'complete'` after another status poll, even though Smartling still reports 100%.
- Five new tests for #7: skip when nothing to cancel, sync 200 success, async 202→`COMPLETED`, async 202→`FAILED`, request-level failure. All resolve on the first poll so none incur real wait time.
- #8 (spinners) has no automated coverage — pure UI feedback, no existing test harness for `translate.js` to extend — verified manually.
- Six tests rewritten and two new tests added for #9 (getJobProgress switch): origin-rewriting + jobUid-required, no-op with no jobUid, real-percentage passthrough, floor-passthrough (renamed — Smartling does the flooring now, we just verify we don't re-round), marks translated with full file count at 100%, doesn't revert `'complete'`, doesn't revert `'cancelled'` (new), retries a 429.
- #10 has no automated coverage — same `translate.js` test-harness gap as #8 — verified by code review of every call site of the new shared predicate.
- #11 has no automated coverage for the same reason — verified by code review.
- Full `npm test` (1223 tests) and lint pass.

## Verification
Full end-to-end through the real DA Translate app UI against a real test site (`scdemos/smartling-demo`) and a real Smartling project (project-scoped API token), including a 3-page, 2-language (French + German) batch:
- Confirmed real machine-translated content landed at `/fr/...` and `/de/...` paths.
- Confirmed via the Smartling API directly that auto-authorization worked: `firstAuthorizedDate` populated 16 seconds after job creation, with zero manual intervention.
- Verified the final status-reporting logic directly against the real API: computed percentages for a real file's 10 locales matched expectations exactly (2 completed target locales at 100%, 8 non-target locales at 0%).
- Caught and fixed a real bug before shipping (totalStringCount assumed per-locale, actually file-level) by checking the implementation against a live API response rather than only the schema/docs.

Ready for review.







