### PR TITLE
fix(quick-edit): pass document to loadPage, so a site that declares the argument decorates

### DIFF
--- a/nx/public/plugins/quick-edit/quick-edit.js
+++ b/nx/public/plugins/quick-edit/quick-edit.js
@@ -26,7 +26,7 @@ let parentControllerPort = null;
 async function setBody(body, ctx) {
   const doc = new DOMParser().parseFromString(body, 'text/html');
   document.body.innerHTML = doc.body.innerHTML;
-  await ctx.loadPage();
+  await ctx.loadPage(document);
   restoreBlockIndices(doc, document);
   setupNodeSelection(ctx);
   setSelectedNode(getSelectedNode());

--- a/nx2/public/plugins/quick-edit/quick-edit.js
+++ b/nx2/public/plugins/quick-edit/quick-edit.js
@@ -13,7 +13,7 @@ const QUICK_EDIT_ID = 'quick-edit-iframe';
 async function setBody(body, ctx) {
   const doc = new DOMParser().parseFromString(body, 'text/html');
   document.body.innerHTML = doc.body.innerHTML;
-  await ctx.loadPage();
+  await ctx.loadPage(document);
   setupContentEditableListeners(ctx);
   setupImageDropListeners(ctx, document.body.querySelector('main'));
   setupActions(ctx);


### PR DESCRIPTION
`setBody` called the site's `loadPage` with no argument, so a site that declares one got `undefined` and threw instead of re-decorating.
