### PR TITLE
fix(ew): render picker icons correctly in dark mode

### DIFF
--- a/nx2/blocks/shared/picker/picker.js
+++ b/nx2/blocks/shared/picker/picker.js
@@ -147,13 +147,9 @@ class NxPicker extends LitElement {
         >
           <span class="picker-item-label">${item.label}</span>
           ${item.trailingIcon ? html`
-            <img
-              class="picker-open-in-icon"
-              src=${item.trailingIcon}
-              width="14"
-              height="14"
-              alt=""
-            />` : nothing}
+            <svg class="picker-open-in-icon" viewBox="0 0 20 20" aria-hidden="true">
+              <use href="${item.trailingIcon}#icon"></use>
+            </svg>` : nothing}
           ${selected ? CHECKMARK : nothing}
         </button>
       </li>


### PR DESCRIPTION
Fix the icons in the picker so they render correctly in dark mode.

BEFORE:
<img width="157" height="488" alt="image" src="https://github.com/user-attachments/assets/eba2e925-5e19-4464-b3cd-b196f3209045" />

AFTER:
<img width="151" height="495" alt="image" src="https://github.com/user-attachments/assets/c59bd191-a625-40c2-a377-01daabfb3fe7" />
