### PR TITLE
feat(ew): render color based options with a preview swatch in menu

### DIFF
--- a/nx2/blocks/shared/menu/menu.css
+++ b/nx2/blocks/shared/menu/menu.css
@@ -70,6 +70,14 @@ nx-popover {
   }
 }
 
+.menu-item-swatch {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--s2-gray-300);
+  border-radius: var(--s2-corner-radius-75);
+}
+
 .menu-item-text {
   display: flex;
   flex-direction: column;

--- a/nx2/blocks/shared/menu/menu.js
+++ b/nx2/blocks/shared/menu/menu.js
@@ -130,6 +130,7 @@ class NxMenu extends LitElement {
           @focus=${() => { this._active = item.id; }}
         >
           ${item.icon ? html`<svg class="menu-item-icon" viewBox="0 0 20 20" aria-hidden="true"><use href="${codeBase}/img/icons/s2-icon-${item.icon}-20-n.svg#icon"></use></svg>` : nothing}
+          ${item.swatch ? html`<span class="menu-item-swatch" style="background:${item.swatch}"></span>` : nothing}
           <span class="menu-item-text">
             <span class="menu-item-label">${item.label}</span>
             ${item.description ? html`<span class="menu-item-description">${item.description}</span>` : nothing}

--- a/nx2/test/unit/nx/blocks/shared/menu/menu.test.js
+++ b/nx2/test/unit/nx/blocks/shared/menu/menu.test.js
@@ -35,4 +35,16 @@ describe('nx-menu description', () => {
     const label = el.shadowRoot.querySelector('.menu-item-label');
     expect(label.textContent).to.equal('Report a bug');
   });
+
+  it('renders a color swatch when item.swatch is set', async () => {
+    const el = await createMenu([{ id: 'red', label: 'Red', swatch: '#ff0000' }]);
+    const swatch = el.shadowRoot.querySelector('.menu-item-swatch');
+    expect(swatch).to.not.be.null;
+    expect(swatch.style.background).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('does not render a swatch when item.swatch is absent', async () => {
+    const el = await createMenu([{ id: 'files', label: 'Files or images' }]);
+    expect(el.shadowRoot.querySelector('.menu-item-swatch')).to.be.null;
+  });
 });


### PR DESCRIPTION
For block-options, if an item is a color value (hex or gradient), render a preview swatch beside it.

Test URL: https://slash--da-live--adobe.aem.live/canvas?nx=swatch#/aemsites/intuit-erp/drafts/ukhalid/account-management

Must land with https://github.com/adobe/da-live/pull/1263