### PR TITLE
feat: mark GLaaS tasks as auto-transcreation fix 

### DIFF
--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -51,7 +51,7 @@ async function getSha256InHex(input) {
 
 /** Shared callbackConfig + config for v1.2 and v2 multimodal task create. */
 export async function buildGlaasCreateMetadata({ task, service }) {
-  const { name, workflow, businessUnit, fixTranslation } = task;
+  const { name, workflow, businessUnit, reviewerResync } = task;
   const callbackConfig = [];
   const projectKeyKV = [];
   if (service?.preview) {
@@ -69,7 +69,7 @@ export async function buildGlaasCreateMetadata({ task, service }) {
     key: 'businessUnit',
     value: businessUnit,
   }, ...projectKeyKV];
-  if (fixTranslation) {
+  if (reviewerResync) {
     config.push({ key: 'isAutoTranscreationFixTask', value: 'true' });
   }
   return { callbackConfig, config };

--- a/nx/blocks/loc/connectors/glaas/api.js
+++ b/nx/blocks/loc/connectors/glaas/api.js
@@ -51,7 +51,7 @@ async function getSha256InHex(input) {
 
 /** Shared callbackConfig + config for v1.2 and v2 multimodal task create. */
 export async function buildGlaasCreateMetadata({ task, service }) {
-  const { name, workflow, businessUnit } = task;
+  const { name, workflow, businessUnit, fixTranslation } = task;
   const callbackConfig = [];
   const projectKeyKV = [];
   if (service?.preview) {
@@ -69,6 +69,9 @@ export async function buildGlaasCreateMetadata({ task, service }) {
     key: 'businessUnit',
     value: businessUnit,
   }, ...projectKeyKV];
+  if (fixTranslation) {
+    config.push({ key: 'isAutoTranscreationFixTask', value: 'true' });
+  }
   return { callbackConfig, config };
 }
 

--- a/nx/blocks/loc/connectors/glaas/index.js
+++ b/nx/blocks/loc/connectors/glaas/index.js
@@ -380,6 +380,7 @@ async function recreateTaskAndFetchSubtasks({
     workflow: task.workflow,
     workflowName: task.workflowName,
     businessUnit: workflowMeta?.businessUnit,
+    fixTranslation: workflowMeta?.fixTranslation,
     langs: task.langs,
     urlPaths: task.urlPaths,
   };
@@ -403,6 +404,13 @@ const getBusinessUnit = (siteName) => {
   return 'Digital Media';
 };
 
+const FIX_TRANSLATION_OPTION_KEY = 'translation.service.custom.option.Fix Translation';
+
+function isFixTranslation(options) {
+  const value = options?.[FIX_TRANSLATION_OPTION_KEY];
+  return value === true || value === 'true';
+}
+
 function initializeLanguageWorkflowTasks(tasks) {
   Object.values(tasks).forEach((task) => {
     task.langs.forEach((lang) => {
@@ -417,6 +425,7 @@ function initializeLanguageWorkflowTasks(tasks) {
         workflow: task.workflow,
         workflowName: task.workflowName,
         businessUnit: task.businessUnit,
+        fixTranslation: task.fixTranslation,
         name: task.name,
         urls: task.urlPaths || [],
         status: {
@@ -431,13 +440,18 @@ function initializeLanguageWorkflowTasks(tasks) {
   return tasks;
 }
 
-async function getTasks(org, site, title, langs, urls, timestamp) {
+async function getTasks(org, site, title, langs, urls, timestamp, options) {
   const config = await fetchConfig(org, site);
   // Extract just the URL paths for grouping logic
   const urlPaths = urls.map((url) => (typeof url === 'object' ? url.suppliedPath : url));
   // groupUrlsByWorkflow works with simple path strings
   const workflowGroups = groupUrlsByWorkflow(urlPaths, langs, config);
   const tasks = workflowGroups2tasks(title, workflowGroups, langs, timestamp);
+  // Mark tasks as a translation fix (resend) before persisting workflow task state
+  const fixTranslation = isFixTranslation(options);
+  Object.values(tasks).forEach((task) => {
+    task.fixTranslation = fixTranslation;
+  });
   // Pre-populate workflow task structure for each language
   initializeLanguageWorkflowTasks(tasks);
   // Add business unit to each task
@@ -450,10 +464,10 @@ async function getTasks(org, site, title, langs, urls, timestamp) {
 }
 
 export async function sendAllLanguages({
-  org, site, title, service, langs, urls, actions,
+  org, site, title, service, langs, urls, actions, options,
 }) {
   const timestamp = Date.now();
-  const tasks = await getTasks(org, site, title, langs, urls, timestamp);
+  const tasks = await getTasks(org, site, title, langs, urls, timestamp, options);
   await addTranslationMetadata(org, site, langs, urls);
   for (const key of Object.keys(tasks)) {
     await sendTask(service, tasks[key], urls, actions, { org, site });

--- a/nx/blocks/loc/connectors/glaas/index.js
+++ b/nx/blocks/loc/connectors/glaas/index.js
@@ -380,7 +380,7 @@ async function recreateTaskAndFetchSubtasks({
     workflow: task.workflow,
     workflowName: task.workflowName,
     businessUnit: workflowMeta?.businessUnit,
-    fixTranslation: workflowMeta?.fixTranslation,
+    reviewerResync: workflowMeta?.reviewerResync,
     langs: task.langs,
     urlPaths: task.urlPaths,
   };
@@ -404,10 +404,10 @@ const getBusinessUnit = (siteName) => {
   return 'Digital Media';
 };
 
-const FIX_TRANSLATION_OPTION_KEY = 'translation.service.custom.option.Fix Translation';
+const REVIEWER_RESYNC_OPTION_KEY = 'translation.service.custom.option.Reviewer Resync';
 
-function isFixTranslation(options) {
-  const value = options?.[FIX_TRANSLATION_OPTION_KEY];
+function isReviewerResync(options) {
+  const value = options?.[REVIEWER_RESYNC_OPTION_KEY];
   return value === true || value === 'true';
 }
 
@@ -425,7 +425,7 @@ function initializeLanguageWorkflowTasks(tasks) {
         workflow: task.workflow,
         workflowName: task.workflowName,
         businessUnit: task.businessUnit,
-        fixTranslation: task.fixTranslation,
+        reviewerResync: task.reviewerResync,
         name: task.name,
         urls: task.urlPaths || [],
         status: {
@@ -447,10 +447,10 @@ async function getTasks(org, site, title, langs, urls, timestamp, options) {
   // groupUrlsByWorkflow works with simple path strings
   const workflowGroups = groupUrlsByWorkflow(urlPaths, langs, config);
   const tasks = workflowGroups2tasks(title, workflowGroups, langs, timestamp);
-  // Mark tasks as a translation fix (resend) before persisting workflow task state
-  const fixTranslation = isFixTranslation(options);
+  // Mark tasks as a reviewer resync (resend) before persisting workflow task state
+  const reviewerResync = isReviewerResync(options);
   Object.values(tasks).forEach((task) => {
-    task.fixTranslation = fixTranslation;
+    task.reviewerResync = reviewerResync;
   });
   // Pre-populate workflow task structure for each language
   initializeLanguageWorkflowTasks(tasks);


### PR DESCRIPTION
- Read the "Fix Translation" custom option and thread it as task.fixTranslation through getTasks, workflow task persistence, and task recreation
- Push isAutoTranscreationFixTask: true into the task-level config sent to GLaaS (both regular v1.2 and multimodal create paths) when set

