### PR TITLE
fix: add support for HLX6 for daConfig.js using api.js config route

### DIFF
--- a/nx2/test/mocks/fetch.js
+++ b/nx2/test/mocks/fetch.js
@@ -1,0 +1,61 @@
+import { HLX_ADMIN } from '../../utils/utils.js';
+
+// Shared `window.fetch` mock for tests that exercise `nx2/utils/api.js`,
+// directly or transitively (daConfig.js, ewFlags.js, org-check.js, ...).
+//
+// `api.js`'s `isHlx6` probes `${HLX_ADMIN}/ping/{org}/{site}` before most
+// requests; every caller of this mock needs that request handled the same
+// way, so it is built in here rather than repeated per test file.
+//
+// Usage:
+//   let fetchCtl;
+//   afterEach(() => fetchCtl?.restore());
+//   ...
+//   fetchCtl = installFetch({
+//     pingHlx6: true,             // make isHlx6() resolve true
+//     routes: [
+//       { match: '/org/site/', body: JSON.stringify({ foo: 'bar' }) },
+//       { match: (url) => url.endsWith('/x'), status: 404 },
+//     ],
+//     fallback: { body: '{}' },   // used when no route matches (default: 200 '{}')
+//   });
+//   ... assertions against fetchCtl.calls / fetchCtl.lastCall() ...
+//   fetchCtl.restore();
+//
+// `match` may be a substring (checked via `url.includes(match)`) or a
+// predicate `(url) => boolean`. Routes are checked in order; first match wins.
+export function installFetch({
+  pingHlx6 = false,
+  routes = [],
+  fallback = { body: '{}', status: 200, headers: {} },
+} = {}) {
+  const calls = [];
+  const origFetch = window.fetch;
+
+  window.fetch = async (url, opts = {}) => {
+    const u = url.toString();
+    calls.push({
+      url: u,
+      method: opts.method || 'GET',
+      headers: opts.headers || {},
+      body: opts.body,
+    });
+
+    if (u.includes(`${HLX_ADMIN}/ping/`)) {
+      const headers = pingHlx6 ? { 'x-api-upgrade-available': 'true' } : {};
+      return new Response('', { status: 200, headers });
+    }
+
+    const route = routes.find(({ match }) => (
+      typeof match === 'function' ? match(u) : u.includes(match)
+    ));
+    const { body = '{}', status = 200, headers = {} } = route ?? fallback;
+    return new Response(body, { status, headers });
+  };
+
+  return {
+    calls,
+    lastCall: () => calls[calls.length - 1],
+    restore: () => { window.fetch = origFetch; },
+  };
+}

--- a/nx2/test/mocks/fetch.js
+++ b/nx2/test/mocks/fetch.js
@@ -2,60 +2,46 @@ import { HLX_ADMIN } from '../../utils/utils.js';
 
 // Shared `window.fetch` mock for tests that exercise `nx2/utils/api.js`,
 // directly or transitively (daConfig.js, ewFlags.js, org-check.js, ...).
+// Extracted from test/nx2/utils/api.test.js so other test files reuse the
+// same helper instead of hand-rolling their own.
 //
-// `api.js`'s `isHlx6` probes `${HLX_ADMIN}/ping/{org}/{site}` before most
-// requests; every caller of this mock needs that request handled the same
-// way, so it is built in here rather than repeated per test file.
+// `installFetch` covers the common case: one response (status/body/headers)
+// for every non-ping request. `isHlx6`'s `HLX_ADMIN/ping/...` probe is
+// handled automatically (`pingHlx6` controls whether it looks upgraded).
 //
-// Usage:
-//   let fetchCtl;
-//   afterEach(() => fetchCtl?.restore());
-//   ...
-//   fetchCtl = installFetch({
-//     pingHlx6: true,             // make isHlx6() resolve true
-//     routes: [
-//       { match: '/org/site/', body: JSON.stringify({ foo: 'bar' }) },
-//       { match: (url) => url.endsWith('/x'), status: 404 },
-//     ],
-//     fallback: { body: '{}' },   // used when no route matches (default: 200 '{}')
-//   });
-//   ... assertions against fetchCtl.calls / fetchCtl.lastCall() ...
-//   fetchCtl.restore();
-//
-// `match` may be a substring (checked via `url.includes(match)`) or a
-// predicate `(url) => boolean`. Routes are checked in order; first match wins.
-export function installFetch({
-  pingHlx6 = false,
-  routes = [],
-  fallback = { body: '{}', status: 200, headers: {} },
-} = {}) {
-  const calls = [];
-  const origFetch = window.fetch;
+// For tests that need different responses per URL (e.g. org vs site config,
+// or DA-legacy vs hlx6 source-bus endpoints), assign `window.fetch` directly
+// after calling `restoreFetch()`, pushing entries into the exported `calls`
+// array yourself — see api.test.js's `source.list org-level ...` tests for
+// the pattern.
+export const calls = [];
+let origFetch;
 
+export function installFetch({
+  pingHlx6 = false, headers = {}, status: httpStatus = 200, body = '{}',
+} = {}) {
+  calls.length = 0;
+  origFetch = window.fetch;
   window.fetch = async (url, opts = {}) => {
     const u = url.toString();
-    calls.push({
-      url: u,
-      method: opts.method || 'GET',
-      headers: opts.headers || {},
-      body: opts.body,
-    });
-
+    calls.push({ url: u, method: opts.method || 'GET', headers: opts.headers || {}, body: opts.body });
     if (u.includes(`${HLX_ADMIN}/ping/`)) {
-      const headers = pingHlx6 ? { 'x-api-upgrade-available': 'true' } : {};
-      return new Response('', { status: 200, headers });
+      const respHeaders = pingHlx6 ? { 'x-api-upgrade-available': 'true' } : {};
+      return new Response('', { status: 200, headers: respHeaders });
     }
-
-    const route = routes.find(({ match }) => (
-      typeof match === 'function' ? match(u) : u.includes(match)
-    ));
-    const { body = '{}', status = 200, headers = {} } = route ?? fallback;
-    return new Response(body, { status, headers });
+    return new Response(body, { status: httpStatus, headers });
   };
+}
 
-  return {
-    calls,
-    lastCall: () => calls[calls.length - 1],
-    restore: () => { window.fetch = origFetch; },
-  };
+export function restoreFetch() {
+  if (origFetch) window.fetch = origFetch;
+  origFetch = null;
+}
+
+export function lastCall() {
+  return calls[calls.length - 1];
+}
+
+export function callsTo(origin) {
+  return calls.filter((c) => c.url.startsWith(origin));
 }

--- a/nx2/utils/daConfig.js
+++ b/nx2/utils/daConfig.js
@@ -3,7 +3,7 @@ import { config } from './api.js';
 /** Returns the primary data array from a DA config JSON response (handles multi-sheet). */
 export function getFirstSheet(json) {
   if (json[':type'] !== 'multi-sheet') return json.data;
-  return json[Object.keys(json)[0]]?.data;
+  return json[json[':names']?.[0]]?.data;
 }
 
 /** Memoized fetches for `/{org}` and optional `/{org}/{site}` config documents. */

--- a/nx2/utils/daConfig.js
+++ b/nx2/utils/daConfig.js
@@ -1,5 +1,4 @@
-import { DA_ADMIN } from './utils.js';
-import { daFetch } from './api.js';
+import { config } from './api.js';
 
 /** Returns the primary data array from a DA config JSON response (handles multi-sheet). */
 export function getFirstSheet(json) {
@@ -11,14 +10,14 @@ export function getFirstSheet(json) {
 export const fetchDaConfigs = (() => {
   const cache = {};
 
-  const fetchConfig = async (pathname) => {
-    const resp = await daFetch({ url: `${DA_ADMIN}/config${pathname}/` });
-    if (!resp.ok) return { error: `Error loading ${pathname}`, status: resp.status };
+  const fetchConfig = async (key, org, site) => {
+    const resp = await config.get({ org, site });
+    if (!resp.ok) return { error: `Error loading ${key}`, status: resp.status };
     return resp.json();
   };
 
-  const cacheConfig = (key) => {
-    cache[key] = fetchConfig(key).then((result) => {
+  const cacheConfig = (key, org, site) => {
+    cache[key] = fetchConfig(key, org, site).then((result) => {
       if (result.error) delete cache[key];
       return result;
     });
@@ -29,8 +28,8 @@ export const fetchDaConfigs = (() => {
     const orgKey = `/${org}`;
     const siteKey = site ? `/${org}/${site}` : null;
 
-    const configs = [cache[orgKey] ?? cacheConfig(orgKey)];
-    if (siteKey) configs.push(cache[siteKey] ?? cacheConfig(siteKey));
+    const configs = [cache[orgKey] ?? cacheConfig(orgKey, org, undefined)];
+    if (siteKey) configs.push(cache[siteKey] ?? cacheConfig(siteKey, org, site));
     return configs;
   };
 })();

--- a/nx2/utils/org-check.js
+++ b/nx2/utils/org-check.js
@@ -1,5 +1,4 @@
-import { DA_ADMIN } from './utils.js';
-import { daFetch } from './api.js';
+import { config, source } from './api.js';
 import { showToast, VARIANT_WARNING } from '../blocks/shared/toast/toast.js';
 
 const DEF_SANDBOX = 'aem-sandbox';
@@ -21,7 +20,7 @@ async function getSandboxContent() {
 }
 
 async function getIsSandbox(org) {
-  const confResp = await daFetch({ url: `${DA_ADMIN}/config/${org}/` });
+  const confResp = await config.get({ org });
   const { status } = confResp;
 
   if (status === 403 || status === 401) return false;
@@ -31,9 +30,8 @@ async function getIsSandbox(org) {
     if (json.permissions) return false;
   }
 
-  const listResp = await daFetch({ url: `${DA_ADMIN}/list/${org}` });
-  const listJson = await listResp.json();
-  return listJson.length > 0;
+  const { items } = await source.list({ org });
+  return items.length > 0;
 }
 
 async function orgCheck() {

--- a/test/nx2/utils/api.test.js
+++ b/test/nx2/utils/api.test.js
@@ -1,5 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { HLX_ADMIN, AEM_API, DA_ADMIN } from '../../../nx2/utils/utils.js';
+import {
+  calls, installFetch, restoreFetch, lastCall, callsTo,
+} from '../../../nx2/test/mocks/fetch.js';
 
 import {
   daFetch,
@@ -42,31 +45,6 @@ const makeOrgSite = ({ hlx6 = false } = {}) => {
   }
   return { org: o, site: s };
 };
-
-let calls;
-let origFetch;
-
-const installFetch = ({ pingHlx6 = false, headers = {}, status: httpStatus = 200, body = '{}' } = {}) => {
-  calls = [];
-  origFetch = window.fetch;
-  window.fetch = async (url, opts = {}) => {
-    const u = url.toString();
-    calls.push({ url: u, method: opts.method || 'GET', headers: opts.headers || {}, body: opts.body });
-    if (u.includes(`${HLX_ADMIN}/ping/`)) {
-      const respHeaders = pingHlx6 ? { 'x-api-upgrade-available': 'true' } : {};
-      return new Response('', { status: 200, headers: respHeaders });
-    }
-    return new Response(body, { status: httpStatus, headers });
-  };
-};
-
-const restoreFetch = () => {
-  if (origFetch) window.fetch = origFetch;
-  origFetch = null;
-};
-
-const lastCall = () => calls[calls.length - 1];
-const callsTo = (origin) => calls.filter((c) => c.url.startsWith(origin));
 
 describe('api.js', () => {
   beforeEach(() => {
@@ -194,7 +172,7 @@ describe('api.js', () => {
 
     it('source.list org-level merges DA-legacy and hlx6 sites, deduping by name', async () => {
       restoreFetch();
-      calls = [];
+      calls.length = 0;
       window.fetch = async (url, opts = {}) => {
         const u = url.toString();
         calls.push({ url: u, method: opts.method || 'GET', headers: opts.headers || {} });
@@ -223,7 +201,7 @@ describe('api.js', () => {
 
     it('source.list org-level returns hlx6 sites even when DA-legacy 404s', async () => {
       restoreFetch();
-      calls = [];
+      calls.length = 0;
       window.fetch = async (url, opts = {}) => {
         const u = url.toString();
         calls.push({ url: u, method: opts.method || 'GET' });
@@ -244,7 +222,7 @@ describe('api.js', () => {
 
     it('source.list org-level returns DA-legacy sites even when hlx6 source-bus 404s', async () => {
       restoreFetch();
-      calls = [];
+      calls.length = 0;
       window.fetch = async (url, opts = {}) => {
         const u = url.toString();
         calls.push({ url: u, method: opts.method || 'GET' });
@@ -271,7 +249,7 @@ describe('api.js', () => {
 
     it('source.list org-level only fetches hlx6 sites on the first page (no continuationToken)', async () => {
       restoreFetch();
-      calls = [];
+      calls.length = 0;
       window.fetch = async (url, opts = {}) => {
         const u = url.toString();
         calls.push({ url: u, method: opts.method || 'GET', headers: opts.headers || {} });

--- a/test/nx2/utils/daConfig.test.js
+++ b/test/nx2/utils/daConfig.test.js
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
-import { AEM_API, DA_ADMIN } from '../../../nx2/utils/utils.js';
-import { installFetch } from '../../../nx2/test/mocks/fetch.js';
+import { AEM_API, DA_ADMIN, HLX_ADMIN } from '../../../nx2/utils/utils.js';
+import {
+  calls, installFetch, restoreFetch, lastCall,
+} from '../../../nx2/test/mocks/fetch.js';
 import { getFirstSheet, fetchDaConfigs } from '../../../nx2/utils/daConfig.js';
 
 // fetchDaConfigs memoizes per `/{org}` and `/{org}/{site}` key for the
@@ -30,30 +32,32 @@ describe('getFirstSheet', () => {
 });
 
 describe('fetchDaConfigs', () => {
-  let fetchCtl;
-  afterEach(() => fetchCtl?.restore());
+  afterEach(() => restoreFetch());
 
   it('legacy: fetches org-only config from DA_ADMIN when no site is given', async () => {
     const org = uniq('org');
-    fetchCtl = installFetch({
-      fallback: { body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
-    });
+    installFetch({ body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) });
 
     const [orgConfig] = await Promise.all(fetchDaConfigs({ org }));
 
-    expect(fetchCtl.lastCall().url).to.equal(`${DA_ADMIN}/config/${org}/`);
+    expect(lastCall().url).to.equal(`${DA_ADMIN}/config/${org}/`);
     expect(orgConfig.flags.data).to.deep.equal([{ key: 'ew.enabled', value: 'true' }]);
   });
 
   it('legacy: fetches both org and site config, site resolves as the last entry', async () => {
     const org = uniq('org');
     const site = uniq('site');
-    fetchCtl = installFetch({
-      routes: [
-        { match: `/${org}/${site}/`, body: JSON.stringify({ flags: { data: [{ key: 'site' }] } }) },
-        { match: `/${org}/`, body: JSON.stringify({ flags: { data: [{ key: 'org' }] } }) },
-      ],
-    });
+    restoreFetch();
+    calls.length = 0;
+    window.fetch = async (url) => {
+      const u = url.toString();
+      calls.push({ url: u, method: 'GET' });
+      if (u.includes(`${HLX_ADMIN}/ping/`)) return new Response('', { status: 200 });
+      if (u.includes(`/${org}/${site}/`)) {
+        return new Response(JSON.stringify({ flags: { data: [{ key: 'site' }] } }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ flags: { data: [{ key: 'org' }] } }), { status: 200 });
+    };
 
     const configs = fetchDaConfigs({ org, site });
     expect(configs).to.have.length(2);
@@ -66,27 +70,25 @@ describe('fetchDaConfigs', () => {
   it('memoizes: a second call with the same org/site does not re-fetch', async () => {
     const org = uniq('org');
     const site = uniq('site');
-    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
+    installFetch({ body: JSON.stringify({ flags: { data: [] } }) });
 
     await Promise.all(fetchDaConfigs({ org, site }));
-    const callsAfterFirst = fetchCtl.calls.length;
+    const callsAfterFirst = calls.length;
     await Promise.all(fetchDaConfigs({ org, site }));
 
-    expect(fetchCtl.calls.length).to.equal(callsAfterFirst);
+    expect(calls.length).to.equal(callsAfterFirst);
   });
 
   it('on a non-ok response, returns { error, status } and evicts the cache entry so a later call retries', async () => {
     const org = uniq('org');
-    fetchCtl = installFetch({ fallback: { status: 404, body: '' } });
+    installFetch({ status: 404, body: '' });
 
     const [failed] = await Promise.all(fetchDaConfigs({ org }));
     expect(failed.error).to.be.a('string');
     expect(failed.status).to.equal(404);
 
-    fetchCtl.restore();
-    fetchCtl = installFetch({
-      fallback: { body: JSON.stringify({ flags: { data: [{ key: 'retried' }] } }) },
-    });
+    restoreFetch();
+    installFetch({ body: JSON.stringify({ flags: { data: [{ key: 'retried' }] } }) });
     const [retried] = await Promise.all(fetchDaConfigs({ org }));
     expect(retried.flags.data).to.deep.equal([{ key: 'retried' }]);
   });
@@ -94,14 +96,11 @@ describe('fetchDaConfigs', () => {
   it('hlx6: site config is fetched from AEM_API and normalized back into sheet format', async () => {
     const org = uniq('org');
     const site = uniq('site');
-    fetchCtl = installFetch({
-      pingHlx6: true,
-      fallback: { body: JSON.stringify({ flags: [{ key: 'ew.enabled', value: 'true' }] }) },
-    });
+    installFetch({ pingHlx6: true, body: JSON.stringify({ flags: [{ key: 'ew.enabled', value: 'true' }] }) });
 
     const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
 
-    expect(fetchCtl.calls.some((c) => c.url === `${AEM_API}/${org}/sites/${site}/config/editor/da.json`)).to.equal(true);
+    expect(calls.some((c) => c.url === `${AEM_API}/${org}/sites/${site}/config/editor/da.json`)).to.equal(true);
     expect(siteConfig[':type']).to.equal('sheet');
     expect(siteConfig[':sheetname']).to.equal('flags');
     expect(siteConfig.data).to.deep.equal([{ key: 'ew.enabled', value: 'true' }]);

--- a/test/nx2/utils/daConfig.test.js
+++ b/test/nx2/utils/daConfig.test.js
@@ -1,0 +1,109 @@
+import { expect } from '@esm-bundle/chai';
+import { AEM_API, DA_ADMIN } from '../../../nx2/utils/utils.js';
+import { installFetch } from '../../../nx2/test/mocks/fetch.js';
+import { getFirstSheet, fetchDaConfigs } from '../../../nx2/utils/daConfig.js';
+
+// fetchDaConfigs memoizes per `/{org}` and `/{org}/{site}` key for the
+// lifetime of the module, so every test uses a fresh org/site pair to avoid
+// bleeding cache state across assertions.
+let counter = 0;
+const uniq = (label) => {
+  counter += 1;
+  return `${label}-${counter}`;
+};
+
+describe('getFirstSheet', () => {
+  it('returns .data for a single-sheet doc', () => {
+    const json = { ':type': 'sheet', ':sheetname': 'flags', data: [{ key: 'a' }] };
+    expect(getFirstSheet(json)).to.deep.equal([{ key: 'a' }]);
+  });
+
+  it('returns the first sheet\'s data for a multi-sheet doc', () => {
+    const json = {
+      ':type': 'multi-sheet',
+      ':names': ['flags', 'prompts'],
+      flags: { data: [{ key: 'a' }] },
+      prompts: { data: [{ title: 'hi' }] },
+    };
+    expect(getFirstSheet(json)).to.deep.equal([{ key: 'a' }]);
+  });
+});
+
+describe('fetchDaConfigs', () => {
+  let fetchCtl;
+  afterEach(() => fetchCtl?.restore());
+
+  it('legacy: fetches org-only config from DA_ADMIN when no site is given', async () => {
+    const org = uniq('org');
+    fetchCtl = installFetch({
+      fallback: { body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
+    });
+
+    const [orgConfig] = await Promise.all(fetchDaConfigs({ org }));
+
+    expect(fetchCtl.lastCall().url).to.equal(`${DA_ADMIN}/config/${org}/`);
+    expect(orgConfig.flags.data).to.deep.equal([{ key: 'ew.enabled', value: 'true' }]);
+  });
+
+  it('legacy: fetches both org and site config, site resolves as the last entry', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    fetchCtl = installFetch({
+      routes: [
+        { match: `/${org}/${site}/`, body: JSON.stringify({ flags: { data: [{ key: 'site' }] } }) },
+        { match: `/${org}/`, body: JSON.stringify({ flags: { data: [{ key: 'org' }] } }) },
+      ],
+    });
+
+    const configs = fetchDaConfigs({ org, site });
+    expect(configs).to.have.length(2);
+    const [orgConfig, siteConfig] = await Promise.all(configs);
+
+    expect(orgConfig.flags.data).to.deep.equal([{ key: 'org' }]);
+    expect(siteConfig.flags.data).to.deep.equal([{ key: 'site' }]);
+  });
+
+  it('memoizes: a second call with the same org/site does not re-fetch', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
+
+    await Promise.all(fetchDaConfigs({ org, site }));
+    const callsAfterFirst = fetchCtl.calls.length;
+    await Promise.all(fetchDaConfigs({ org, site }));
+
+    expect(fetchCtl.calls.length).to.equal(callsAfterFirst);
+  });
+
+  it('on a non-ok response, returns { error, status } and evicts the cache entry so a later call retries', async () => {
+    const org = uniq('org');
+    fetchCtl = installFetch({ fallback: { status: 404, body: '' } });
+
+    const [failed] = await Promise.all(fetchDaConfigs({ org }));
+    expect(failed.error).to.be.a('string');
+    expect(failed.status).to.equal(404);
+
+    fetchCtl.restore();
+    fetchCtl = installFetch({
+      fallback: { body: JSON.stringify({ flags: { data: [{ key: 'retried' }] } }) },
+    });
+    const [retried] = await Promise.all(fetchDaConfigs({ org }));
+    expect(retried.flags.data).to.deep.equal([{ key: 'retried' }]);
+  });
+
+  it('hlx6: site config is fetched from AEM_API and normalized back into sheet format', async () => {
+    const org = uniq('org');
+    const site = uniq('site');
+    fetchCtl = installFetch({
+      pingHlx6: true,
+      fallback: { body: JSON.stringify({ flags: [{ key: 'ew.enabled', value: 'true' }] }) },
+    });
+
+    const [, siteConfig] = await Promise.all(fetchDaConfigs({ org, site }));
+
+    expect(fetchCtl.calls.some((c) => c.url === `${AEM_API}/${org}/sites/${site}/config/editor/da.json`)).to.equal(true);
+    expect(siteConfig[':type']).to.equal('sheet');
+    expect(siteConfig[':sheetname']).to.equal('flags');
+    expect(siteConfig.data).to.deep.equal([{ key: 'ew.enabled', value: 'true' }]);
+  });
+});

--- a/test/nx2/utils/ewFlags.test.js
+++ b/test/nx2/utils/ewFlags.test.js
@@ -1,119 +1,125 @@
 import { expect } from '@esm-bundle/chai';
-import { HLX_ADMIN } from '../../../nx2/utils/utils.js';
+import { installFetch } from '../../../nx2/test/mocks/fetch.js';
 import {
   getEWFlags, isEWEnabled, isEwChatDisabled, isCoworkerEnabled,
 } from '../../../nx2/utils/ewFlags.js';
 
-// `config.get` (used internally by ewFlags -> daConfig -> api.js) probes
-// `isHlx6` with a ping request before hitting the config endpoint. Responses
-// must be real `Response` objects so `resp.headers.get(...)` works.
-const installFetch = (siteFlagsByPath) => {
-  window.fetch = async (url) => {
-    const u = url.toString();
-    if (u.includes(`${HLX_ADMIN}/ping/`)) return new Response('', { status: 200 });
-    const match = Object.keys(siteFlagsByPath).find((path) => u.includes(path));
-    const body = match ? siteFlagsByPath[match] : { flags: { data: [] } };
-    return new Response(JSON.stringify(body), { status: 200 });
-  };
-};
-
+// getEWFlags -> daConfig.fetchDaConfigs -> api.js's config.get(), which
+// probes isHlx6 (HLX_ADMIN/ping/...) before hitting the (legacy) config
+// endpoint. installFetch handles that ping automatically.
 describe('getEWFlags', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
+  let fetchCtl;
+  afterEach(() => fetchCtl?.restore());
 
   it('returns all ew.* flags merged from org and site configs', async () => {
-    installFetch({
-      '/flag-site1/': { flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } },
-      '/flag-org1/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/flag-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } }) },
+        { match: '/flag-org1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
+      ],
     });
     const flags = await getEWFlags({ org: 'flag-org1', site: 'flag-site1' });
     expect(flags).to.deep.equal({ 'ew.enabled': 'true', 'ew.canvasDefaultView': 'split' });
   });
 
   it('site level flag overrides org level flag', async () => {
-    installFetch({
-      '/flag-site2/': { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } },
-      '/flag-org2/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/flag-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }) },
+        { match: '/flag-org2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
+      ],
     });
     const flags = await getEWFlags({ org: 'flag-org2', site: 'flag-site2' });
     expect(flags['ew.enabled']).to.equal('false');
   });
 
   it('returns empty object when no ew.* flags are present', async () => {
-    installFetch({});
+    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
     expect(await getEWFlags({ org: 'flag-org3', site: 'flag-site3' })).to.deep.equal({});
   });
 
   it('ignores non-ew.* flags', async () => {
-    installFetch({
-      '/flag-org4/': { flags: { data: [{ key: 'other.flag', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/flag-org4/', body: JSON.stringify({ flags: { data: [{ key: 'other.flag', value: 'true' }] } }) },
+      ],
+      fallback: { body: JSON.stringify({ flags: { data: [] } }) },
     });
     expect(await getEWFlags({ org: 'flag-org4', site: 'flag-site4' })).to.deep.equal({});
   });
 });
 
 describe('isEWEnabled', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
+  let fetchCtl;
+  afterEach(() => fetchCtl?.restore());
 
   it('returns true when ew.enabled flag value is "true"', async () => {
-    installFetch({
-      '/ew-site1/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/ew-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
+      ],
+      fallback: { body: JSON.stringify({}) },
     });
     expect(await isEWEnabled({ org: 'ew-org1', site: 'ew-site1' })).to.be.true;
   });
 
   it('returns false when ew.enabled flag value is "false"', async () => {
-    installFetch({
-      '/ew-site2/': { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/ew-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }) },
+      ],
+      fallback: { body: JSON.stringify({}) },
     });
     expect(await isEWEnabled({ org: 'ew-org2', site: 'ew-site2' })).to.be.false;
   });
 });
 
 describe('isEwChatDisabled', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
+  let fetchCtl;
+  afterEach(() => fetchCtl?.restore());
 
   it('returns true when ew.disableChat is set at org level but not site level', async () => {
-    installFetch({
-      '/dc-site1/': { flags: { data: [] } },
-      '/dc-org1/': { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/dc-site1/', body: JSON.stringify({ flags: { data: [] } }) },
+        { match: '/dc-org1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }) },
+      ],
     });
     expect(await isEwChatDisabled({ org: 'dc-org1', site: 'dc-site1' })).to.be.true;
   });
 
   it('returns true when ew.disableChat is set at site level but not org level', async () => {
-    installFetch({
-      '/dc-site2/': { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } },
-      '/dc-org2/': { flags: { data: [] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/dc-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }) },
+        { match: '/dc-org2/', body: JSON.stringify({ flags: { data: [] } }) },
+      ],
     });
     expect(await isEwChatDisabled({ org: 'dc-org2', site: 'dc-site2' })).to.be.true;
   });
 
   it('returns false when ew.disableChat flag is not set at any level', async () => {
-    installFetch({});
+    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
     expect(await isEwChatDisabled({ org: 'dc-org3', site: 'dc-site3' })).to.be.false;
   });
 });
 
 describe('isCoworkerEnabled', () => {
-  let savedFetch;
-  beforeEach(() => { savedFetch = window.fetch; });
-  afterEach(() => { window.fetch = savedFetch; });
+  let fetchCtl;
+  afterEach(() => fetchCtl?.restore());
 
   it('returns true when ew.coworker flag value is "true"', async () => {
-    installFetch({
-      '/cw-site1/': { flags: { data: [{ key: 'ew.coworker', value: 'true' }] } },
+    fetchCtl = installFetch({
+      routes: [
+        { match: '/cw-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.coworker', value: 'true' }] } }) },
+      ],
+      fallback: { body: JSON.stringify({}) },
     });
     expect(await isCoworkerEnabled({ org: 'cw-org1', site: 'cw-site1' })).to.be.true;
   });
 
   it('returns false when ew.coworker flag is not set at any level', async () => {
-    installFetch({});
+    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
     expect(await isCoworkerEnabled({ org: 'cw-org2', site: 'cw-site2' })).to.be.false;
   });
 });

--- a/test/nx2/utils/ewFlags.test.js
+++ b/test/nx2/utils/ewFlags.test.js
@@ -1,125 +1,119 @@
 import { expect } from '@esm-bundle/chai';
-import { installFetch } from '../../../nx2/test/mocks/fetch.js';
+import { HLX_ADMIN } from '../../../nx2/utils/utils.js';
+import {
+  calls, installFetch, restoreFetch,
+} from '../../../nx2/test/mocks/fetch.js';
 import {
   getEWFlags, isEWEnabled, isEwChatDisabled, isCoworkerEnabled,
 } from '../../../nx2/utils/ewFlags.js';
 
 // getEWFlags -> daConfig.fetchDaConfigs -> api.js's config.get(), which
 // probes isHlx6 (HLX_ADMIN/ping/...) before hitting the (legacy) config
-// endpoint. installFetch handles that ping automatically.
+// endpoint. `installFetch` (shared with api.test.js) handles that ping
+// automatically for the single-response cases below. Where org and site
+// need different bodies, window.fetch is assigned directly after
+// restoreFetch() — same pattern api.test.js uses for its multi-response
+// scenarios.
+const installFlagsByPath = (byPath) => {
+  restoreFetch();
+  calls.length = 0;
+  window.fetch = async (url) => {
+    const u = url.toString();
+    calls.push({ url: u, method: 'GET' });
+    if (u.includes(`${HLX_ADMIN}/ping/`)) return new Response('', { status: 200 });
+    const match = Object.keys(byPath).find((path) => u.includes(path));
+    const body = match ? byPath[match] : JSON.stringify({ flags: { data: [] } });
+    return new Response(body, { status: 200 });
+  };
+};
+
 describe('getEWFlags', () => {
-  let fetchCtl;
-  afterEach(() => fetchCtl?.restore());
+  afterEach(() => restoreFetch());
 
   it('returns all ew.* flags merged from org and site configs', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/flag-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } }) },
-        { match: '/flag-org1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
-      ],
+    installFlagsByPath({
+      '/flag-site1/': JSON.stringify({ flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } }),
+      '/flag-org1/': JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
     });
     const flags = await getEWFlags({ org: 'flag-org1', site: 'flag-site1' });
     expect(flags).to.deep.equal({ 'ew.enabled': 'true', 'ew.canvasDefaultView': 'split' });
   });
 
   it('site level flag overrides org level flag', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/flag-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }) },
-        { match: '/flag-org2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
-      ],
+    installFlagsByPath({
+      '/flag-site2/': JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }),
+      '/flag-org2/': JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
     });
     const flags = await getEWFlags({ org: 'flag-org2', site: 'flag-site2' });
     expect(flags['ew.enabled']).to.equal('false');
   });
 
   it('returns empty object when no ew.* flags are present', async () => {
-    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
+    installFetch({ body: JSON.stringify({ flags: { data: [] } }) });
     expect(await getEWFlags({ org: 'flag-org3', site: 'flag-site3' })).to.deep.equal({});
   });
 
   it('ignores non-ew.* flags', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/flag-org4/', body: JSON.stringify({ flags: { data: [{ key: 'other.flag', value: 'true' }] } }) },
-      ],
-      fallback: { body: JSON.stringify({ flags: { data: [] } }) },
-    });
+    installFetch({ body: JSON.stringify({ flags: { data: [{ key: 'other.flag', value: 'true' }] } }) });
     expect(await getEWFlags({ org: 'flag-org4', site: 'flag-site4' })).to.deep.equal({});
   });
 });
 
 describe('isEWEnabled', () => {
-  let fetchCtl;
-  afterEach(() => fetchCtl?.restore());
+  afterEach(() => restoreFetch());
 
   it('returns true when ew.enabled flag value is "true"', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/ew-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }) },
-      ],
-      fallback: { body: JSON.stringify({}) },
+    installFlagsByPath({
+      '/ew-site1/': JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
     });
     expect(await isEWEnabled({ org: 'ew-org1', site: 'ew-site1' })).to.be.true;
   });
 
   it('returns false when ew.enabled flag value is "false"', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/ew-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }) },
-      ],
-      fallback: { body: JSON.stringify({}) },
+    installFlagsByPath({
+      '/ew-site2/': JSON.stringify({ flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }),
     });
     expect(await isEWEnabled({ org: 'ew-org2', site: 'ew-site2' })).to.be.false;
   });
 });
 
 describe('isEwChatDisabled', () => {
-  let fetchCtl;
-  afterEach(() => fetchCtl?.restore());
+  afterEach(() => restoreFetch());
 
   it('returns true when ew.disableChat is set at org level but not site level', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/dc-site1/', body: JSON.stringify({ flags: { data: [] } }) },
-        { match: '/dc-org1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }) },
-      ],
+    installFlagsByPath({
+      '/dc-site1/': JSON.stringify({ flags: { data: [] } }),
+      '/dc-org1/': JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }),
     });
     expect(await isEwChatDisabled({ org: 'dc-org1', site: 'dc-site1' })).to.be.true;
   });
 
   it('returns true when ew.disableChat is set at site level but not org level', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/dc-site2/', body: JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }) },
-        { match: '/dc-org2/', body: JSON.stringify({ flags: { data: [] } }) },
-      ],
+    installFlagsByPath({
+      '/dc-site2/': JSON.stringify({ flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }),
+      '/dc-org2/': JSON.stringify({ flags: { data: [] } }),
     });
     expect(await isEwChatDisabled({ org: 'dc-org2', site: 'dc-site2' })).to.be.true;
   });
 
   it('returns false when ew.disableChat flag is not set at any level', async () => {
-    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
+    installFetch({ body: JSON.stringify({ flags: { data: [] } }) });
     expect(await isEwChatDisabled({ org: 'dc-org3', site: 'dc-site3' })).to.be.false;
   });
 });
 
 describe('isCoworkerEnabled', () => {
-  let fetchCtl;
-  afterEach(() => fetchCtl?.restore());
+  afterEach(() => restoreFetch());
 
   it('returns true when ew.coworker flag value is "true"', async () => {
-    fetchCtl = installFetch({
-      routes: [
-        { match: '/cw-site1/', body: JSON.stringify({ flags: { data: [{ key: 'ew.coworker', value: 'true' }] } }) },
-      ],
-      fallback: { body: JSON.stringify({}) },
+    installFlagsByPath({
+      '/cw-site1/': JSON.stringify({ flags: { data: [{ key: 'ew.coworker', value: 'true' }] } }),
     });
     expect(await isCoworkerEnabled({ org: 'cw-org1', site: 'cw-site1' })).to.be.true;
   });
 
   it('returns false when ew.coworker flag is not set at any level', async () => {
-    fetchCtl = installFetch({ fallback: { body: JSON.stringify({ flags: { data: [] } }) } });
+    installFetch({ body: JSON.stringify({ flags: { data: [] } }) });
     expect(await isCoworkerEnabled({ org: 'cw-org2', site: 'cw-site2' })).to.be.false;
   });
 });

--- a/test/nx2/utils/ewFlags.test.js
+++ b/test/nx2/utils/ewFlags.test.js
@@ -1,7 +1,21 @@
 import { expect } from '@esm-bundle/chai';
+import { HLX_ADMIN } from '../../../nx2/utils/utils.js';
 import {
   getEWFlags, isEWEnabled, isEwChatDisabled, isCoworkerEnabled,
 } from '../../../nx2/utils/ewFlags.js';
+
+// `config.get` (used internally by ewFlags -> daConfig -> api.js) probes
+// `isHlx6` with a ping request before hitting the config endpoint. Responses
+// must be real `Response` objects so `resp.headers.get(...)` works.
+const installFetch = (siteFlagsByPath) => {
+  window.fetch = async (url) => {
+    const u = url.toString();
+    if (u.includes(`${HLX_ADMIN}/ping/`)) return new Response('', { status: 200 });
+    const match = Object.keys(siteFlagsByPath).find((path) => u.includes(path));
+    const body = match ? siteFlagsByPath[match] : { flags: { data: [] } };
+    return new Response(JSON.stringify(body), { status: 200 });
+  };
+};
 
 describe('getEWFlags', () => {
   let savedFetch;
@@ -9,36 +23,31 @@ describe('getEWFlags', () => {
   afterEach(() => { window.fetch = savedFetch; });
 
   it('returns all ew.* flags merged from org and site configs', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/flag-site1/')
-        ? { flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } }
-        : { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
+    installFetch({
+      '/flag-site1/': { flags: { data: [{ key: 'ew.canvasDefaultView', value: 'split' }] } },
+      '/flag-org1/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
     });
     const flags = await getEWFlags({ org: 'flag-org1', site: 'flag-site1' });
     expect(flags).to.deep.equal({ 'ew.enabled': 'true', 'ew.canvasDefaultView': 'split' });
   });
 
   it('site level flag overrides org level flag', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/flag-site2/')
-        ? { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }
-        : { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }),
+    installFetch({
+      '/flag-site2/': { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } },
+      '/flag-org2/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
     });
     const flags = await getEWFlags({ org: 'flag-org2', site: 'flag-site2' });
     expect(flags['ew.enabled']).to.equal('false');
   });
 
   it('returns empty object when no ew.* flags are present', async () => {
-    window.fetch = async () => ({ ok: true, json: async () => ({ flags: { data: [] } }) });
+    installFetch({});
     expect(await getEWFlags({ org: 'flag-org3', site: 'flag-site3' })).to.deep.equal({});
   });
 
   it('ignores non-ew.* flags', async () => {
-    window.fetch = async () => ({
-      ok: true,
-      json: async () => ({ flags: { data: [{ key: 'other.flag', value: 'true' }] } }),
+    installFetch({
+      '/flag-org4/': { flags: { data: [{ key: 'other.flag', value: 'true' }] } },
     });
     expect(await getEWFlags({ org: 'flag-org4', site: 'flag-site4' })).to.deep.equal({});
   });
@@ -50,21 +59,15 @@ describe('isEWEnabled', () => {
   afterEach(() => { window.fetch = savedFetch; });
 
   it('returns true when ew.enabled flag value is "true"', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/ew-site1/')
-        ? { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } }
-        : {}),
+    installFetch({
+      '/ew-site1/': { flags: { data: [{ key: 'ew.enabled', value: 'true' }] } },
     });
     expect(await isEWEnabled({ org: 'ew-org1', site: 'ew-site1' })).to.be.true;
   });
 
   it('returns false when ew.enabled flag value is "false"', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/ew-site2/')
-        ? { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } }
-        : {}),
+    installFetch({
+      '/ew-site2/': { flags: { data: [{ key: 'ew.enabled', value: 'false' }] } },
     });
     expect(await isEWEnabled({ org: 'ew-org2', site: 'ew-site2' })).to.be.false;
   });
@@ -76,27 +79,23 @@ describe('isEwChatDisabled', () => {
   afterEach(() => { window.fetch = savedFetch; });
 
   it('returns true when ew.disableChat is set at org level but not site level', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/dc-site1/')
-        ? { flags: { data: [] } }
-        : { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }),
+    installFetch({
+      '/dc-site1/': { flags: { data: [] } },
+      '/dc-org1/': { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } },
     });
     expect(await isEwChatDisabled({ org: 'dc-org1', site: 'dc-site1' })).to.be.true;
   });
 
   it('returns true when ew.disableChat is set at site level but not org level', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/dc-site2/')
-        ? { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } }
-        : { flags: { data: [] } }),
+    installFetch({
+      '/dc-site2/': { flags: { data: [{ key: 'ew.disableChat', value: 'true' }] } },
+      '/dc-org2/': { flags: { data: [] } },
     });
     expect(await isEwChatDisabled({ org: 'dc-org2', site: 'dc-site2' })).to.be.true;
   });
 
   it('returns false when ew.disableChat flag is not set at any level', async () => {
-    window.fetch = async () => ({ ok: true, json: async () => ({ flags: { data: [] } }) });
+    installFetch({});
     expect(await isEwChatDisabled({ org: 'dc-org3', site: 'dc-site3' })).to.be.false;
   });
 });
@@ -107,17 +106,14 @@ describe('isCoworkerEnabled', () => {
   afterEach(() => { window.fetch = savedFetch; });
 
   it('returns true when ew.coworker flag value is "true"', async () => {
-    window.fetch = async (url) => ({
-      ok: true,
-      json: async () => (url.includes('/cw-site1/')
-        ? { flags: { data: [{ key: 'ew.coworker', value: 'true' }] } }
-        : {}),
+    installFetch({
+      '/cw-site1/': { flags: { data: [{ key: 'ew.coworker', value: 'true' }] } },
     });
     expect(await isCoworkerEnabled({ org: 'cw-org1', site: 'cw-site1' })).to.be.true;
   });
 
   it('returns false when ew.coworker flag is not set at any level', async () => {
-    window.fetch = async () => ({ ok: true, json: async () => ({ flags: { data: [] } }) });
+    installFetch({});
     expect(await isCoworkerEnabled({ org: 'cw-org2', site: 'cw-site2' })).to.be.false;
   });
 });


### PR DESCRIPTION
* using api.js config route for `daConfig.js`
* adding tests for `daConfig.js`
* making `installFetch` with Admin API /ping call re-useable